### PR TITLE
Use platform's default C++ standard library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ cc = "1.0.49"
 codespan = "0.7"
 codespan-reporting = "0.7"
 cxxbridge-macro = { version = "=0.1.2", path = "macro" }
+link-cplusplus = "1.0"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,6 @@ fn main() {
         .file("src/cxxbridge.cc")
         .flag("-std=c++11")
         .compile("cxxbridge01");
-    println!("cargo:rustc-flags=-l dylib=stdc++");
     println!("cargo:rerun-if-changed=src/cxxbridge.cc");
     println!("cargo:rerun-if-changed=include/cxxbridge.h");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,6 +342,8 @@
     clippy::useless_let_if_seq
 )]
 
+extern crate link_cplusplus;
+
 mod cxx_string;
 mod error;
 mod gen;


### PR DESCRIPTION
Fixes #19 by using https://github.com/dtolnay/link-cplusplus to determine the C++ standard library link flag.