### PR TITLE
Parse function pointer types

### DIFF
--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -45,6 +45,7 @@ pub(crate) fn typecheck(apis: &[Api], types: &Types) -> Result<()> {
                     errors.push(unsupported_reference_type(ty));
                 }
             }
+            Type::Fn(_) => errors.push(unimplemented_fn_type(ty)),
             _ => {}
         }
     }
@@ -212,4 +213,8 @@ fn return_by_value(ty: &Type, types: &Types) -> Error {
     let desc = describe(ty, types);
     let message = format!("returning {} by value is not supported", desc);
     Error::new_spanned(ty, message)
+}
+
+fn unimplemented_fn_type(ty: &Type) -> Error {
+    Error::new_spanned(ty, "function pointer support is not implemented yet")
 }

--- a/syntax/tokens.rs
+++ b/syntax/tokens.rs
@@ -1,7 +1,7 @@
 use crate::syntax::atom::Atom::*;
-use crate::syntax::{Derive, ExternFn, Ref, Ty1, Type, Var};
+use crate::syntax::{Derive, ExternFn, Ref, Signature, Ty1, Type, Var};
 use proc_macro2::{Ident, Span, TokenStream};
-use quote::{quote, quote_spanned, ToTokens};
+use quote::{quote_spanned, ToTokens};
 use syn::Token;
 
 impl ToTokens for Type {
@@ -16,21 +16,7 @@ impl ToTokens for Type {
             }
             Type::RustBox(ty) | Type::UniquePtr(ty) => ty.to_tokens(tokens),
             Type::Ref(r) | Type::Str(r) => r.to_tokens(tokens),
-            Type::Fn(f) => {
-                let fn_token = f.fn_token;
-                let args = &f.args;
-                tokens.extend(quote!(#fn_token(#(#args),*)));
-                let mut ret = match &f.ret {
-                    Some(ret) => quote!(#ret),
-                    None => quote!(()),
-                };
-                if f.throws {
-                    ret = quote!(::std::result::Result<#ret, _>);
-                }
-                if f.ret.is_some() || f.throws {
-                    tokens.extend(quote!(-> #ret));
-                }
-            }
+            Type::Fn(f) => f.to_tokens(tokens),
             Type::Void(span) => tokens.extend(quote_spanned!(*span=> ())),
         }
     }
@@ -78,5 +64,11 @@ impl ToTokens for Derive {
 impl ToTokens for ExternFn {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         self.sig.tokens.to_tokens(tokens);
+    }
+}
+
+impl ToTokens for Signature {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.tokens.to_tokens(tokens);
     }
 }


### PR DESCRIPTION
This PR is just the parsing, so we don't do anything useful with them yet.

```console
error: function pointer support is not implemented yet
  --> tests/ffi/lib.rs:35:38
   |
35 |         fn c_take_callback(callback: fn(String) -> Result<usize>);
   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
```