### PR TITLE
Support opaque types that are not structs

### DIFF
--- a/gen/write.rs
+++ b/gen/write.rs
@@ -40,7 +40,8 @@ pub(super) fn gen(namespace: Vec<String>, apis: &[Api], types: &Types, header: b
     for api in apis {
         match api {
             Api::Struct(strct) => write_struct_decl(out, &strct.ident),
-            Api::CxxType(ety) | Api::RustType(ety) => write_struct_decl(out, &ety.ident),
+            Api::CxxType(ety) => write_struct_using(out, &ety.ident),
+            Api::RustType(ety) => write_struct_decl(out, &ety.ident),
             _ => {}
         }
     }
@@ -165,6 +166,10 @@ fn write_struct(out: &mut OutFile, strct: &Struct) {
 
 fn write_struct_decl(out: &mut OutFile, ident: &Ident) {
     writeln!(out, "struct {};", ident);
+}
+
+fn write_struct_using(out: &mut OutFile, ident: &Ident) {
+    writeln!(out, "using {} = {};", ident, ident);
 }
 
 fn write_cxx_function_shim(out: &mut OutFile, efn: &ExternFn, types: &Types) {


### PR DESCRIPTION
Fixes #13.

This way we can have:

```cpp
// c++

using Obj = void*;
```

```rust
// rust

#[cxx::bridge]
mod ffi {
    extern "C" {
        include!("...");

        type Obj;
        fn f(obj: &Obj);
    }
}
```

We no longer assume anything about opaque C++ types except that something with the right name has been declared by one of the header(s).

cc @not-a-seagull