### PR TITLE
Better use of namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,10 +298,10 @@ of functions.
 
 <table>
 <tr><th>name in Rust</th><th>name in C++</th><th>restrictions</th></tr>
-<tr><td>String</td><td>cxxbridge::String</td><td></td></tr>
-<tr><td>&amp;str</td><td>cxxbridge::Str</td><td></td></tr>
+<tr><td>String</td><td>rust::String</td><td></td></tr>
+<tr><td>&amp;str</td><td>rust::Str</td><td></td></tr>
 <tr><td><a href="https://docs.rs/cxx/0.1/cxx/struct.CxxString.html">CxxString</a></td><td>std::string</td><td><sup><i>cannot be passed by value</i></sup></td></tr>
-<tr><td>Box&lt;T&gt;</td><td>cxxbridge::Box&lt;T&gt;</td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
+<tr><td>Box&lt;T&gt;</td><td>rust::Box&lt;T&gt;</td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
 <tr><td><a href="https://docs.rs/cxx/0.1/cxx/struct.UniquePtr.html">UniquePtr&lt;T&gt;</a></td><td>std::unique_ptr&lt;T&gt;</td><td><sup><i>cannot hold opaque Rust type</i></sup></td></tr>
 <tr><td></td><td></td><td></td></tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ of functions.
 <tr><td>String</td><td>cxxbridge::String</td><td></td></tr>
 <tr><td>&amp;str</td><td>cxxbridge::Str</td><td></td></tr>
 <tr><td><a href="https://docs.rs/cxx/0.1/cxx/struct.CxxString.html">CxxString</a></td><td>std::string</td><td><sup><i>cannot be passed by value</i></sup></td></tr>
-<tr><td>Box&lt;T&gt;</td><td>cxxbridge::RustBox&lt;T&gt;</td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
+<tr><td>Box&lt;T&gt;</td><td>cxxbridge::Box&lt;T&gt;</td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
 <tr><td><a href="https://docs.rs/cxx/0.1/cxx/struct.UniquePtr.html">UniquePtr&lt;T&gt;</a></td><td>std::unique_ptr&lt;T&gt;</td><td><sup><i>cannot hold opaque Rust type</i></sup></td></tr>
 <tr><td></td><td></td><td></td></tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ of functions.
 <table>
 <tr><th>name in Rust</th><th>name in C++</th><th>restrictions</th></tr>
 <tr><td>String</td><td>cxxbridge::String</td><td></td></tr>
-<tr><td>&amp;str</td><td>cxxbridge::RustStr</td><td></td></tr>
+<tr><td>&amp;str</td><td>cxxbridge::Str</td><td></td></tr>
 <tr><td><a href="https://docs.rs/cxx/0.1/cxx/struct.CxxString.html">CxxString</a></td><td>std::string</td><td><sup><i>cannot be passed by value</i></sup></td></tr>
 <tr><td>Box&lt;T&gt;</td><td>cxxbridge::RustBox&lt;T&gt;</td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
 <tr><td><a href="https://docs.rs/cxx/0.1/cxx/struct.UniquePtr.html">UniquePtr&lt;T&gt;</a></td><td>std::unique_ptr&lt;T&gt;</td><td><sup><i>cannot hold opaque Rust type</i></sup></td></tr>

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ of functions.
 
 <table>
 <tr><th>name in Rust</th><th>name in C++</th><th>restrictions</th></tr>
-<tr><td>String</td><td>cxxbridge::RustString</td><td></td></tr>
+<tr><td>String</td><td>cxxbridge::String</td><td></td></tr>
 <tr><td>&amp;str</td><td>cxxbridge::RustStr</td><td></td></tr>
 <tr><td><a href="https://docs.rs/cxx/0.1/cxx/struct.CxxString.html">CxxString</a></td><td>std::string</td><td><sup><i>cannot be passed by value</i></sup></td></tr>
 <tr><td>Box&lt;T&gt;</td><td>cxxbridge::RustBox&lt;T&gt;</td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>

--- a/demo-cxx/demo.cc
+++ b/demo-cxx/demo.cc
@@ -9,7 +9,7 @@ ThingC::ThingC(std::string appname) : appname(std::move(appname)) {}
 
 ThingC::~ThingC() { std::cout << "done with ThingC" << std::endl; }
 
