### PR TITLE
Preserve hyphens in bazel third-party crate names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
         - cp third-party/Cargo.lock .
         - cargo vendor --versioned-dirs --locked third-party/vendor
       script:
-        - bazel run demo-rs:demo_rs --verbose_failures --noshow_progress
+        - bazel run demo-rs --verbose_failures --noshow_progress
         - bazel test ... --verbose_failures --noshow_progress
   allow_failures:
     - os: windows # https://github.com/dtolnay/cxx/issues/25

--- a/BUILD
+++ b/BUILD
@@ -6,14 +6,14 @@ rust_library(
     data = ["src/gen/include/cxxbridge.h"],
     visibility = ["//visibility:public"],
     deps = [
-        ":core_lib",
-        ":cxxbridge_macro",
+        ":core-lib",
+        ":cxxbridge-macro",
         "//third-party:anyhow",
         "//third-party:cc",
         "//third-party:codespan",
-        "//third-party:codespan_reporting",
-        "//third-party:link_cplusplus",
-        "//third-party:proc_macro2",
+        "//third-party:codespan-reporting",
+        "//third-party:link-cplusplus",
+        "//third-party:proc-macro2",
         "//third-party:quote",
         "//third-party:syn",
         "//third-party:thiserror",
@@ -28,8 +28,8 @@ rust_binary(
     deps = [
         "//third-party:anyhow",
         "//third-party:codespan",
-        "//third-party:codespan_reporting",
-        "//third-party:proc_macro2",
+        "//third-party:codespan-reporting",
+        "//third-party:proc-macro2",
         "//third-party:quote",
         "//third-party:structopt",
         "//third-party:syn",
@@ -46,17 +46,17 @@ cc_library(
 )
 
 cc_library(
-    name = "core_lib",
+    name = "core-lib",
     srcs = ["src/cxxbridge.cc"],
     hdrs = ["include/cxxbridge.h"],
 )
 
 rust_library(
-    name = "cxxbridge_macro",
+    name = "cxxbridge-macro",
     srcs = glob(["macro/src/**"]),
     crate_type = "proc-macro",
     deps = [
-        "//third-party:proc_macro2",
+        "//third-party:proc-macro2",
         "//third-party:quote",
         "//third-party:syn",
     ],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,10 +2,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_rust",
-    sha256 = "3d3faa85e49ebf4d26c40075549a17739d636360064b94a9d481b37ace0add82",
-    strip_prefix = "rules_rust-6e87304c834c30b9c9f585cad19f30e7045281d7",
-    # Master branch as of 2020-02-22
-    url = "https://github.com/bazelbuild/rules_rust/archive/6e87304c834c30b9c9f585cad19f30e7045281d7.tar.gz",
+    sha256 = "b7ac870f4cab1cd7e56fd2cbe303f63d78d21cc1a6e3922f21887d373c090e20",
+    strip_prefix = "rules_rust-5a679d418955a122798f42c7bb67c55ca68a2493",
+    # Master branch as of 2020-02-24
+    url = "https://github.com/dtolnay/rules_rust/archive/5a679d418955a122798f42c7bb67c55ca68a2493.tar.gz",
 )
 
 http_archive(

--- a/demo-rs/BUILD
+++ b/demo-rs/BUILD
@@ -1,7 +1,7 @@
 load("//:build/rust.bzl", "rust_binary", "rust_library")
 
 rust_binary(
-    name = "demo_rs",
+    name = "demo-rs",
     srcs = glob(["src/**"]),
     deps = [
         ":gen",

--- a/third-party/BUILD
+++ b/third-party/BUILD
@@ -30,7 +30,7 @@ rust_library(
     deps = [
         ":bitflags",
         ":textwrap",
-        ":unicode_width",
+        ":unicode-width",
     ],
 )
 
@@ -38,17 +38,17 @@ rust_library(
     name = "codespan",
     srcs = glob(["vendor/codespan-0.7.0/src/**"]),
     visibility = ["//visibility:public"],
-    deps = [":unicode_segmentation"],
+    deps = [":unicode-segmentation"],
 )
 
 rust_library(
-    name = "codespan_reporting",
+    name = "codespan-reporting",
     srcs = glob(["vendor/codespan-reporting-0.7.0/src/**"]),
     visibility = ["//visibility:public"],
     deps = [
         ":codespan",
         ":termcolor",
-        ":unicode_width",
+        ":unicode-width",
     ],
 )
 
@@ -56,7 +56,7 @@ rust_library(
     name = "heck",
     srcs = glob(["vendor/heck-0.3.1/src/**"]),
     edition = "2015",
-    deps = [":unicode_segmentation"],
+    deps = [":unicode-segmentation"],
 )
 
 rust_library(
@@ -65,38 +65,38 @@ rust_library(
 )
 
 rust_library(
-    name = "link_cplusplus",
+    name = "link-cplusplus",
     srcs = glob(["vendor/link-cplusplus-1.0.1/src/**"]),
     visibility = ["//visibility:public"],
 )
 
 rust_library(
-    name = "proc_macro_error",
+    name = "proc-macro-error",
     srcs = glob(["vendor/proc-macro-error-0.4.9/src/**"]),
     rustc_flags = ["--cfg=use_fallback"],
     deps = [
-        ":proc_macro2",
-        ":proc_macro_error_attr",
+        ":proc-macro2",
+        ":proc-macro-error-attr",
         ":quote",
         ":syn",
     ],
 )
 
 rust_library(
-    name = "proc_macro_error_attr",
+    name = "proc-macro-error-attr",
     srcs = glob(["vendor/proc-macro-error-attr-0.4.9/src/**"]),
     crate_type = "proc-macro",
     deps = [
-        ":proc_macro2",
+        ":proc-macro2",
         ":quote",
         ":rustversion",
         ":syn",
-        ":syn_mid",
+        ":syn-mid",
     ],
 )
 
 rust_library(
-    name = "proc_macro2",
+    name = "proc-macro2",
     srcs = glob(["vendor/proc-macro2-1.0.8/src/**"]),
     crate_features = [
         "proc-macro",
@@ -108,7 +108,7 @@ rust_library(
         "--cfg=wrap_proc_macro",
     ],
     visibility = ["//visibility:public"],
-    deps = [":unicode_xid"],
+    deps = [":unicode-xid"],
 )
 
 rust_library(
@@ -116,7 +116,7 @@ rust_library(
     srcs = glob(["vendor/quote-1.0.2/src/**"]),
     crate_features = ["proc-macro"],
     visibility = ["//visibility:public"],
-    deps = [":proc_macro2"],
+    deps = [":proc-macro2"],
 )
 
 rust_library(
@@ -125,7 +125,7 @@ rust_library(
     crate_type = "proc-macro",
     out_dir_tar = ":rustversion_buildscript_outdir",
     deps = [
-        ":proc_macro2",
+        ":proc-macro2",
         ":quote",
         ":syn",
     ],
@@ -157,18 +157,18 @@ rust_library(
     deps = [
         ":clap",
         ":lazy_static",
-        ":structopt_derive",
+        ":structopt-derive",
     ],
 )
 
 rust_library(
-    name = "structopt_derive",
+    name = "structopt-derive",
     srcs = glob(["vendor/structopt-derive-0.4.2/src/**"]),
     crate_type = "proc-macro",
     deps = [
         ":heck",
-        ":proc_macro2",
-        ":proc_macro_error",
+        ":proc-macro2",
+        ":proc-macro-error",
         ":quote",
         ":syn",
     ],
@@ -187,17 +187,17 @@ rust_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        ":proc_macro2",
+        ":proc-macro2",
         ":quote",
-        ":unicode_xid",
+        ":unicode-xid",
     ],
 )
 
 rust_library(
-    name = "syn_mid",
+    name = "syn-mid",
     srcs = glob(["vendor/syn-mid-0.5.0/src/**"]),
     deps = [
-        ":proc_macro2",
+        ":proc-macro2",
         ":quote",
         ":syn",
     ],
@@ -211,39 +211,39 @@ rust_library(
 rust_library(
     name = "textwrap",
     srcs = glob(["vendor/textwrap-0.11.0/src/**"]),
-    deps = [":unicode_width"],
+    deps = [":unicode-width"],
 )
 
 rust_library(
     name = "thiserror",
     srcs = glob(["vendor/thiserror-1.0.11/src/**"]),
     visibility = ["//visibility:public"],
-    deps = [":thiserror_impl"],
+    deps = [":thiserror-impl"],
 )
 
 rust_library(
-    name = "thiserror_impl",
+    name = "thiserror-impl",
     srcs = glob(["vendor/thiserror-impl-1.0.11/src/**"]),
     crate_type = "proc-macro",
     deps = [
-        ":proc_macro2",
+        ":proc-macro2",
         ":quote",
         ":syn",
     ],
 )
 
 rust_library(
-    name = "unicode_segmentation",
+    name = "unicode-segmentation",
     srcs = glob(["vendor/unicode-segmentation-1.6.0/src/**"]),
     edition = "2015",
 )
 
 rust_library(
-    name = "unicode_width",
+    name = "unicode-width",
     srcs = glob(["vendor/unicode-width-0.1.7/src/**"]),
 )
 
 rust_library(
-    name = "unicode_xid",
+    name = "unicode-xid",
     srcs = glob(["vendor/unicode-xid-0.2.0/src/**"]),
 )


### PR DESCRIPTION
Depends on https://github.com/bazelbuild/rules_rust/pull/295.