### PR TITLE
Fix README.md to match the files linked just below.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ this repo (with the C++ side of the implementation in the *demo-cxx* directory).
 To try it out, jump into demo-rs and run `cargo run`.
 
 ```rust
-#[cxx::bridge]
+#[cxx::bridge(namespace = org::example)]
 mod ffi {
     // Any shared structs, whose fields will be visible to both languages.
     struct SharedThing {


### PR DESCRIPTION
I was a bit confused about how this snippet in `README.md` matched the .h and .cc files below. I figured it out as soon as I looked at the real `main.rs` but here's a tiny PR to keep them in sync.