### PR TITLE
Use terminate instead of abort in no-exceptions mode

### DIFF
--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -1,6 +1,6 @@
 #include "../include/cxx.h"
-#include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <iostream>
 #include <memory>
 #include <stdexcept>
@@ -9,7 +9,7 @@ template <typename Exception>
 [[noreturn]] static void panic(const char *msg) {
 #if defined(RUST_CXX_NO_EXCEPTIONS)
   std::cerr << "Error: " << msg << ". Aborting." << std::endl;
-  std::abort();
+  std::terminate();
 #else
   throw Exception(msg);
 #endif


### PR DESCRIPTION
Fixes #111.