### PR TITLE
Make Result work with UniquePtr, RustBox, RustString, Str

### DIFF
--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -36,6 +36,8 @@ pub mod ffi {
         fn c_try_return_void() -> Result<()>;
         fn c_try_return_primitive() -> Result<usize>;
         fn c_fail_return_primitive() -> Result<usize>;
+        fn c_try_return_string() -> Result<UniquePtr<CxxString>>;
+        fn c_fail_return_string() -> Result<UniquePtr<CxxString>>;
     }
 
     extern "Rust" {

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -98,6 +98,14 @@ size_t c_try_return_primitive() { return 2020; }
 
 size_t c_fail_return_primitive() { throw std::logic_error("logic error"); }
 
+std::unique_ptr<std::string> c_try_return_string() {
+  return std::unique_ptr<std::string>(new std::string("ok"));
+}
+
+std::unique_ptr<std::string> c_fail_return_string() { 
+  throw std::logic_error("logic error getting string"); 
+}
+
 extern "C" C *cxx_test_suite_get_unique_ptr() noexcept {
   return std::unique_ptr<C>(new C{2020}).release();
 }

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -39,5 +39,7 @@ void c_take_unique_ptr_string(std::unique_ptr<std::string> s);
 void c_try_return_void();
 size_t c_try_return_primitive();
 size_t c_fail_return_primitive();
+std::unique_ptr<std::string> c_try_return_string();
+std::unique_ptr<std::string> c_fail_return_string();
 
 } // namespace tests

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -45,6 +45,18 @@ fn test_c_return() {
         "logic error",
         ffi::c_fail_return_primitive().unwrap_err().what(),
     );
+    assert_eq!(
+        "ok",
+        ffi::c_try_return_string()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .to_string()
+    );
+    assert_eq!(
+        "logic error getting string",
+        ffi::c_fail_return_string().unwrap_err().what(),
+    );
 }
 
 #[test]


### PR DESCRIPTION
Minimal fix to get it working.

I put in a test with a C++ function that returns `Result<UniquePtr<CxxString>>`.