### PR TITLE
Implement special case types in extern Rust argument position

### DIFF
--- a/gen/write.rs
+++ b/gen/write.rs
@@ -308,6 +308,11 @@ fn write_rust_function_shim(out: &mut OutFile, efn: &ExternFn, types: &Types) {
                 write!(out, "&");
             }
             write!(out, "{}", arg.ident);
+            match arg.ty {
+                Type::RustBox(_) => write!(out, ".into_raw()"),
+                Type::UniquePtr(_) => write!(out, ".release()"),
+                _ => {}
+            }
         }
         if indirect_return {
             if !efn.args.is_empty() {

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -231,10 +231,21 @@ fn expand_rust_function_shim(namespace: &Namespace, efn: &ExternFn, types: &Type
     let args = efn.args.iter().map(|arg| expand_extern_arg(arg, types));
     let vars = efn.args.iter().map(|arg| {
         let ident = &arg.ident;
-        if types.needs_indirect_abi(&arg.ty) {
+        let var = if types.needs_indirect_abi(&arg.ty) {
             quote!(::std::ptr::read(#ident))
         } else {
             quote!(#ident)
+        };
+        match &arg.ty {
+            Type::Ident(ident) if ident == "String" => quote!(#var.into_string()),
+            Type::RustBox(_) => quote!(::std::boxed::Box::from_raw(#var)),
+            Type::UniquePtr(_) => quote!(::cxx::UniquePtr::from_raw(#var)),
+            Type::Ref(ty) => match &ty.inner {
+                Type::Ident(ident) if ident == "String" => quote!(#var.as_string()),
+                _ => var,
+            },
+            Type::Str(_) => quote!(#var.as_str()),
+            _ => var,
         }
     });
     let mut outparam = None;


### PR DESCRIPTION
Implements support for our usual special cases in argument position of extern "Rust" functions. This was missed in 0.1.0 and the generated code did not compile for these cases.

```rust
extern "C" {
    type T;
}
extern "Rust" {
    fn demo(string: String, ref_string: &String, ref_str: &str, uptr: UniquePtr<T>);
}
```