### PR TITLE
Disallow shared structs having 0 fields

### DIFF
--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -13,7 +13,7 @@ mod tokens;
 pub mod types;
 
 use proc_macro2::{Ident, Span, TokenStream};
-use syn::{LitStr, Token};
+use syn::{token::Brace, LitStr, Token};
 
 pub use self::atom::Atom;
 pub use self::doc::Doc;
@@ -40,6 +40,7 @@ pub struct Struct {
     pub derives: Vec<Ident>,
     pub struct_token: Token![struct],
     pub ident: Ident,
+    pub brace_token: Brace,
     pub fields: Vec<Var>,
 }
 

--- a/tests/ui/empty_struct.rs
+++ b/tests/ui/empty_struct.rs
@@ -1,0 +1,6 @@
+#[cxx::bridge]
+mod ffi {
+    struct Empty {}
+}
+
+fn main() {}

--- a/tests/ui/empty_struct.stderr
+++ b/tests/ui/empty_struct.stderr
@@ -1,0 +1,5 @@
+error: structs without any fields are not supported
+ --> $DIR/empty_struct.rs:3:5
+  |
+3 |     struct Empty {}
+  |     ^^^^^^^^^^^^^^^


### PR DESCRIPTION
Such structs problematically have a size of 0 in Rust and 1 in C++. Thus if they are used as a field of another struct, there would be a discrepancy in field offset for any fields after it:

```rust
mod ffi {
    struct Empty {}
    struct NonEmpty {
        empty: Empty,
        i: u8, // offset 0 in Rust, 1 in C++
    }
}
```

Easiest to just disallow for now with an error message.

```console
error: structs without any fields are not supported
 --> $DIR/empty_struct.rs:3:5
  |
3 |     struct Empty {}
  |     ^^^^^^^^^^^^^^^
```