### PR TITLE
Parse Result<T> return type

### DIFF
--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -69,6 +69,12 @@ pub(crate) fn typecheck(apis: &[Api], types: &Types) -> Result<()> {
                         errors.push(return_by_value(ty, types));
                     }
                 }
+                if efn.throws {
+                    errors.push(Error::new_spanned(
+                        efn,
+                        "fallible functions are not implemented yet",
+                    ));
+                }
             }
             _ => {}
         }

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -50,6 +50,7 @@ pub struct ExternFn {
     pub receiver: Option<Receiver>,
     pub args: Vec<Var>,
     pub ret: Option<Type>,
+    pub throws: bool,
     pub semi_token: Token![;],
 }
 


### PR DESCRIPTION
The translation to C++ isn't implemented yet, but it will parse and show a dedicated error message for now.

```rust
extern "Rust" {
    fn f() -> Result<()>;
              ^^^^^^^^^^
}
```