### PR TITLE
Fix ssize_t on Windows

### DIFF
--- a/include/cxx.h
+++ b/include/cxx.h
@@ -8,6 +8,10 @@
 #include <type_traits>
 #include <utility>
 
+#ifdef _WIN32
+#define ssize_t SSIZE_T
+#endif
+
 namespace rust {
 inline namespace cxxbridge02 {
 


### PR DESCRIPTION
Rust's `isize` converted into `ssize_t`, but it's not defined on Windows. That leads to compilation errors. There's `SSIZE_T` though.