### PR TITLE
Add output

### DIFF
--- a/cmd/src/main.rs
+++ b/cmd/src/main.rs
@@ -15,10 +15,19 @@ struct Opt {
     /// Emit header with declarations only
     #[structopt(long)]
     header: bool,
+
+    /// Emit full cxxbridge header
+    #[structopt(long)]
+    cxxbridge: bool,
+
 }
 
 fn main() {
     let opt = Opt::from_args();
+    if opt.cxxbridge {
+        let _ = io::stdout().lock().write_all(gen::include::get_full_cxxbridge().as_ref());
+        return;
+    }
     let gen = if opt.header {
         gen::do_generate_header
     } else {

--- a/gen/include.rs
+++ b/gen/include.rs
@@ -11,7 +11,3 @@ pub fn get(guard: &str) -> &'static str {
         panic!("not found in cxxbridge.h header: {}", guard)
     }
 }
-
-pub fn get_full_cxxbridge() -> &'static str {
-	return HEADER
-} 

--- a/gen/include.rs
+++ b/gen/include.rs
@@ -11,3 +11,7 @@ pub fn get(guard: &str) -> &'static str {
         panic!("not found in cxxbridge.h header: {}", guard)
     }
 }
+
+pub fn get_full_cxxbridge() -> &'static str {
+	return HEADER
+} 


### PR DESCRIPTION
I started using this and everything worked in Bazel, except for a linkage error right at the end. This is because it's difficult to make cc::Build work well with Bazel's various toolchain and cross-compilation settings. It's way easier just to use the source file.

I manually added the cxxbridge.cc source file to my build, and it works. This patch adds another option to emit the cxxbridge.cc file, but I left it printing the wrong thing for now. This is because the relative include path in the .cc file doesn't make a ton of sense. It would be easier if the two files were just next to each other, either by moving the header, or by linking it into src/.