-std::unique_ptr<ThingC> make_demo(cxxbridge::Str appname) {
+std::unique_ptr<ThingC> make_demo(::rust::Str appname) {
   return std::unique_ptr<ThingC>(new ThingC(appname));
 }
 

--- a/demo-cxx/demo.cc
+++ b/demo-cxx/demo.cc
@@ -3,13 +3,13 @@
 #include <iostream>
 
 namespace org {
-namespace rust {
+namespace example {
 
 ThingC::ThingC(std::string appname) : appname(std::move(appname)) {}
 
 ThingC::~ThingC() { std::cout << "done with ThingC" << std::endl; }
 
-std::unique_ptr<ThingC> make_demo(::rust::Str appname) {
+std::unique_ptr<ThingC> make_demo(rust::Str appname) {
   return std::unique_ptr<ThingC>(new ThingC(appname));
 }
 
@@ -17,5 +17,5 @@ const std::string &get_name(const ThingC &thing) { return thing.appname; }
 
 void do_thing(SharedThing state) { print_r(*state.y); }
 
-} // namespace rust
+} // namespace example
 } // namespace org

--- a/demo-cxx/demo.cc
+++ b/demo-cxx/demo.cc
@@ -9,7 +9,7 @@ ThingC::ThingC(std::string appname) : appname(std::move(appname)) {}
 
 ThingC::~ThingC() { std::cout << "done with ThingC" << std::endl; }
 
-std::unique_ptr<ThingC> make_demo(cxxbridge::RustStr appname) {
+std::unique_ptr<ThingC> make_demo(cxxbridge::Str appname) {
   return std::unique_ptr<ThingC>(new ThingC(appname));
 }
 

--- a/demo-cxx/demo.h
+++ b/demo-cxx/demo.h
@@ -16,7 +16,7 @@ public:
 
 struct SharedThing;
 
-std::unique_ptr<ThingC> make_demo(cxxbridge::RustStr appname);
+std::unique_ptr<ThingC> make_demo(cxxbridge::Str appname);
 const std::string &get_name(const ThingC &thing);
 void do_thing(SharedThing state);
 

--- a/demo-cxx/demo.h
+++ b/demo-cxx/demo.h
@@ -4,7 +4,7 @@
 #include <string>
 
 namespace org {
-namespace rust {
+namespace example {
 
 class ThingC {
 public:
@@ -16,9 +16,9 @@ public:
 
 struct SharedThing;
 
-std::unique_ptr<ThingC> make_demo(::rust::Str appname);
+std::unique_ptr<ThingC> make_demo(rust::Str appname);
 const std::string &get_name(const ThingC &thing);
 void do_thing(SharedThing state);
 
-} // namespace rust
+} // namespace example
 } // namespace org

--- a/demo-cxx/demo.h
+++ b/demo-cxx/demo.h
@@ -16,7 +16,7 @@ public:
 
 struct SharedThing;
 
-std::unique_ptr<ThingC> make_demo(cxxbridge::Str appname);
+std::unique_ptr<ThingC> make_demo(::rust::Str appname);
 const std::string &get_name(const ThingC &thing);
 void do_thing(SharedThing state);
 

--- a/demo-rs/src/main.rs
+++ b/demo-rs/src/main.rs
@@ -1,4 +1,4 @@
-#[cxx::bridge(namespace = org::rust)]
+#[cxx::bridge(namespace = org::example)]
 mod ffi {
     struct SharedThing {
         z: i32,

--- a/gen/write.rs
+++ b/gen/write.rs
@@ -365,7 +365,7 @@ fn write_extern_return_type(out: &mut OutFile, ty: &Option<Type>, types: &Types)
             write_type(out, &ty.inner);
             write!(out, " *");
         }
-        Some(Type::Str(_)) => write!(out, "::cxxbridge::RustStr::Repr "),
+        Some(Type::Str(_)) => write!(out, "::cxxbridge::Str::Repr "),
         Some(ty) if types.needs_indirect_abi(ty) => write!(out, "void "),
         _ => write_return_type(out, ty),
     }
@@ -377,7 +377,7 @@ fn write_extern_arg(out: &mut OutFile, arg: &Var, types: &Types) {
             write_type_space(out, &ty.inner);
             write!(out, "*");
         }
-        Type::Str(_) => write!(out, "::cxxbridge::RustStr::Repr "),
+        Type::Str(_) => write!(out, "::cxxbridge::Str::Repr "),
         _ => write_type_space(out, &arg.ty),
     }
     if types.needs_indirect_abi(&arg.ty) {
@@ -422,7 +422,7 @@ fn write_type(out: &mut OutFile, ty: &Type) {
             write!(out, " &");
         }
         Type::Str(_) => {
-            write!(out, "::cxxbridge::RustStr");
+            write!(out, "::cxxbridge::Str");
         }
     }
 }

--- a/gen/write.rs
+++ b/gen/write.rs
@@ -21,19 +21,9 @@ pub(super) fn gen(namespace: Vec<String>, apis: &[Api], types: &Types, header: b
     write_includes(out, types);
     write_include_cxxbridge(out, types);
 
-    if !header {
-        out.next_section();
-        write_namespace_alias(out, types);
-    }
-
     out.next_section();
     for name in &namespace {
         writeln!(out, "namespace {} {{", name);
-    }
-
-    if header {
-        out.next_section();
-        write_namespace_alias(out, types);
     }
 
     out.next_section();
@@ -125,7 +115,8 @@ fn write_include_cxxbridge(out: &mut OutFile, types: &Types) {
         }
     }
 
-    out.begin_block("namespace cxxbridge01");
+    out.begin_block("namespace rust");
+    out.begin_block("inline namespace cxxbridge01");
     if needs_rust_box {
         writeln!(out, "// #include \"cxxbridge.h\"");
         for line in include::get("CXXBRIDGE01_RUST_BOX").lines() {
@@ -135,20 +126,7 @@ fn write_include_cxxbridge(out: &mut OutFile, types: &Types) {
         }
     }
     out.end_block();
-}
-
-fn write_namespace_alias(out: &mut OutFile, types: &Types) {
-    let mut needs_namespace_alias = false;
-    for ty in types {
-        if let Type::RustBox(_) = ty {
-            needs_namespace_alias = true;
-            break;
-        }
-    }
-
-    if needs_namespace_alias {
-        writeln!(out, "namespace cxxbridge = cxxbridge01;");
-    }
+    out.end_block();
 }
 
 fn write_struct(out: &mut OutFile, strct: &Struct) {
@@ -365,7 +343,7 @@ fn write_extern_return_type(out: &mut OutFile, ty: &Option<Type>, types: &Types)
             write_type(out, &ty.inner);
             write!(out, " *");
         }
-        Some(Type::Str(_)) => write!(out, "::cxxbridge::Str::Repr "),
+        Some(Type::Str(_)) => write!(out, "::rust::Str::Repr "),
         Some(ty) if types.needs_indirect_abi(ty) => write!(out, "void "),
         _ => write_return_type(out, ty),
     }
@@ -377,7 +355,7 @@ fn write_extern_arg(out: &mut OutFile, arg: &Var, types: &Types) {
             write_type_space(out, &ty.inner);
             write!(out, "*");
         }
-        Type::Str(_) => write!(out, "::cxxbridge::Str::Repr "),
+        Type::Str(_) => write!(out, "::rust::Str::Repr "),
         _ => write_type_space(out, &arg.ty),
     }
     if types.needs_indirect_abi(&arg.ty) {
@@ -401,11 +379,11 @@ fn write_type(out: &mut OutFile, ty: &Type) {
             Some(I64) => write!(out, "int64_t"),
             Some(Isize) => write!(out, "ssize_t"),
             Some(CxxString) => write!(out, "::std::string"),
-            Some(RustString) => write!(out, "::cxxbridge::String"),
+            Some(RustString) => write!(out, "::rust::String"),
             None => write!(out, "{}", ident),
         },
         Type::RustBox(ty) => {
-            write!(out, "::cxxbridge::Box<");
+            write!(out, "::rust::Box<");
             write_type(out, &ty.inner);
             write!(out, ">");
         }
@@ -422,7 +400,7 @@ fn write_type(out: &mut OutFile, ty: &Type) {
             write!(out, " &");
         }
         Type::Str(_) => {
-            write!(out, "::cxxbridge::Str");
+            write!(out, "::rust::Str");
         }
     }
 }
