### PR TITLE
Implement function pointer passing from Rust to C++

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -1,0 +1,5 @@
+#[repr(C)]
+pub struct FatFunction {
+    pub trampoline: *const (),
+    pub ptr: *const (),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,6 +356,7 @@ mod assert;
 mod cxx_string;
 mod error;
 mod exception;
+mod function;
 mod gen;
 mod opaque;
 mod paths;
@@ -374,6 +375,7 @@ pub use cxxbridge_macro::bridge;
 // Not public API.
 #[doc(hidden)]
 pub mod private {
+    pub use crate::function::FatFunction;
     pub use crate::opaque::Opaque;
     pub use crate::result::{r#try, Result};
     pub use crate::rust_str::RustStr;

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -1,5 +1,5 @@
 use crate::syntax::atom::Atom::{self, *};
-use crate::syntax::{error, ident, Api, ExternFn, Ref, Struct, Ty1, Type, Types};
+use crate::syntax::{error, ident, Api, ExternFn, Lang, Ref, Struct, Ty1, Type, Types};
 use proc_macro2::{Delimiter, Group, Ident, TokenStream};
 use quote::{quote, ToTokens};
 use std::fmt::Display;
@@ -136,10 +136,12 @@ fn check_api_fn(cx: &mut Check, efn: &ExternFn) {
             cx.error(arg, msg);
         }
         if let Type::Fn(_) = arg.ty {
-            cx.error(
-                arg,
-                "passing a function pointer argument is not implemented yet",
-            );
+            if efn.lang == Lang::Rust {
+                cx.error(
+                    arg,
+                    "passing a function pointer from C++ to Rust is not implemented yet",
+                );
+            }
         }
     }
 

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -32,6 +32,7 @@ pub mod ffi {
         fn c_take_str(s: &str);
         fn c_take_rust_string(s: String);
         fn c_take_unique_ptr_string(s: UniquePtr<CxxString>);
+        fn c_take_callback(callback: fn(String) -> usize);
 
         fn c_try_return_void() -> Result<()>;
         fn c_try_return_primitive() -> Result<usize>;

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -92,6 +92,10 @@ void c_take_unique_ptr_string(std::unique_ptr<std::string> s) {
   }
 }
 
+void c_take_callback(rust::Fn<size_t(rust::String)> callback) {
+  callback("2020");
+}
+
 void c_try_return_void() {}
 
 size_t c_try_return_primitive() { return 2020; }

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -35,6 +35,7 @@ void c_take_ref_c(const C &c);
 void c_take_str(rust::Str s);
 void c_take_rust_string(rust::String s);
 void c_take_unique_ptr_string(std::unique_ptr<std::string> s);
+void c_take_callback(rust::Fn<size_t(rust::String)> callback);
 
 void c_try_return_void();
 size_t c_try_return_primitive();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -78,6 +78,18 @@ fn test_c_take() {
 }
 
 #[test]
+fn test_c_callback() {
+    fn callback(s: String) -> usize {
+        if s == "2020" {
+            cxx_test_suite_set_correct();
+        }
+        0
+    }
+
+    check!(ffi::c_take_callback(callback));
+}
+
+#[test]
 fn test_c_call_r() {
     fn cxx_run_test() {
         extern "C" {


### PR DESCRIPTION
For example:

```rust
mod ffi {
    extern "C" {
        fn c_take_callback(callback: fn(String) -> usize);
    }
}
```

This corresponds to an argument of type `rust::Fn<`​`>` on the C++ side, with an `operator()` to call the Rust function pointer.

```cpp
void c_take_callback(rust::Fn<size_t(rust::String)> callback) {
  callback("...");
}
```

---

The generated code is currently as follows; we can make this better in subsequent PRs.

```cpp
void cxxbridge02$c_take_callback(::rust::Fn<size_t(::rust::String)> callback) noexcept {
  void (*c_take_callback$)(::rust::Fn<size_t(::rust::String)>) = c_take_callback;
  c_take_callback$(callback);
}

size_t cxxbridge02$c_take_callback$callback$1(::rust::String *_0, void *) noexcept;

size_t cxxbridge02$c_take_callback$callback$0(::rust::String _0, void *extern$) noexcept {
  return cxxbridge02$c_take_callback$callback$1(&_0, extern$);
}
```

```rust
pub fn c_take_callback(callback: fn(String) -> usize) {
    extern "C" {
        #[link_name = "cxxbridge02$c_take_callback"]
        fn __c_take_callback(callback: ::cxx::private::FatFunction);
    }
    let callback = ::cxx::private::FatFunction {
        trampoline: {
            extern "C" {
                #[link_name = "cxxbridge02$c_take_callback$callback$0"]
                fn trampoline();
            }
            #[export_name = "cxxbridge02$c_take_callback$callback$1"]
            unsafe extern "C" fn __(
                _0: *mut ::cxx::private::RustString,
                __extern: fn(String) -> usize,
            ) -> usize {
                let __fn = "cxx_test_suite::ffi::c_take_callback::callback";
                ::cxx::private::catch_unwind(__fn, move || {
                    __extern(::std::mem::take((*_0).as_mut_string()))
                })
            }
            trampoline as usize as *const ()
        },
        ptr: callback as usize as *const (),
    };
    unsafe { __c_take_callback(callback) }
}
```