### PR TITLE
Add in_place constructor for Box

### DIFF
--- a/include/cxx.h
+++ b/include/cxx.h
@@ -132,6 +132,14 @@ public:
   T *operator->() noexcept { return this->ptr; }
   T &operator*() noexcept { return *this->ptr; }
 
+  template <typename... Fields>
+  static Box in_place(Fields&&... fields) {
+    Box box;
+    box.uninit();
+    ::new (box.ptr) T{std::forward<Fields>(fields)...};
+    return box;
+  }
+
   // Important: requires that `raw` came from an into_raw call. Do not pass a
   // pointer from `new` or any other source.
   static Box from_raw(T *raw) noexcept {


### PR DESCRIPTION
Closes #102.

The use of list initialization is because the only types that can be boxed *and* constructed by C++ are shared structs, and we take care that those are always aggregates. (Opaque Rust types aren't constructible by C++, and opaque C++ types aren't allowed to be placed in Box.)