@@ -458,7 +436,8 @@ fn write_generic_instantiations(out: &mut OutFile, types: &Types) {
     }
     out.end_block();
 
-    out.begin_block("namespace cxxbridge01");
+    out.begin_block("namespace rust");
+    out.begin_block("inline namespace cxxbridge01");
     for ty in types {
         if let Type::RustBox(ty) = ty {
             if let Type::Ident(inner) = &ty.inner {
@@ -466,6 +445,7 @@ fn write_generic_instantiations(out: &mut OutFile, types: &Types) {
             }
         }
     }
+    out.end_block();
     out.end_block();
 }
 
@@ -482,27 +462,27 @@ fn write_rust_box_extern(out: &mut OutFile, ident: &Ident) {
     writeln!(out, "#define CXXBRIDGE01_RUST_BOX_{}", instance);
     writeln!(
         out,
-        "void cxxbridge01$rust_box${}$uninit(::cxxbridge::Box<{}> *ptr) noexcept;",
+        "void cxxbridge01$rust_box${}$uninit(::rust::Box<{}> *ptr) noexcept;",
         instance, inner,
     );
     writeln!(
         out,
-        "void cxxbridge01$rust_box${}$set_raw(::cxxbridge::Box<{}> *ptr, {} *raw) noexcept;",
+        "void cxxbridge01$rust_box${}$set_raw(::rust::Box<{}> *ptr, {} *raw) noexcept;",
         instance, inner, inner
     );
     writeln!(
         out,
-        "void cxxbridge01$rust_box${}$drop(::cxxbridge::Box<{}> *ptr) noexcept;",
+        "void cxxbridge01$rust_box${}$drop(::rust::Box<{}> *ptr) noexcept;",
         instance, inner,
     );
     writeln!(
         out,
-        "const {} *cxxbridge01$rust_box${}$deref(const ::cxxbridge::Box<{}> *ptr) noexcept;",
+        "const {} *cxxbridge01$rust_box${}$deref(const ::rust::Box<{}> *ptr) noexcept;",
         inner, instance, inner,
     );
     writeln!(
         out,
-        "{} *cxxbridge01$rust_box${}$deref_mut(::cxxbridge::Box<{}> *ptr) noexcept;",
+        "{} *cxxbridge01$rust_box${}$deref_mut(::rust::Box<{}> *ptr) noexcept;",
         inner, instance, inner,
     );
     writeln!(out, "#endif // CXXBRIDGE01_RUST_BOX_{}", instance);

--- a/gen/write.rs
+++ b/gen/write.rs
@@ -405,7 +405,7 @@ fn write_type(out: &mut OutFile, ty: &Type) {
             None => write!(out, "{}", ident),
         },
         Type::RustBox(ty) => {
-            write!(out, "::cxxbridge::RustBox<");
+            write!(out, "::cxxbridge::Box<");
             write_type(out, &ty.inner);
             write!(out, ">");
         }
@@ -482,27 +482,27 @@ fn write_rust_box_extern(out: &mut OutFile, ident: &Ident) {
     writeln!(out, "#define CXXBRIDGE01_RUST_BOX_{}", instance);
     writeln!(
         out,
-        "void cxxbridge01$rust_box${}$uninit(::cxxbridge::RustBox<{}> *ptr) noexcept;",
+        "void cxxbridge01$rust_box${}$uninit(::cxxbridge::Box<{}> *ptr) noexcept;",
         instance, inner,
     );
     writeln!(
         out,
-        "void cxxbridge01$rust_box${}$set_raw(::cxxbridge::RustBox<{}> *ptr, {} *raw) noexcept;",
+        "void cxxbridge01$rust_box${}$set_raw(::cxxbridge::Box<{}> *ptr, {} *raw) noexcept;",
         instance, inner, inner
     );
     writeln!(
         out,
-        "void cxxbridge01$rust_box${}$drop(::cxxbridge::RustBox<{}> *ptr) noexcept;",
+        "void cxxbridge01$rust_box${}$drop(::cxxbridge::Box<{}> *ptr) noexcept;",
         instance, inner,
     );
     writeln!(
         out,
-        "const {} *cxxbridge01$rust_box${}$deref(const ::cxxbridge::RustBox<{}> *ptr) noexcept;",
+        "const {} *cxxbridge01$rust_box${}$deref(const ::cxxbridge::Box<{}> *ptr) noexcept;",
         inner, instance, inner,
     );
     writeln!(
         out,
-        "{} *cxxbridge01$rust_box${}$deref_mut(::cxxbridge::RustBox<{}> *ptr) noexcept;",
+        "{} *cxxbridge01$rust_box${}$deref_mut(::cxxbridge::Box<{}> *ptr) noexcept;",
         inner, instance, inner,
     );
     writeln!(out, "#endif // CXXBRIDGE01_RUST_BOX_{}", instance);
@@ -518,7 +518,7 @@ fn write_rust_box_impl(out: &mut OutFile, ident: &Ident) {
     let instance = inner.replace("::", "$");
 
     writeln!(out, "template <>");
-    writeln!(out, "void RustBox<{}>::uninit() noexcept {{", inner);
+    writeln!(out, "void Box<{}>::uninit() noexcept {{", inner);
     writeln!(
         out,
         "  return cxxbridge01$rust_box${}$uninit(this);",
@@ -529,7 +529,7 @@ fn write_rust_box_impl(out: &mut OutFile, ident: &Ident) {
     writeln!(out, "template <>");
     writeln!(
         out,
-        "void RustBox<{}>::set_raw({} *raw) noexcept {{",
+        "void Box<{}>::set_raw({} *raw) noexcept {{",
         inner, inner,
     );
     writeln!(
@@ -540,7 +540,7 @@ fn write_rust_box_impl(out: &mut OutFile, ident: &Ident) {
     writeln!(out, "}}");
 
     writeln!(out, "template <>");
-    writeln!(out, "void RustBox<{}>::drop() noexcept {{", inner);
+    writeln!(out, "void Box<{}>::drop() noexcept {{", inner);
     writeln!(
         out,
         "  return cxxbridge01$rust_box${}$drop(this);",
@@ -551,7 +551,7 @@ fn write_rust_box_impl(out: &mut OutFile, ident: &Ident) {
     writeln!(out, "template <>");
     writeln!(
         out,
-        "const {} *RustBox<{}>::deref() const noexcept {{",
+        "const {} *Box<{}>::deref() const noexcept {{",
         inner, inner,
     );
     writeln!(
@@ -562,11 +562,7 @@ fn write_rust_box_impl(out: &mut OutFile, ident: &Ident) {
     writeln!(out, "}}");
 
     writeln!(out, "template <>");
-    writeln!(
-        out,
-        "{} *RustBox<{}>::deref_mut() noexcept {{",
-        inner, inner,
-    );
+    writeln!(out, "{} *Box<{}>::deref_mut() noexcept {{", inner, inner);
     writeln!(
         out,
         "  return cxxbridge01$rust_box${}$deref_mut(this);",

--- a/gen/write.rs
+++ b/gen/write.rs
@@ -401,7 +401,7 @@ fn write_type(out: &mut OutFile, ty: &Type) {
             Some(I64) => write!(out, "int64_t"),
             Some(Isize) => write!(out, "ssize_t"),
             Some(CxxString) => write!(out, "::std::string"),
-            Some(RustString) => write!(out, "::cxxbridge::RustString"),
+            Some(RustString) => write!(out, "::cxxbridge::String"),
             None => write!(out, "{}", ident),
         },
         Type::RustBox(ty) => {

--- a/include/cxxbridge.h
+++ b/include/cxxbridge.h
@@ -9,16 +9,16 @@ namespace cxxbridge = cxxbridge01;
 
 namespace cxxbridge01 {
 
-class RustString final {
+class String final {
 public:
-  RustString() noexcept;
-  RustString(const RustString &other) noexcept;
-  RustString(RustString &&other) noexcept;
-  RustString(const char *s);
-  RustString(const std::string &s);
-  RustString &operator=(const RustString &other) noexcept;
-  RustString &operator=(RustString &&other) noexcept;
-  ~RustString() noexcept;
+  String() noexcept;
+  String(const String &other) noexcept;
+  String(String &&other) noexcept;
+  String(const char *s);
+  String(const std::string &s);
+  String &operator=(const String &other) noexcept;
+  String &operator=(String &&other) noexcept;
+  ~String() noexcept;
   operator std::string() const;
 
   // Note: no null terminator.
@@ -127,7 +127,7 @@ private:
 };
 #endif // CXXBRIDGE01_RUST_BOX
 
-std::ostream &operator<<(std::ostream &os, const RustString &s);
+std::ostream &operator<<(std::ostream &os, const String &s);
 std::ostream &operator<<(std::ostream &os, const RustStr &s);
 
 } // namespace cxxbridge01

--- a/include/cxxbridge.h
+++ b/include/cxxbridge.h
@@ -31,14 +31,14 @@ private:
   std::array<uintptr_t, 3> repr;
 };
 
-class RustStr final {
+class Str final {
 public:
-  RustStr() noexcept;
-  RustStr(const char *s);
-  RustStr(const std::string &s);
-  RustStr(std::string &&s) = delete;
-  RustStr(const RustStr &other) noexcept;
-  RustStr &operator=(RustStr other) noexcept;
+  Str() noexcept;
+  Str(const char *s);
+  Str(const std::string &s);
+  Str(std::string &&s) = delete;
+  Str(const Str &other) noexcept;
+  Str &operator=(Str other) noexcept;
   operator std::string() const;
 
   // Note: no null terminator.
@@ -54,7 +54,7 @@ public:
     const char *ptr;
     size_t len;
   };
-  RustStr(Repr repr) noexcept;
+  Str(Repr repr) noexcept;
   operator Repr() noexcept;
 
 private:
@@ -128,6 +128,6 @@ private:
 #endif // CXXBRIDGE01_RUST_BOX
 
 std::ostream &operator<<(std::ostream &os, const String &s);
-std::ostream &operator<<(std::ostream &os, const RustStr &s);
+std::ostream &operator<<(std::ostream &os, const Str &s);
 
 } // namespace cxxbridge01

--- a/include/cxxbridge.h
+++ b/include/cxxbridge.h
@@ -63,15 +63,15 @@ private:
 
 #ifndef CXXBRIDGE01_RUST_BOX
 #define CXXBRIDGE01_RUST_BOX
-template <typename T> class RustBox final {
+template <typename T> class Box final {
 public:
-  RustBox(const RustBox &other) : RustBox(*other) {}
-  RustBox(RustBox &&other) noexcept : repr(other.repr) { other.repr = 0; }
-  RustBox(const T &val) {
+  Box(const Box &other) : Box(*other) {}
+  Box(Box &&other) noexcept : repr(other.repr) { other.repr = 0; }
+  Box(const T &val) {
     this->uninit();
     ::new (this->deref_mut()) T(val);
   }
-  RustBox &operator=(const RustBox &other) {
+  Box &operator=(const Box &other) {
     if (this != &other) {
       if (this->repr) {
         **this = *other;
@@ -82,7 +82,7 @@ public:
     }
     return *this;
   }
-  RustBox &operator=(RustBox &&other) noexcept {
+  Box &operator=(Box &&other) noexcept {
     if (this->repr) {
       this->drop();
     }
@@ -90,7 +90,7 @@ public:
     other.repr = 0;
     return *this;
   }
-  ~RustBox() noexcept {
+  ~Box() noexcept {
     if (this->repr) {
       this->drop();
     }
@@ -103,8 +103,8 @@ public:
 
   // Important: requires that `raw` came from an into_raw call. Do not pass a
   // pointer from `new` or any other source.
-  static RustBox from_raw(T *raw) noexcept {
-    RustBox box;
+  static Box from_raw(T *raw) noexcept {
+    Box box;
     box.set_raw(raw);
     return box;
   }
@@ -116,7 +116,7 @@ public:
   }
 
 private:
-  RustBox() noexcept {}
+  Box() noexcept {}
   void uninit() noexcept;
   void set_raw(T *) noexcept;
   T *get_raw() noexcept;

--- a/include/cxxbridge.h
+++ b/include/cxxbridge.h
@@ -4,10 +4,8 @@
 #include <iostream>
 #include <string>
 
-namespace cxxbridge01 {}
-namespace cxxbridge = cxxbridge01;
-
-namespace cxxbridge01 {
+namespace rust {
+inline namespace cxxbridge01 {
 
 class String final {
 public:
@@ -130,4 +128,5 @@ private:
 std::ostream &operator<<(std::ostream &os, const String &s);
 std::ostream &operator<<(std::ostream &os, const Str &s);
 
-} // namespace cxxbridge01
+} // inline namespace cxxbridge01
+} // namespace rust

--- a/src/cxxbridge.cc
+++ b/src/cxxbridge.cc
@@ -14,16 +14,16 @@ size_t cxxbridge01$cxx_string$length(const std::string &s) noexcept {
   return s.length();
 }
 
-// RustString
-void cxxbridge01$rust_string$new(cxxbridge::RustString *self) noexcept;
-void cxxbridge01$rust_string$clone(cxxbridge::RustString *self,
-                                   const cxxbridge::RustString &other) noexcept;
-bool cxxbridge01$rust_string$from(cxxbridge::RustString *self, const char *ptr,
+// cxxbridge::String
+void cxxbridge01$rust_string$new(cxxbridge::String *self) noexcept;
+void cxxbridge01$rust_string$clone(cxxbridge::String *self,
+                                   const cxxbridge::String &other) noexcept;
+bool cxxbridge01$rust_string$from(cxxbridge::String *self, const char *ptr,
                                   size_t len) noexcept;
-void cxxbridge01$rust_string$drop(cxxbridge::RustString *self) noexcept;
+void cxxbridge01$rust_string$drop(cxxbridge::String *self) noexcept;
 const char *
-cxxbridge01$rust_string$ptr(const cxxbridge::RustString *self) noexcept;
-size_t cxxbridge01$rust_string$len(const cxxbridge::RustString *self) noexcept;
+cxxbridge01$rust_string$ptr(const cxxbridge::String *self) noexcept;
+size_t cxxbridge01$rust_string$len(const cxxbridge::String *self) noexcept;
 
 // RustStr
 bool cxxbridge01$rust_str$valid(const char *ptr, size_t len) noexcept;
@@ -31,39 +31,39 @@ bool cxxbridge01$rust_str$valid(const char *ptr, size_t len) noexcept;
 
 namespace cxxbridge01 {
 
-RustString::RustString() noexcept { cxxbridge01$rust_string$new(this); }
+String::String() noexcept { cxxbridge01$rust_string$new(this); }
 
-RustString::RustString(const RustString &other) noexcept {
+String::String(const String &other) noexcept {
   cxxbridge01$rust_string$clone(this, other);
 }
 
-RustString::RustString(RustString &&other) noexcept {
+String::String(String &&other) noexcept {
   this->repr = other.repr;
   cxxbridge01$rust_string$new(&other);
 }
 
-RustString::RustString(const char *s) {
+String::String(const char *s) {
   auto len = strlen(s);
   if (!cxxbridge01$rust_string$from(this, s, len)) {
-    throw std::invalid_argument("data for RustString is not utf-8");
+    throw std::invalid_argument("data for cxxbridge::String is not utf-8");
   }
 }
 
-RustString::RustString(const std::string &s) {
+String::String(const std::string &s) {
   auto ptr = s.data();
   auto len = s.length();
   if (!cxxbridge01$rust_string$from(this, ptr, len)) {
-    throw std::invalid_argument("data for RustString is not utf-8");
+    throw std::invalid_argument("data for cxxbridge::String is not utf-8");
   }
 }
 
-RustString::~RustString() noexcept { cxxbridge01$rust_string$drop(this); }
+String::~String() noexcept { cxxbridge01$rust_string$drop(this); }
 
-RustString::operator std::string() const {
+String::operator std::string() const {
   return std::string(this->data(), this->size());
 }
 
-RustString &RustString::operator=(const RustString &other) noexcept {
+String &String::operator=(const String &other) noexcept {
   if (this != &other) {
     cxxbridge01$rust_string$drop(this);
     cxxbridge01$rust_string$clone(this, other);
@@ -71,7 +71,7 @@ RustString &RustString::operator=(const RustString &other) noexcept {
   return *this;
 }
 
-RustString &RustString::operator=(RustString &&other) noexcept {
+String &String::operator=(String &&other) noexcept {
   if (this != &other) {
     cxxbridge01$rust_string$drop(this);
     this->repr = other.repr;
@@ -80,19 +80,19 @@ RustString &RustString::operator=(RustString &&other) noexcept {
   return *this;
 }
 
-const char *RustString::data() const noexcept {
+const char *String::data() const noexcept {
   return cxxbridge01$rust_string$ptr(this);
 }
 
-size_t RustString::size() const noexcept {
+size_t String::size() const noexcept {
   return cxxbridge01$rust_string$len(this);
 }
 
-size_t RustString::length() const noexcept {
+size_t String::length() const noexcept {
   return cxxbridge01$rust_string$len(this);
 }
 
-std::ostream &operator<<(std::ostream &os, const RustString &s) {
+std::ostream &operator<<(std::ostream &os, const String &s) {
   os.write(s.data(), s.size());
   return os;
 }

--- a/src/cxxbridge.cc
+++ b/src/cxxbridge.cc
@@ -3,8 +3,6 @@
 #include <memory>
 #include <stdexcept>
 
-namespace cxxbridge = cxxbridge01;
-
 extern "C" {
 const char *cxxbridge01$cxx_string$data(const std::string &s) noexcept {
   return s.data();
@@ -14,22 +12,23 @@ size_t cxxbridge01$cxx_string$length(const std::string &s) noexcept {
   return s.length();
 }
 
-// cxxbridge::String
-void cxxbridge01$rust_string$new(cxxbridge::String *self) noexcept;
-void cxxbridge01$rust_string$clone(cxxbridge::String *self,
-                                   const cxxbridge::String &other) noexcept;
-bool cxxbridge01$rust_string$from(cxxbridge::String *self, const char *ptr,
+// rust::String
+void cxxbridge01$rust_string$new(rust::String *self) noexcept;
+void cxxbridge01$rust_string$clone(rust::String *self,
+                                   const rust::String &other) noexcept;
+bool cxxbridge01$rust_string$from(rust::String *self, const char *ptr,
                                   size_t len) noexcept;
-void cxxbridge01$rust_string$drop(cxxbridge::String *self) noexcept;
+void cxxbridge01$rust_string$drop(rust::String *self) noexcept;
 const char *
-cxxbridge01$rust_string$ptr(const cxxbridge::String *self) noexcept;
-size_t cxxbridge01$rust_string$len(const cxxbridge::String *self) noexcept;
+cxxbridge01$rust_string$ptr(const rust::String *self) noexcept;
+size_t cxxbridge01$rust_string$len(const rust::String *self) noexcept;
 
-// cxxbridge::Str
+// rust::Str
 bool cxxbridge01$rust_str$valid(const char *ptr, size_t len) noexcept;
 } // extern "C"
 
-namespace cxxbridge01 {
+namespace rust {
+inline namespace cxxbridge01 {
 
 String::String() noexcept { cxxbridge01$rust_string$new(this); }
 
@@ -45,7 +44,7 @@ String::String(String &&other) noexcept {
 String::String(const char *s) {
   auto len = strlen(s);
   if (!cxxbridge01$rust_string$from(this, s, len)) {
-    throw std::invalid_argument("data for cxxbridge::String is not utf-8");
+    throw std::invalid_argument("data for rust::String is not utf-8");
   }
 }
 
@@ -53,7 +52,7 @@ String::String(const std::string &s) {
   auto ptr = s.data();
   auto len = s.length();
   if (!cxxbridge01$rust_string$from(this, ptr, len)) {
-    throw std::invalid_argument("data for cxxbridge::String is not utf-8");
+    throw std::invalid_argument("data for rust::String is not utf-8");
   }
 }
 
@@ -102,13 +101,13 @@ Str::Str() noexcept
 
 Str::Str(const char *s) : repr(Repr{s, strlen(s)}) {
   if (!cxxbridge01$rust_str$valid(this->repr.ptr, this->repr.len)) {
-    throw std::invalid_argument("data for cxxbridge::Str is not utf-8");
+    throw std::invalid_argument("data for rust::Str is not utf-8");
   }
 }
 
 Str::Str(const std::string &s) : repr(Repr{s.data(), s.length()}) {
   if (!cxxbridge01$rust_str$valid(this->repr.ptr, this->repr.len)) {
-    throw std::invalid_argument("data for cxxbridge::Str is not utf-8");
+    throw std::invalid_argument("data for rust::Str is not utf-8");
   }
 }
 
@@ -138,7 +137,8 @@ std::ostream &operator<<(std::ostream &os, const Str &s) {
   return os;
 }
 
-} // namespace cxxbridge01
+} // inline namespace cxxbridge01
+} // namespace rust
 
 extern "C" {
 void cxxbridge01$unique_ptr$std$string$null(

--- a/src/cxxbridge.cc
+++ b/src/cxxbridge.cc
@@ -25,7 +25,7 @@ const char *
 cxxbridge01$rust_string$ptr(const cxxbridge::String *self) noexcept;
 size_t cxxbridge01$rust_string$len(const cxxbridge::String *self) noexcept;
 
-// RustStr
+// cxxbridge::Str
 bool cxxbridge01$rust_str$valid(const char *ptr, size_t len) noexcept;
 } // extern "C"
 
@@ -97,43 +97,43 @@ std::ostream &operator<<(std::ostream &os, const String &s) {
   return os;
 }
 
-RustStr::RustStr() noexcept
+Str::Str() noexcept
     : repr(Repr{reinterpret_cast<const char *>(this), 0}) {}
 
-RustStr::RustStr(const char *s) : repr(Repr{s, strlen(s)}) {
+Str::Str(const char *s) : repr(Repr{s, strlen(s)}) {
   if (!cxxbridge01$rust_str$valid(this->repr.ptr, this->repr.len)) {
-    throw std::invalid_argument("data for RustStr is not utf-8");
+    throw std::invalid_argument("data for cxxbridge::Str is not utf-8");
   }
 }
 
-RustStr::RustStr(const std::string &s) : repr(Repr{s.data(), s.length()}) {
+Str::Str(const std::string &s) : repr(Repr{s.data(), s.length()}) {
   if (!cxxbridge01$rust_str$valid(this->repr.ptr, this->repr.len)) {
-    throw std::invalid_argument("data for RustStr is not utf-8");
+    throw std::invalid_argument("data for cxxbridge::Str is not utf-8");
   }
 }
 
-RustStr::RustStr(const RustStr &) noexcept = default;
+Str::Str(const Str &) noexcept = default;
 
-RustStr &RustStr::operator=(RustStr other) noexcept {
+Str &Str::operator=(Str other) noexcept {
   this->repr = other.repr;
   return *this;
 }
 
-RustStr::operator std::string() const {
+Str::operator std::string() const {
   return std::string(this->data(), this->size());
 }
 
-const char *RustStr::data() const noexcept { return this->repr.ptr; }
+const char *Str::data() const noexcept { return this->repr.ptr; }
 
-size_t RustStr::size() const noexcept { return this->repr.len; }
+size_t Str::size() const noexcept { return this->repr.len; }
 
-size_t RustStr::length() const noexcept { return this->repr.len; }
+size_t Str::length() const noexcept { return this->repr.len; }
 
-RustStr::RustStr(Repr repr_) noexcept : repr(repr_) {}
+Str::Str(Repr repr_) noexcept : repr(repr_) {}
 
-RustStr::operator Repr() noexcept { return this->repr; }
+Str::operator Repr() noexcept { return this->repr; }
 
-std::ostream &operator<<(std::ostream &os, const RustStr &s) {
+std::ostream &operator<<(std::ostream &os, const Str &s) {
   os.write(s.data(), s.size());
   return os;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,7 +302,7 @@
 //!
 //! <table>
 //! <tr><th>name in Rust</th><th>name in C++</th><th>restrictions</th></tr>
-//! <tr><td>String</td><td>cxxbridge::RustString</td><td></td></tr>
+//! <tr><td>String</td><td>cxxbridge::String</td><td></td></tr>
 //! <tr><td>&amp;str</td><td>cxxbridge::RustStr</td><td></td></tr>
 //! <tr><td><a href="https://docs.rs/cxx/0.1/cxx/struct.CxxString.html">CxxString</a></td><td>std::string</td><td><sup><i>cannot be passed by value</i></sup></td></tr>
 //! <tr><td>Box&lt;T&gt;</td><td>cxxbridge::RustBox&lt;T&gt;</td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,7 +305,7 @@
 //! <tr><td>String</td><td>cxxbridge::String</td><td></td></tr>
 //! <tr><td>&amp;str</td><td>cxxbridge::Str</td><td></td></tr>
 //! <tr><td><a href="https://docs.rs/cxx/0.1/cxx/struct.CxxString.html">CxxString</a></td><td>std::string</td><td><sup><i>cannot be passed by value</i></sup></td></tr>
-//! <tr><td>Box&lt;T&gt;</td><td>cxxbridge::RustBox&lt;T&gt;</td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
+//! <tr><td>Box&lt;T&gt;</td><td>cxxbridge::Box&lt;T&gt;</td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
 //! <tr><td><a href="https://docs.rs/cxx/0.1/cxx/struct.UniquePtr.html">UniquePtr&lt;T&gt;</a></td><td>std::unique_ptr&lt;T&gt;</td><td><sup><i>cannot hold opaque Rust type</i></sup></td></tr>
 //! <tr><td></td><td></td><td></td></tr>
 //! </table>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,7 +303,7 @@
 //! <table>
 //! <tr><th>name in Rust</th><th>name in C++</th><th>restrictions</th></tr>
 //! <tr><td>String</td><td>cxxbridge::String</td><td></td></tr>
-//! <tr><td>&amp;str</td><td>cxxbridge::RustStr</td><td></td></tr>
+//! <tr><td>&amp;str</td><td>cxxbridge::Str</td><td></td></tr>
 //! <tr><td><a href="https://docs.rs/cxx/0.1/cxx/struct.CxxString.html">CxxString</a></td><td>std::string</td><td><sup><i>cannot be passed by value</i></sup></td></tr>
 //! <tr><td>Box&lt;T&gt;</td><td>cxxbridge::RustBox&lt;T&gt;</td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
 //! <tr><td><a href="https://docs.rs/cxx/0.1/cxx/struct.UniquePtr.html">UniquePtr&lt;T&gt;</a></td><td>std::unique_ptr&lt;T&gt;</td><td><sup><i>cannot hold opaque Rust type</i></sup></td></tr>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,10 +302,10 @@
 //!
 //! <table>
 //! <tr><th>name in Rust</th><th>name in C++</th><th>restrictions</th></tr>
-//! <tr><td>String</td><td>cxxbridge::String</td><td></td></tr>
-//! <tr><td>&amp;str</td><td>cxxbridge::Str</td><td></td></tr>
+//! <tr><td>String</td><td>rust::String</td><td></td></tr>
+//! <tr><td>&amp;str</td><td>rust::Str</td><td></td></tr>
 //! <tr><td><a href="https://docs.rs/cxx/0.1/cxx/struct.CxxString.html">CxxString</a></td><td>std::string</td><td><sup><i>cannot be passed by value</i></sup></td></tr>
-//! <tr><td>Box&lt;T&gt;</td><td>cxxbridge::Box&lt;T&gt;</td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
+//! <tr><td>Box&lt;T&gt;</td><td>rust::Box&lt;T&gt;</td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
 //! <tr><td><a href="https://docs.rs/cxx/0.1/cxx/struct.UniquePtr.html">UniquePtr&lt;T&gt;</a></td><td>std::unique_ptr&lt;T&gt;</td><td><sup><i>cannot hold opaque Rust type</i></sup></td></tr>
 //! <tr><td></td><td></td><td></td></tr>
 //! </table>

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -24,7 +24,7 @@ cxxbridge::RustStr c_return_str(const Shared &shared) {
   return "2020";
 }
 
-cxxbridge::RustString c_return_rust_string() { return "2020"; }
+cxxbridge::String c_return_rust_string() { return "2020"; }
 
 std::unique_ptr<std::string> c_return_unique_ptr_string() {
   return std::unique_ptr<std::string>(new std::string("2020"));
@@ -67,7 +67,7 @@ void c_take_str(cxxbridge::RustStr s) {
   }
 }
 
-void c_take_rust_string(cxxbridge::RustString s) {
+void c_take_rust_string(cxxbridge::String s) {
   if (std::string(s) == "2020") {
     cxx_test_suite_set_correct();
   }
@@ -100,7 +100,7 @@ extern "C" const char *cxx_run_test() noexcept {
   r_take_unique_ptr(std::unique_ptr<C>(new C{2020}));
   r_take_ref_c(C{2020});
   r_take_str(cxxbridge::RustStr("2020"));
-  // TODO r_take_rust_string(cxxbridge::RustString("2020"));
+  // TODO r_take_rust_string(cxxbridge::String("2020"));
   r_take_unique_ptr_string(
       std::unique_ptr<std::string>(new std::string("2020")));
 

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -19,12 +19,12 @@ std::unique_ptr<C> c_return_unique_ptr() {
 
 const size_t &c_return_ref(const Shared &shared) { return shared.z; }
 
-cxxbridge::Str c_return_str(const Shared &shared) {
+rust::Str c_return_str(const Shared &shared) {
   (void)shared;
   return "2020";
 }
 
-cxxbridge::String c_return_rust_string() { return "2020"; }
+rust::String c_return_rust_string() { return "2020"; }
 
 std::unique_ptr<std::string> c_return_unique_ptr_string() {
   return std::unique_ptr<std::string>(new std::string("2020"));
@@ -42,7 +42,7 @@ void c_take_shared(Shared shared) {
   }
 }
 
-void c_take_box(cxxbridge::Box<R> r) {
+void c_take_box(rust::Box<R> r) {
   (void)r;
   cxx_test_suite_set_correct();
 }
@@ -61,13 +61,13 @@ void c_take_ref_c(const C &c) {
   }
 }
 
-void c_take_str(cxxbridge::Str s) {
+void c_take_str(rust::Str s) {
   if (std::string(s) == "2020") {
     cxx_test_suite_set_correct();
   }
 }
 
-void c_take_rust_string(cxxbridge::String s) {
+void c_take_rust_string(rust::String s) {
   if (std::string(s) == "2020") {
     cxx_test_suite_set_correct();
   }
@@ -99,8 +99,8 @@ extern "C" const char *cxx_run_test() noexcept {
   r_take_shared(Shared{2020});
   r_take_unique_ptr(std::unique_ptr<C>(new C{2020}));
   r_take_ref_c(C{2020});
-  r_take_str(cxxbridge::Str("2020"));
-  // TODO r_take_rust_string(cxxbridge::String("2020"));
+  r_take_str(rust::Str("2020"));
+  // TODO r_take_rust_string(rust::String("2020"));
   r_take_unique_ptr_string(
       std::unique_ptr<std::string>(new std::string("2020")));
 

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -42,7 +42,7 @@ void c_take_shared(Shared shared) {
   }
 }
 
-void c_take_box(cxxbridge::RustBox<R> r) {
+void c_take_box(cxxbridge::Box<R> r) {
   (void)r;
   cxx_test_suite_set_correct();
 }

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -19,7 +19,7 @@ std::unique_ptr<C> c_return_unique_ptr() {
 
 const size_t &c_return_ref(const Shared &shared) { return shared.z; }
 
-cxxbridge::RustStr c_return_str(const Shared &shared) {
+cxxbridge::Str c_return_str(const Shared &shared) {
   (void)shared;
   return "2020";
 }
@@ -61,7 +61,7 @@ void c_take_ref_c(const C &c) {
   }
 }
 
-void c_take_str(cxxbridge::RustStr s) {
+void c_take_str(cxxbridge::Str s) {
   if (std::string(s) == "2020") {
     cxx_test_suite_set_correct();
   }
@@ -99,7 +99,7 @@ extern "C" const char *cxx_run_test() noexcept {
   r_take_shared(Shared{2020});
   r_take_unique_ptr(std::unique_ptr<C>(new C{2020}));
   r_take_ref_c(C{2020});
-  r_take_str(cxxbridge::RustStr("2020"));
+  r_take_str(cxxbridge::Str("2020"));
   // TODO r_take_rust_string(cxxbridge::String("2020"));
   r_take_unique_ptr_string(
       std::unique_ptr<std::string>(new std::string("2020")));

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -19,7 +19,7 @@ private:
 
 size_t c_return_primitive();
 Shared c_return_shared();
-cxxbridge::RustBox<R> c_return_box();
+cxxbridge::Box<R> c_return_box();
 std::unique_ptr<C> c_return_unique_ptr();
 const size_t &c_return_ref(const Shared &shared);
 cxxbridge::Str c_return_str(const Shared &shared);
@@ -28,7 +28,7 @@ std::unique_ptr<std::string> c_return_unique_ptr_string();
 
 void c_take_primitive(size_t n);
 void c_take_shared(Shared shared);
-void c_take_box(cxxbridge::RustBox<R> r);
+void c_take_box(cxxbridge::Box<R> r);
 void c_take_unique_ptr(std::unique_ptr<C> c);
 void c_take_ref_r(const R &r);
 void c_take_ref_c(const C &c);

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -22,7 +22,7 @@ Shared c_return_shared();
 cxxbridge::RustBox<R> c_return_box();
 std::unique_ptr<C> c_return_unique_ptr();
 const size_t &c_return_ref(const Shared &shared);
-cxxbridge::RustStr c_return_str(const Shared &shared);
+cxxbridge::Str c_return_str(const Shared &shared);
 cxxbridge::String c_return_rust_string();
 std::unique_ptr<std::string> c_return_unique_ptr_string();
 
@@ -32,7 +32,7 @@ void c_take_box(cxxbridge::RustBox<R> r);
 void c_take_unique_ptr(std::unique_ptr<C> c);
 void c_take_ref_r(const R &r);
 void c_take_ref_c(const C &c);
-void c_take_str(cxxbridge::RustStr s);
+void c_take_str(cxxbridge::Str s);
 void c_take_rust_string(cxxbridge::String s);
 void c_take_unique_ptr_string(std::unique_ptr<std::string> s);
 

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -19,21 +19,21 @@ private:
 
 size_t c_return_primitive();
 Shared c_return_shared();
-cxxbridge::Box<R> c_return_box();
+rust::Box<R> c_return_box();
 std::unique_ptr<C> c_return_unique_ptr();
 const size_t &c_return_ref(const Shared &shared);
-cxxbridge::Str c_return_str(const Shared &shared);
-cxxbridge::String c_return_rust_string();
+rust::Str c_return_str(const Shared &shared);
+rust::String c_return_rust_string();
 std::unique_ptr<std::string> c_return_unique_ptr_string();
 
 void c_take_primitive(size_t n);
 void c_take_shared(Shared shared);
-void c_take_box(cxxbridge::Box<R> r);
+void c_take_box(rust::Box<R> r);
 void c_take_unique_ptr(std::unique_ptr<C> c);
 void c_take_ref_r(const R &r);
 void c_take_ref_c(const C &c);
-void c_take_str(cxxbridge::Str s);
-void c_take_rust_string(cxxbridge::String s);
+void c_take_str(rust::Str s);
+void c_take_rust_string(rust::String s);
 void c_take_unique_ptr_string(std::unique_ptr<std::string> s);
 
 } // namespace tests

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -23,7 +23,7 @@ cxxbridge::RustBox<R> c_return_box();
 std::unique_ptr<C> c_return_unique_ptr();
 const size_t &c_return_ref(const Shared &shared);
 cxxbridge::RustStr c_return_str(const Shared &shared);
-cxxbridge::RustString c_return_rust_string();
+cxxbridge::String c_return_rust_string();
 std::unique_ptr<std::string> c_return_unique_ptr_string();
 
 void c_take_primitive(size_t n);
@@ -33,7 +33,7 @@ void c_take_unique_ptr(std::unique_ptr<C> c);
 void c_take_ref_r(const R &r);
 void c_take_ref_c(const C &c);
 void c_take_str(cxxbridge::RustStr s);
-void c_take_rust_string(cxxbridge::RustString s);
+void c_take_rust_string(cxxbridge::String s);
 void c_take_unique_ptr_string(std::unique_ptr<std::string> s);
 
 } // namespace tests


### PR DESCRIPTION
Fixes #46.

Before: `cxxbridge::RustString`, `cxxbridge::RustStr`, `cxxbridge::RustBox`
After: `rust::String`, `rust::Str`, `rust::Box`