### PR TITLE
Implement conversion of exception⟶Result

### DIFF
--- a/gen/include.rs
+++ b/gen/include.rs
@@ -18,6 +18,7 @@ pub fn get(guard: &str) -> &'static str {
 pub struct Includes {
     custom: Vec<String>,
     pub cstdint: bool,
+    pub cstring: bool,
     pub memory: bool,
     pub string: bool,
     pub type_traits: bool,
@@ -40,6 +41,9 @@ impl Display for Includes {
         }
         if self.cstdint {
             writeln!(f, "#include <cstdint>")?;
+        }
+        if self.cstring {
+            writeln!(f, "#include <cstring>")?;
         }
         if self.memory {
             writeln!(f, "#include <memory>")?;

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -1,0 +1,29 @@
+use std::fmt::{self, Debug, Display};
+use std::slice;
+
+/// Exception thrown from an `extern "C"` function.
+#[derive(Debug)]
+pub struct Exception {
+    pub(crate) what: Box<str>,
+}
+
+impl Display for Exception {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.what)
+    }
+}
+
+impl std::error::Error for Exception {}
+
+impl Exception {
+    pub fn what(&self) -> &str {
+        &self.what
+    }
+}
+
+#[export_name = "cxxbridge02$exception"]
+unsafe extern "C" fn exception(ptr: *const u8, len: usize) -> *const u8 {
+    let slice = slice::from_raw_parts(ptr, len);
+    let boxed = String::from_utf8_lossy(slice).into_owned().into_boxed_str();
+    Box::leak(boxed).as_ptr()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,6 +354,7 @@ mod assert;
 
 mod cxx_string;
 mod error;
+mod exception;
 mod gen;
 mod opaque;
 mod paths;
@@ -365,6 +366,7 @@ mod unique_ptr;
 mod unwind;
 
 pub use crate::cxx_string::CxxString;
+pub use crate::exception::Exception;
 pub use crate::unique_ptr::UniquePtr;
 pub use cxxbridge_macro::bridge;
 

--- a/src/rust_str.rs
+++ b/src/rust_str.rs
@@ -7,8 +7,8 @@ use std::str;
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct RustStr {
-    ptr: NonNull<u8>,
-    len: usize,
+    pub(crate) ptr: NonNull<u8>,
+    pub(crate) len: usize,
 }
 
 impl RustStr {

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -1,5 +1,5 @@
 use crate::syntax::atom::Atom::{self, *};
-use crate::syntax::{error, ident, Api, ExternFn, Lang::*, Ref, Ty1, Type, Types, Var};
+use crate::syntax::{error, ident, Api, ExternFn, Ref, Ty1, Type, Types, Var};
 use proc_macro2::Ident;
 use syn::{Error, Result};
 
@@ -68,12 +68,6 @@ pub(crate) fn typecheck(apis: &[Api], types: &Types) -> Result<()> {
                     if is_unsized(ty, types) {
                         errors.push(return_by_value(ty, types));
                     }
-                }
-                if efn.throws && efn.lang == Cxx {
-                    errors.push(Error::new_spanned(
-                        efn,
-                        "fallible C++ functions are not implemented yet",
-                    ));
                 }
             }
             _ => {}

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -30,6 +30,10 @@ pub mod ffi {
         fn c_take_str(s: &str);
         fn c_take_rust_string(s: String);
         fn c_take_unique_ptr_string(s: UniquePtr<CxxString>);
+
+        fn c_try_return_void() -> Result<()>;
+        fn c_try_return_primitive() -> Result<usize>;
+        fn c_fail_return_primitive() -> Result<usize>;
     }
 
     extern "Rust" {

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -1,6 +1,7 @@
 #include "tests/ffi/tests.h"
 #include "tests/ffi/lib.rs"
 #include <cstring>
+#include <stdexcept>
 
 extern "C" void cxx_test_suite_set_correct() noexcept;
 extern "C" tests::R *cxx_test_suite_get_box() noexcept;
@@ -90,6 +91,12 @@ void c_take_unique_ptr_string(std::unique_ptr<std::string> s) {
     cxx_test_suite_set_correct();
   }
 }
+
+void c_try_return_void() {}
+
+size_t c_try_return_primitive() { return 2020; }
+
+size_t c_fail_return_primitive() { throw std::logic_error("logic error"); }
 
 extern "C" C *cxx_test_suite_get_unique_ptr() noexcept {
   return std::unique_ptr<C>(new C{2020}).release();

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -36,4 +36,8 @@ void c_take_str(rust::Str s);
 void c_take_rust_string(rust::String s);
 void c_take_unique_ptr_string(std::unique_ptr<std::string> s);
 
+void c_try_return_void();
+size_t c_try_return_primitive();
+size_t c_fail_return_primitive();
+
 } // namespace tests

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -38,6 +38,13 @@ fn test_c_return() {
             .to_str()
             .unwrap()
     );
+
+    assert_eq!((), ffi::c_try_return_void().unwrap());
+    assert_eq!(2020, ffi::c_try_return_primitive().unwrap());
+    assert_eq!(
+        "logic error",
+        ffi::c_fail_return_primitive().unwrap_err().what(),
+    );
 }
 
 #[test]


### PR DESCRIPTION
This allows an `extern "C"` function to be declared with a Result\<T\> return type. We wrap the C++ function body in try/catch and turn any std::exception into a Rust error of type `cxx::Exception` using the `what()` virtual function of the C++ exception.

The reverse direction of Result⟶exception was implemented in #73.

#53