### PR TITLE
Use iosfwd for forward declared ostream insertion operators

### DIFF
--- a/include/cxxbridge.h
+++ b/include/cxxbridge.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <array>
 #include <cstdint>
-#include <iostream>
+#include <iosfwd>
 #include <string>
 
 namespace rust {

--- a/src/cxxbridge.cc
+++ b/src/cxxbridge.cc
@@ -1,5 +1,6 @@
 #include "../include/cxxbridge.h"
 #include <cstring>
+#include <iostream>
 #include <memory>
 #include <stdexcept>
 


### PR DESCRIPTION
As was suggested in #8.

> Improved unnecessary code generation by using `iosfwd` instead of `iostream`. I recommend looking at what happens per translation unit when including `iostream`. It's not pretty, but `iosfwd` allows us to forward declare the `ostream` insertion operators without incurring this overhead.