### PR TITLE
Adding &[u8] support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ returns of functions.
 <tr><th>name in Rust</th><th>name in C++</th><th>restrictions</th></tr>
 <tr><td>String</td><td>rust::String</td><td></td></tr>
 <tr><td>&amp;str</td><td>rust::Str</td><td></td></tr>
+<tr><td>&amp;[u8]</td><td>rust::Slice&lt;uint8_t&gt;</td><td>(no other slice types currently supported)</td></tr>
 <tr><td><a href="https://docs.rs/cxx/0.2/cxx/struct.CxxString.html">CxxString</a></td><td>std::string</td><td><sup><i>cannot be passed by value</i></sup></td></tr>
 <tr><td>Box&lt;T&gt;</td><td>rust::Box&lt;T&gt;</td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
 <tr><td><a href="https://docs.rs/cxx/0.2/cxx/struct.UniquePtr.html">UniquePtr&lt;T&gt;</a></td><td>std::unique_ptr&lt;T&gt;</td><td><sup><i>cannot hold opaque Rust type</i></sup></td></tr>
@@ -316,7 +317,6 @@ matter of designing a nice API for each in its non-native language.
 
 <table>
 <tr><th>name in Rust</th><th>name in C++</th></tr>
-<tr><td>&amp;[T]</td><td><sup><i>tbd</i></sup></td></tr>
 <tr><td>Vec&lt;T&gt;</td><td><sup><i>tbd</i></sup></td></tr>
 <tr><td>BTreeMap&lt;K, V&gt;</td><td><sup><i>tbd</i></sup></td></tr>
 <tr><td>HashMap&lt;K, V&gt;</td><td><sup><i>tbd</i></sup></td></tr>

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -16,6 +16,43 @@ inline namespace cxxbridge02 {
 
 struct unsafe_bitcopy_t;
 
+#ifndef CXXBRIDGE02_RUST_SLICE
+#define CXXBRIDGE02_RUST_SLICE
+template<typename T>
+class Slice final {
+public:
+  Slice() noexcept : repr(Repr{reinterpret_cast<const T *>(this), 0}) {}
+  Slice(const Slice<T> &) noexcept = default;
+
+  Slice(const T* s, size_t size) : repr(Repr{s, size}) {}
+
+  Slice &operator=(Slice<T> other) noexcept {
+    this->repr = other.repr;
+    return *this;
+  }
+
+  const T *data() const noexcept { return this->repr.ptr; }
+  size_t size() const noexcept { return this->repr.len; }
+  size_t length() const noexcept { return this->repr.len; }
+
+  // Repr is PRIVATE; must not be used other than by our generated code.
+  //
+  // At present this class is only used for &[u8] slices.
+  // Not necessarily ABI compatible with &[u8]. Codegen will translate to
+  // cxx::rust_slice_u8::RustSlice which matches this layout.
+  struct Repr {
+    const T *ptr;
+    size_t len;
+  };
+  Slice(Repr repr_) noexcept : repr(repr_) {}
+  explicit operator Repr() noexcept { return this->repr; }
+
+private:
+  Repr repr;
+};
+
+#endif // CXXBRIDGE02_RUST_SLICE
+
 #ifndef CXXBRIDGE02_RUST_STRING
 #define CXXBRIDGE02_RUST_STRING
 class String final {

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -184,6 +184,7 @@ fn expand_cxx_function_shim(namespace: &Namespace, efn: &ExternFn, types: &Types
                 _ => quote!(#var),
             },
             Type::Str(_) => quote!(::cxx::private::RustStr::from(#var)),
+            Type::SliceRefU8(_) => quote!(::cxx::private::RustSliceU8::from(#var)),
             ty if types.needs_indirect_abi(ty) => quote!(#var.as_mut_ptr()),
             _ => quote!(#var),
         }
@@ -255,6 +256,7 @@ fn expand_cxx_function_shim(namespace: &Namespace, efn: &ExternFn, types: &Types
                 _ => None,
             },
             Type::Str(_) => Some(quote!(#call.map(|r| r.as_str()))),
+            Type::SliceRefU8(_) => Some(quote!(#call.map(|r| r.as_slice()))),
             _ => None,
         })
     } else {
@@ -267,6 +269,7 @@ fn expand_cxx_function_shim(namespace: &Namespace, efn: &ExternFn, types: &Types
                 _ => None,
             },
             Type::Str(_) => Some(quote!(#call.as_str())),
+            Type::SliceRefU8(_) => Some(quote!(#call.as_slice())),
             _ => None,
         })
     }
@@ -375,6 +378,7 @@ fn expand_rust_function_shim_impl(
                 _ => quote!(#ident),
             },
             Type::Str(_) => quote!(#ident.as_str()),
+            Type::SliceRefU8(_) => quote!(#ident.as_slice()),
             ty if types.needs_indirect_abi(ty) => quote!(::std::ptr::read(#ident)),
             _ => quote!(#ident),
         }
@@ -402,6 +406,7 @@ fn expand_rust_function_shim_impl(
                 _ => None,
             },
             Type::Str(_) => Some(quote!(::cxx::private::RustStr::from(#call))),
+            Type::SliceRefU8(_) => Some(quote!(::cxx::private::RustSliceU8::from(#call))),
             _ => None,
         })
         .unwrap_or(call);
@@ -572,6 +577,7 @@ fn expand_extern_type(ty: &Type) -> TokenStream {
             _ => quote!(#ty),
         },
         Type::Str(_) => quote!(::cxx::private::RustStr),
+        Type::SliceRefU8(_) => quote!(::cxx::private::RustSliceU8),
         _ => quote!(#ty),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,6 +367,7 @@ mod gen;
 mod opaque;
 mod paths;
 mod result;
+mod rust_sliceu8;
 mod rust_str;
 mod rust_string;
 mod syntax;
@@ -384,6 +385,7 @@ pub mod private {
     pub use crate::function::FatFunction;
     pub use crate::opaque::Opaque;
     pub use crate::result::{r#try, Result};
+    pub use crate::rust_sliceu8::RustSliceU8;
     pub use crate::rust_str::RustStr;
     pub use crate::rust_string::RustString;
     pub use crate::unique_ptr::UniquePtrTarget;

--- a/src/rust_sliceu8.rs
+++ b/src/rust_sliceu8.rs
@@ -1,0 +1,26 @@
+use std::mem;
+use std::slice;
+use std::ptr::NonNull;
+
+// Not necessarily ABI compatible with &[u8]. Codegen performs the translation.
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct RustSliceU8 {
+    pub(crate) ptr: NonNull<u8>,
+    pub(crate) len: usize,
+}
+
+impl RustSliceU8 {
+    pub fn from(s: &[u8]) -> Self {
+        RustSliceU8 {
+            ptr: NonNull::from(s).cast::<u8>(),
+            len: s.len(),
+        }
+    }
+
+    pub unsafe fn as_slice<'a>(self) -> &'a [u8] {
+        slice::from_raw_parts(self.ptr.as_ptr(), self.len)
+    }
+}
+
+const_assert!(mem::size_of::<Option<RustSliceU8>>() == mem::size_of::<RustSliceU8>());

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -245,6 +245,8 @@ fn describe(cx: &mut Check, ty: &Type) -> String {
         Type::UniquePtr(_) => "unique_ptr".to_owned(),
         Type::Ref(_) => "reference".to_owned(),
         Type::Str(_) => "&str".to_owned(),
+        Type::Slice(_) => "slice".to_owned(),
+        Type::SliceRefU8(_) => "&[u8]".to_owned(),
         Type::Fn(_) => "function pointer".to_owned(),
         Type::Void(_) => "()".to_owned(),
     }

--- a/syntax/impls.rs
+++ b/syntax/impls.rs
@@ -1,4 +1,4 @@
-use crate::syntax::{ExternFn, Receiver, Ref, Signature, Ty1, Type};
+use crate::syntax::{ExternFn, Receiver, Ref, Signature, Slice, Ty1, Type};
 use std::hash::{Hash, Hasher};
 use std::mem;
 use std::ops::Deref;
@@ -21,6 +21,8 @@ impl Hash for Type {
             Type::Ref(t) => t.hash(state),
             Type::Str(t) => t.hash(state),
             Type::Fn(t) => t.hash(state),
+            Type::Slice(t) => t.hash(state),
+            Type::SliceRefU8(t) => t.hash(state),
             Type::Void(_) => {}
         }
     }
@@ -37,6 +39,8 @@ impl PartialEq for Type {
             (Type::Ref(lhs), Type::Ref(rhs)) => lhs == rhs,
             (Type::Str(lhs), Type::Str(rhs)) => lhs == rhs,
             (Type::Fn(lhs), Type::Fn(rhs)) => lhs == rhs,
+            (Type::Slice(lhs), Type::Slice(rhs)) => lhs == rhs,
+            (Type::SliceRefU8(lhs), Type::SliceRefU8(rhs)) => lhs == rhs,
             (Type::Void(_), Type::Void(_)) => true,
             (_, _) => false,
         }
@@ -102,6 +106,32 @@ impl Hash for Ref {
             inner,
         } = self;
         mutability.is_some().hash(state);
+        inner.hash(state);
+    }
+}
+
+impl Eq for Slice {}
+
+impl PartialEq for Slice {
+    fn eq(&self, other: &Slice) -> bool {
+        let Slice {
+            bracket: _,
+            inner,
+        } = self;
+        let Slice {
+            bracket: _,
+            inner: inner2,
+        } = other;
+        inner == inner2
+    }
+}
+
+impl Hash for Slice {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let Slice {
+            bracket: _,
+            inner,
+        } = self;
         inner.hash(state);
     }
 }

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -15,7 +15,7 @@ pub mod types;
 use self::parse::kw;
 use proc_macro2::{Ident, Span};
 use syn::punctuated::Punctuated;
-use syn::token::{Brace, Paren};
+use syn::token::{Brace, Bracket, Paren};
 use syn::{LitStr, Token};
 
 pub use self::atom::Atom;
@@ -84,6 +84,8 @@ pub enum Type {
     Str(Box<Ref>),
     Fn(Box<Signature>),
     Void(Span),
+    Slice(Box<Slice>),
+    SliceRefU8(Box<Ref>),
 }
 
 pub struct Ty1 {
@@ -96,6 +98,11 @@ pub struct Ty1 {
 pub struct Ref {
     pub ampersand: Token![&],
     pub mutability: Option<Token![mut]>,
+    pub inner: Type,
+}
+
+pub struct Slice {
+    pub bracket: Bracket,
     pub inner: Type,
 }
 

--- a/syntax/tokens.rs
+++ b/syntax/tokens.rs
@@ -1,5 +1,5 @@
 use crate::syntax::atom::Atom::*;
-use crate::syntax::{Derive, ExternFn, Ref, Signature, Ty1, Type, Var};
+use crate::syntax::{Derive, ExternFn, Ref, Signature, Slice, Ty1, Type, Var};
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote_spanned, ToTokens};
 use syn::Token;
@@ -15,7 +15,8 @@ impl ToTokens for Type {
                 ident.to_tokens(tokens);
             }
             Type::RustBox(ty) | Type::UniquePtr(ty) => ty.to_tokens(tokens),
-            Type::Ref(r) | Type::Str(r) => r.to_tokens(tokens),
+            Type::Ref(r) | Type::Str(r) | Type::SliceRefU8(r) => r.to_tokens(tokens),
+            Type::Slice(s) => s.to_tokens(tokens),
             Type::Fn(f) => f.to_tokens(tokens),
             Type::Void(span) => tokens.extend(quote_spanned!(*span=> ())),
         }
@@ -48,6 +49,14 @@ impl ToTokens for Ref {
         self.ampersand.to_tokens(tokens);
         self.mutability.to_tokens(tokens);
         self.inner.to_tokens(tokens);
+    }
+}
+
+impl ToTokens for Slice {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.bracket.surround(tokens, |tokens| {
+            self.inner.to_tokens(tokens);
+        });
     }
 }
 

--- a/syntax/types.rs
+++ b/syntax/types.rs
@@ -23,9 +23,10 @@ impl<'a> Types<'a> {
         fn visit<'a>(all: &mut Set<'a, Type>, ty: &'a Type) {
             all.insert(ty);
             match ty {
-                Type::Ident(_) | Type::Str(_) | Type::Void(_) => {}
+                Type::Ident(_) | Type::Str(_) | Type::Void(_) | Type::SliceRefU8(_) => {}
                 Type::RustBox(ty) | Type::UniquePtr(ty) => visit(all, &ty.inner),
                 Type::Ref(r) => visit(all, &r.inner),
+                Type::Slice(s) => visit(all, &s.inner),
                 Type::Fn(f) => {
                     if let Some(ret) = &f.ret {
                         visit(all, ret);

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -24,6 +24,7 @@ pub mod ffi {
         fn c_return_unique_ptr() -> UniquePtr<C>;
         fn c_return_ref(shared: &Shared) -> &usize;
         fn c_return_str(shared: &Shared) -> &str;
+        fn c_return_sliceu8(shared: &Shared) -> &[u8];
         fn c_return_rust_string() -> String;
         fn c_return_unique_ptr_string() -> UniquePtr<CxxString>;
 
@@ -34,6 +35,7 @@ pub mod ffi {
         fn c_take_ref_r(r: &R);
         fn c_take_ref_c(c: &C);
         fn c_take_str(s: &str);
+        fn c_take_sliceu8(s: &[u8]);
         fn c_take_rust_string(s: String);
         fn c_take_unique_ptr_string(s: UniquePtr<CxxString>);
         fn c_take_callback(callback: fn(String) -> usize);
@@ -44,6 +46,7 @@ pub mod ffi {
         fn c_try_return_box() -> Result<Box<R>>;
         fn c_try_return_ref(s: &String) -> Result<&String>;
         fn c_try_return_str(s: &str) -> Result<&str>;
+        fn c_try_return_sliceu8(s: &[u8]) -> Result<&[u8]>;
         fn c_try_return_rust_string() -> Result<String>;
         fn c_try_return_unique_ptr_string() -> Result<UniquePtr<CxxString>>;
     }
@@ -67,6 +70,7 @@ pub mod ffi {
         fn r_take_ref_r(r: &R);
         fn r_take_ref_c(c: &C);
         fn r_take_str(s: &str);
+        fn r_take_sliceu8(s: &[u8]);
         fn r_take_rust_string(s: String);
         fn r_take_unique_ptr_string(s: UniquePtr<CxxString>);
 
@@ -158,6 +162,11 @@ fn r_take_str(s: &str) {
 
 fn r_take_rust_string(s: String) {
     assert_eq!(s, "2020");
+}
+
+fn r_take_sliceu8(s: &[u8]) {
+    assert_eq!(s.len(), 5);
+    assert_eq!(std::str::from_utf8(s).unwrap(), "2020\u{0}");
 }
 
 fn r_take_unique_ptr_string(s: UniquePtr<CxxString>) {

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -9,6 +9,8 @@ extern "C" bool cxx_test_suite_r_is_correct(const tests::R *) noexcept;
 
 namespace tests {
 
+const char* SLICE_DATA = "2020";
+
 C::C(size_t n) : n(n) {}
 
 size_t C::get() const { return this->n; }
@@ -30,6 +32,11 @@ const size_t &c_return_ref(const Shared &shared) { return shared.z; }
 rust::Str c_return_str(const Shared &shared) {
   (void)shared;
   return "2020";
+}
+
+rust::Slice<uint8_t> c_return_sliceu8(const Shared& shared) {
+  (void)shared;
+  return rust::Slice<uint8_t>((const unsigned char*)SLICE_DATA, 5);
 }
 
 rust::String c_return_rust_string() { return "2020"; }
@@ -80,6 +87,12 @@ void c_take_str(rust::Str s) {
   }
 }
 
+void c_take_sliceu8(rust::Slice<uint8_t> s) {
+  if (std::string((const char*)s.data(), s.size()) == "2020") {
+    cxx_test_suite_set_correct();
+  }
+}
+
 void c_take_rust_string(rust::String s) {
   if (std::string(s) == "2020") {
     cxx_test_suite_set_correct();
@@ -107,6 +120,8 @@ rust::Box<R> c_try_return_box() { return c_return_box(); }
 const rust::String &c_try_return_ref(const rust::String &s) { return s; }
 
 rust::Str c_try_return_str(rust::Str s) { return s; }
+
+rust::Slice<uint8_t> c_try_return_sliceU8(rust::Slice<uint8_t> s) { return s; }
 
 rust::String c_try_return_rust_string() { return c_return_rust_string(); }
 
@@ -146,6 +161,7 @@ extern "C" const char *cxx_run_test() noexcept {
   r_take_unique_ptr(std::unique_ptr<C>(new C{2020}));
   r_take_ref_c(C{2020});
   r_take_str(rust::Str("2020"));
+  r_take_sliceu8(rust::Slice<uint8_t>((const unsigned char*)SLICE_DATA, 5));
   r_take_rust_string(rust::String("2020"));
   r_take_unique_ptr_string(
       std::unique_ptr<std::string>(new std::string("2020")));

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -121,7 +121,7 @@ const rust::String &c_try_return_ref(const rust::String &s) { return s; }
 
 rust::Str c_try_return_str(rust::Str s) { return s; }
 
-rust::Slice<uint8_t> c_try_return_sliceU8(rust::Slice<uint8_t> s) { return s; }
+rust::Slice<uint8_t> c_try_return_sliceu8(rust::Slice<uint8_t> s) { return s; }
 
 rust::String c_try_return_rust_string() { return c_return_rust_string(); }
 

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -23,6 +23,7 @@ rust::Box<R> c_return_box();
 std::unique_ptr<C> c_return_unique_ptr();
 const size_t &c_return_ref(const Shared &shared);
 rust::Str c_return_str(const Shared &shared);
+rust::Slice<uint8_t> c_return_sliceu8(const Shared &shared);
 rust::String c_return_rust_string();
 std::unique_ptr<std::string> c_return_unique_ptr_string();
 
@@ -33,6 +34,7 @@ void c_take_unique_ptr(std::unique_ptr<C> c);
 void c_take_ref_r(const R &r);
 void c_take_ref_c(const C &c);
 void c_take_str(rust::Str s);
+void c_take_sliceu8(rust::Slice<uint8_t> s);
 void c_take_rust_string(rust::String s);
 void c_take_unique_ptr_string(std::unique_ptr<std::string> s);
 void c_take_callback(rust::Fn<size_t(rust::String)> callback);
@@ -43,6 +45,7 @@ size_t c_fail_return_primitive();
 rust::Box<R> c_try_return_box();
 const rust::String &c_try_return_ref(const rust::String &);
 rust::Str c_try_return_str(rust::Str);
+rust::Slice<uint8_t> c_try_return_sliceu8(rust::Slice<uint8_t>);
 rust::String c_try_return_rust_string();
 std::unique_ptr<std::string> c_try_return_unique_ptr_string();
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -29,6 +29,7 @@ fn test_c_return() {
     ffi::c_return_unique_ptr();
     assert_eq!(2020, *ffi::c_return_ref(&shared));
     assert_eq!("2020", ffi::c_return_str(&shared));
+    assert_eq!(b"2020\0", ffi::c_return_sliceu8(&shared));
     assert_eq!("2020", ffi::c_return_rust_string());
     assert_eq!(
         "2020",
@@ -51,6 +52,7 @@ fn test_c_try_return() {
     assert_eq!(2020, *ffi::c_try_return_box().unwrap());
     assert_eq!("2020", *ffi::c_try_return_ref(&"2020".to_owned()).unwrap());
     assert_eq!("2020", ffi::c_try_return_str("2020").unwrap());
+    assert_eq!(b"2020", ffi::c_try_return_sliceu8(b"2020").unwrap());
     assert_eq!("2020", ffi::c_try_return_rust_string().unwrap());
     assert_eq!(
         "2020",

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -71,6 +71,7 @@ fn test_c_take() {
     check!(ffi::c_take_ref_c(unique_ptr.as_ref().unwrap()));
     check!(ffi::c_take_unique_ptr(unique_ptr));
     check!(ffi::c_take_str("2020"));
+    check!(ffi::c_take_sliceu8(b"2020"));
     check!(ffi::c_take_rust_string("2020".to_owned()));
     check!(ffi::c_take_unique_ptr_string(
         ffi::c_return_unique_ptr_string()


### PR DESCRIPTION
This change adds specifically, support for `&[u8]` with a corresponding
`rust::Slice<uint8_t>` type. No other types of slice are permitted. The
rationale is that it may be common to pass binary data back and forth
across the FFI boundary, so it's more urgent to get this in place sooner.
Broader support for other slices can wait for the future.

But, both C++ and Rust-side bindings should allow the existing support
to be broadened to other Slice types in future without code changes.

A few specific notes:

* The name `rust::Slice` might be better as `rust::SliceRef` but I'm
  following the precedent of `rust::Str`.
* It would be good to add constructors from `std::span` but as that's
  a C++20 feature, that may have to wait until C++ feature detection
  is resolved. Meanwhile, `rust::Slice<uint8_t>` can be constructed
  from a raw pointer and a length.
* Internally, this follows the pattern of `&str`, where the parser will
  initially recognize this as `Type::Ref` (of `Type::Slice`) but then
  will replace that with `Type::SliceRefU8`. Type::Slice should not
  persist through later stages. As we later come to support other
  types of slice, we would probably want to remove `Type::SliceRefU8`.