### PR TITLE
Change cast operators to explicit

### DIFF
--- a/demo-cxx/demo.cc
+++ b/demo-cxx/demo.cc
@@ -10,7 +10,7 @@ ThingC::ThingC(std::string appname) : appname(std::move(appname)) {}
 ThingC::~ThingC() { std::cout << "done with ThingC" << std::endl; }
 
 std::unique_ptr<ThingC> make_demo(rust::Str appname) {
-  return std::unique_ptr<ThingC>(new ThingC(appname));
+  return std::unique_ptr<ThingC>(new ThingC(std::string(appname)));
 }
 
 const std::string &get_name(const ThingC &thing) { return thing.appname; }

--- a/include/cxxbridge.h
+++ b/include/cxxbridge.h
@@ -17,7 +17,7 @@ public:
   String &operator=(const String &other) noexcept;
   String &operator=(String &&other) noexcept;
   ~String() noexcept;
-  operator std::string() const;
+  explicit operator std::string() const;
 
   // Note: no null terminator.
   const char *data() const noexcept;
@@ -37,7 +37,7 @@ public:
   Str(std::string &&s) = delete;
   Str(const Str &other) noexcept;
   Str &operator=(Str other) noexcept;
-  operator std::string() const;
+  explicit operator std::string() const;
 
   // Note: no null terminator.
   const char *data() const noexcept;

--- a/include/cxxbridge.h
+++ b/include/cxxbridge.h
@@ -53,7 +53,7 @@ public:
     size_t len;
   };
   Str(Repr repr) noexcept;
-  operator Repr() noexcept;
+  explicit operator Repr() noexcept;
 
 private:
   Repr repr;


### PR DESCRIPTION
#8 assures that this will save headaches.

> Changed all cast operators to `explicit`. This saves more headaches in the long run, I assure you.