### PR TITLE
Specify author explicitly.

### DIFF
--- a/cmd/src/main.rs
+++ b/cmd/src/main.rs
@@ -17,7 +17,7 @@ use structopt::StructOpt;
 #[derive(StructOpt, Debug)]
 #[structopt(
     name = "cxxbridge",
-    author,
+    author = "dtolnay@gmail.com",
     about = "https://github.com/dtolnay/cxx",
     usage = "\
     cxxbridge <input>.rs              Emit .cc file for bridge to stdout


### PR DESCRIPTION
For those building without Cargo, it may be a little awkward to specify
the `CARGO_PKG_AUTHORS` environment variable (in some cases perhaps
requiring a wrapper script around rustc).