### PR TITLE
Allow .rs.h extension when including generated header

### DIFF
--- a/demo-cxx/demo.cc
+++ b/demo-cxx/demo.cc
@@ -1,5 +1,5 @@
 #include "demo-cxx/demo.h"
-#include "demo-rs/src/main.rs"
+#include "demo-rs/src/main.rs.h"
 #include <iostream>
 
 namespace org {

--- a/demo-rs/BUCK
+++ b/demo-rs/BUCK
@@ -36,7 +36,7 @@ genrule(
 cxx_library(
     name = "include",
     exported_headers = {
-        "src/main.rs": ":gen-header",
+        "src/main.rs.h": ":gen-header",
     },
     visibility = ["PUBLIC"],
 )

--- a/demo-rs/BUILD
+++ b/demo-rs/BUILD
@@ -22,7 +22,7 @@ cc_library(
 genrule(
     name = "gen-header",
     srcs = ["src/main.rs"],
-    outs = ["main.rs"],
+    outs = ["main.rs.h"],
     cmd = "$(location //:codegen) --header $< > $@",
     tools = ["//:codegen"],
 )

--- a/tests/BUCK
+++ b/tests/BUCK
@@ -21,7 +21,7 @@ cxx_library(
         ":gen-source",
     ],
     headers = {
-        "ffi/lib.rs": ":gen-header",
+        "ffi/lib.rs.h": ":gen-header",
         "ffi/tests.h": "ffi/tests.h",
     },
     deps = ["//:core"],

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -31,7 +31,7 @@ cc_library(
 genrule(
     name = "gen-header",
     srcs = ["ffi/lib.rs"],
-    outs = ["lib.rs"],
+    outs = ["lib.rs.h"],
     cmd = "$(location //:codegen) --header $< > $@",
     tools = ["//:codegen"],
 )

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -1,5 +1,5 @@
 #include "tests/ffi/tests.h"
-#include "tests/ffi/lib.rs"
+#include "tests/ffi/lib.rs.h"
 #include <cstring>
 #include <stdexcept>
 


### PR DESCRIPTION
Having `#include "path/to/lib.rs"` is cute but potentially annoying or brittle in some environments. This PR exposes `#include "path/to/lib.rs.h"` in addition.