### PR TITLE
Deref and DerefMut for UniquePtr

### DIFF
--- a/src/unique_ptr.rs
+++ b/src/unique_ptr.rs
@@ -104,7 +104,7 @@ where
     fn deref(&self) -> &Self::Target {
         match self.as_ref() {
             Some(target) => target,
-            None => panic!("called deref on a null UniquePtr"),
+            None => panic!("called deref on a null UniquePtr<{}>", T::__NAME),
         }
     }
 }
@@ -116,7 +116,7 @@ where
     fn deref_mut(&mut self) -> &mut Self::Target {
         match self.as_mut() {
             Some(target) => target,
-            None => panic!("called deref_mut on a null UniquePtr"),
+            None => panic!("called deref_mut on a null UniquePtr<{}>", T::__NAME),
         }
     }
 }

--- a/src/unique_ptr.rs
+++ b/src/unique_ptr.rs
@@ -3,6 +3,7 @@ use std::ffi::c_void;
 use std::fmt::{self, Debug, Display};
 use std::marker::PhantomData;
 use std::mem;
+use std::ops::{Deref, DerefMut};
 use std::ptr;
 
 /// Binding to C++ `std::unique_ptr<T, std::default_delete<T>>`.
@@ -91,6 +92,32 @@ where
 {
     fn drop(&mut self) {
         unsafe { T::__drop(self.repr) }
+    }
+}
+
+impl<T> Deref for UniquePtr<T>
+where
+    T: UniquePtrTarget,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        match self.as_ref() {
+            Some(target) => target,
+            None => panic!("called deref on a null UniquePtr"),
+        }
+    }
+}
+
+impl<T> DerefMut for UniquePtr<T>
+where
+    T: UniquePtrTarget,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self.as_mut() {
+            Some(target) => target,
+            None => panic!("called deref_mut on a null UniquePtr"),
+        }
     }
 }
 

--- a/tests/unique_ptr.rs
+++ b/tests/unique_ptr.rs
@@ -1,0 +1,8 @@
+use cxx::{CxxString, UniquePtr};
+
+#[test]
+#[should_panic = "called deref on a null UniquePtr<CxxString>"]
+fn test_deref_null() {
+    let unique_ptr = UniquePtr::<CxxString>::null();
+    let _: &CxxString = &unique_ptr;
+}


### PR DESCRIPTION
The impls will panic on a null pointer. Panicking in Deref is unconventional but this matches the reality of how unique_ptr is used in practice in C++. In most places that unique_ptr is passed around they can never be null, and in the few cases where null is allowed the programmer is responsible for keeping track and handling those pointers carefully.

Providing these impls is less bad than users writing `ptr.as_ref().unwrap()` everywhere, because at least this way we can get the panic message to include type info to help debugging.