### PR TITLE
Support calling C++ and Rust methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ anyhow = "1.0"
 cc = "1.0.49"
 codespan-reporting = "0.9"
 cxxbridge-macro = { version = "=0.2.9", path = "macro" }
+itertools = "0.9"
 link-cplusplus = "1.0"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 quote = "1.0"

--- a/README.md
+++ b/README.md
@@ -84,8 +84,10 @@ mod ffi {
 
         // Functions implemented in C++.
         fn make_demo(appname: &str) -> UniquePtr<ThingC>;
-        fn get_name(thing: &ThingC) -> &CxxString;
         fn do_thing(state: SharedThing);
+
+        // Methods implemented in C++.
+        fn get_name(self: &ThingC) -> &CxxString;
     }
 
     extern "Rust" {
@@ -95,6 +97,9 @@ mod ffi {
 
         // Functions implemented in Rust.
         fn print_r(r: &ThingR);
+
+        // Methods implemented in Rust.
+        fn print(self: &ThingR);
     }
 }
 ```
@@ -335,8 +340,6 @@ This is still early days for CXX; I am releasing it as a minimum viable product
 to collect feedback on the direction and invite collaborators. Here are some of
 the facets that I still intend for this project to tackle:
 
-- [ ] Support associated methods: `extern "Rust" { fn f(self: &Struct); }`
-- [ ] Support C++ member functions
 - [ ] Support structs with type parameters
 - [ ] Support async functions
 

--- a/demo-cxx/demo.cc
+++ b/demo-cxx/demo.cc
@@ -18,7 +18,10 @@ std::unique_ptr<ThingC> make_demo(rust::Str appname) {
   return std::unique_ptr<ThingC>(new ThingC(std::string(appname)));
 }
 
-void do_thing(SharedThing state) { print_r(*state.y); }
+void do_thing(SharedThing state) {
+  print_r(*state.y);
+  state.y->print();
+}
 
 } // namespace example
 } // namespace org

--- a/demo-cxx/demo.cc
+++ b/demo-cxx/demo.cc
@@ -9,11 +9,14 @@ ThingC::ThingC(std::string appname) : appname(std::move(appname)) {}
 
 ThingC::~ThingC() { std::cout << "done with ThingC" << std::endl; }
 
+const std::string &ThingC::get_name() const {
+  std::cout << "I'm a C++ method!" << std::endl;
+  return this->appname;
+}
+
 std::unique_ptr<ThingC> make_demo(rust::Str appname) {
   return std::unique_ptr<ThingC>(new ThingC(std::string(appname)));
 }
-
-const std::string &get_name(const ThingC &thing) { return thing.appname; }
 
 void do_thing(SharedThing state) { print_r(*state.y); }
 

--- a/demo-cxx/demo.h
+++ b/demo-cxx/demo.h
@@ -12,12 +12,13 @@ public:
   ~ThingC();
 
   std::string appname;
+
+  const std::string &get_name() const;
 };
 
 struct SharedThing;
 
 std::unique_ptr<ThingC> make_demo(rust::Str appname);
-const std::string &get_name(const ThingC &thing);
 void do_thing(SharedThing state);
 
 } // namespace example

--- a/demo-rs/src/main.rs
+++ b/demo-rs/src/main.rs
@@ -11,8 +11,9 @@ mod ffi {
 
         type ThingC;
         fn make_demo(appname: &str) -> UniquePtr<ThingC>;
-        fn get_name(thing: &ThingC) -> &CxxString;
+        fn get_name(self: &ThingC) -> &CxxString;
         fn do_thing(state: SharedThing);
+
     }
 
     extern "Rust" {
@@ -29,7 +30,7 @@ fn print_r(r: &ThingR) {
 
 fn main() {
     let x = ffi::make_demo("demo of cxx::bridge");
-    println!("this is a {}", ffi::get_name(x.as_ref().unwrap()));
+    println!("this is a {}", x.as_ref().unwrap().get_name());
 
     ffi::do_thing(ffi::SharedThing {
         z: 222,

--- a/demo-rs/src/main.rs
+++ b/demo-rs/src/main.rs
@@ -19,6 +19,7 @@ mod ffi {
     extern "Rust" {
         type ThingR;
         fn print_r(r: &ThingR);
+        fn print(self: &ThingR);
     }
 }
 
@@ -26,6 +27,12 @@ pub struct ThingR(usize);
 
 fn print_r(r: &ThingR) {
     println!("called back with r={}", r.0);
+}
+
+impl ThingR {
+    fn print(&self) {
+        println!("method called back with r={}", self.0);
+    }
 }
 
 fn main() {

--- a/gen/write.rs
+++ b/gen/write.rs
@@ -326,6 +326,8 @@ fn write_struct_with_methods(out: &mut OutFile, ety: &ExternType, methods: &Vec<
         writeln!(out, "//{}", line);
     }
     writeln!(out, "struct {} final {{", ety.ident);
+    writeln!(out, "  {}() = delete;", ety.ident);
+    writeln!(out, "  {}(const {}&) = delete;", ety.ident, ety.ident);
     for method in methods {
         write!(out, "  ");
         let sig = &method.sig;

--- a/gen/write.rs
+++ b/gen/write.rs
@@ -2,7 +2,7 @@ use crate::gen::namespace::Namespace;
 use crate::gen::out::OutFile;
 use crate::gen::{include, Opt};
 use crate::syntax::atom::Atom::{self, *};
-use crate::syntax::{Api, ExternFn, Receiver, Signature, Struct, Type, Types, Var};
+use crate::syntax::{Api, ExternFn, ExternType, Receiver, Signature, Struct, Type, Types, Var};
 use proc_macro2::Ident;
 
 pub(super) fn gen(
@@ -45,9 +45,25 @@ pub(super) fn gen(
     }
 
     for api in apis {
-        if let Api::Struct(strct) = api {
-            out.next_section();
-            write_struct(out, strct);
+        match api {
+            Api::Struct(strct) => {
+                out.next_section();
+                write_struct(out, strct);
+            }
+            Api::RustType(ety) => {
+                let methods = apis.iter().filter_map(|api| match api {
+                    Api::RustFunction(efn) => match &efn.sig.receiver {
+                        Some(rcvr) if rcvr.ident == ety.ident => Some(efn),
+                        _ => None,
+                    },
+                    _ => None,
+                }).collect::<Vec<_>>();
+                if !methods.is_empty() {
+                    out.next_section();
+                    write_struct_with_methods(out, ety, methods);
+                }
+            }
+            _ => {}
         }
     }
 
@@ -300,6 +316,21 @@ fn write_struct_using(out: &mut OutFile, ident: &Ident) {
     writeln!(out, "using {} = {};", ident, ident);
 }
 
+fn write_struct_with_methods(out: &mut OutFile, ety: &ExternType, methods: Vec<&ExternFn>) {
+    for line in ety.doc.to_string().lines() {
+        writeln!(out, "//{}", line);
+    }
+    writeln!(out, "struct {} final {{", ety.ident);
+    for method in &methods {
+        write!(out, "  ");
+        let sig = &method.sig;
+        let local_name = method.ident.to_string();
+        write_rust_function_shim_decl(out, &local_name, sig, None, false);
+        writeln!(out, ";");
+    }
+    writeln!(out, "}};");
+}
+
 fn write_exception_glue(out: &mut OutFile, apis: &[Api]) {
     let mut has_cxx_throws = false;
     for api in apis {
@@ -326,7 +357,11 @@ fn write_cxx_function_shim(out: &mut OutFile, efn: &ExternFn, types: &Types) {
     } else {
         write_extern_return_type_space(out, &efn.ret, types);
     }
-    write!(out, "{}cxxbridge02${}(", out.namespace, efn.ident);
+    let receiver_type = match &efn.receiver {
+        Some(base) => base.ident.to_string(),
+        None => "_".to_string(),
+    };
+    write!(out, "{}cxxbridge02${}${}(", out.namespace, receiver_type, efn.ident);
     if let Some(base) = &efn.receiver {
         write!(out, "{} *__receiver$", base.ident);
     }
@@ -471,7 +506,11 @@ fn write_function_pointer_trampoline(
 }
 
 fn write_rust_function_decl(out: &mut OutFile, efn: &ExternFn, types: &Types) {
-    let link_name = format!("{}cxxbridge02${}", out.namespace, efn.ident);
+    let receiver_type = match &efn.receiver {
+        Some(base) => base.ident.to_string(),
+        None => "_".to_string(),
+    };
+    let link_name = format!("{}cxxbridge02${}${}", out.namespace, receiver_type, efn.ident);
     let indirect_call = false;
     write_rust_function_decl_impl(out, &link_name, efn, types, indirect_call);
 }
@@ -490,6 +529,10 @@ fn write_rust_function_decl_impl(
     }
     write!(out, "{}(", link_name);
     let mut needs_comma = false;
+    if let Some(base) = &sig.receiver {
+        write!(out, "{} &__receiver$", base.ident);
+        needs_comma = true;
+    }
     for arg in &sig.args {
         if needs_comma {
             write!(out, ", ");
@@ -519,20 +562,26 @@ fn write_rust_function_shim(out: &mut OutFile, efn: &ExternFn, types: &Types) {
         writeln!(out, "//{}", line);
     }
     let local_name = efn.ident.to_string();
-    let invoke = format!("{}cxxbridge02${}", out.namespace, efn.ident);
+    let receiver_type = match &efn.receiver {
+        Some(base) => base.ident.to_string(),
+        None => "_".to_string(),
+    };
+    let invoke = format!("{}cxxbridge02${}${}", out.namespace, receiver_type, efn.ident);
     let indirect_call = false;
     write_rust_function_shim_impl(out, &local_name, efn, types, &invoke, indirect_call);
 }
 
-fn write_rust_function_shim_impl(
+fn write_rust_function_shim_decl(
     out: &mut OutFile,
     local_name: &str,
     sig: &Signature,
-    types: &Types,
-    invoke: &str,
+    receiver: Option<&Receiver>,
     indirect_call: bool,
 ) {
     write_return_type(out, &sig.ret);
+    if let Some(base) = receiver {
+        write!(out, "{}::", base.ident);
+    }
     write!(out, "{}(", local_name);
     for (i, arg) in sig.args.iter().enumerate() {
         if i > 0 {
@@ -551,6 +600,21 @@ fn write_rust_function_shim_impl(
     if !sig.throws {
         write!(out, " noexcept");
     }
+}
+
+fn write_rust_function_shim_impl(
+    out: &mut OutFile,
+    local_name: &str,
+    sig: &Signature,
+    types: &Types,
+    invoke: &str,
+    indirect_call: bool,
+) {
+    if out.header && sig.receiver.is_some() {
+        // We've already defined this inside the struct.
+        return;
+    }
+    write_rust_function_shim_decl(out, local_name, sig, sig.receiver.as_ref(), indirect_call);
     if out.header {
         writeln!(out, ";");
     } else {
@@ -589,8 +653,11 @@ fn write_rust_function_shim_impl(
             write!(out, "::rust::Str::Repr error$ = ");
         }
         write!(out, "{}(", invoke);
+        if let Some(_) = &sig.receiver {
+            write!(out, "*this");
+        }
         for (i, arg) in sig.args.iter().enumerate() {
-            if i > 0 {
+            if i > 0 || sig.receiver.is_some() {
                 write!(out, ", ");
             }
             match &arg.ty {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,10 @@
 //!
 //!         // Functions implemented in C++.
 //!         fn make_demo(appname: &str) -> UniquePtr<ThingC>;
-//!         fn get_name(thing: &ThingC) -> &CxxString;
 //!         fn do_thing(state: SharedThing);
+//!
+//!         // Methods implemented in C++.
+//!         fn get_name(self: &ThingC) -> &CxxString;
 //!     }
 //!
 //!     extern "Rust" {
@@ -90,6 +92,9 @@
 //!
 //!         // Functions implemented in Rust.
 //!         fn print_r(r: &ThingR);
+//!
+//!         // Methods implemented in Rust.
+//!         fn print(self: &ThingR);
 //!     }
 //! }
 //! #
@@ -97,6 +102,12 @@
 //! #
 //! # fn print_r(r: &ThingR) {
 //! #     println!("called back with r={}", r.0);
+//! # }
+//! #
+//! # impl ThingR {
+//! #     fn print(&self) {
+//! #         println!("method called back with r={}", self.0);
+//! #     }
 //! # }
 //! #
 //! # fn main() {}

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -195,6 +195,10 @@ fn check_multiple_arg_lifetimes(cx: &mut Check, efn: &ExternFn) {
         }
     }
 
+    if efn.receiver.is_some() {
+        reference_args += 1;
+    }
+
     if reference_args != 1 {
         cx.error(
             efn,

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -56,6 +56,7 @@ pub mod ffi {
 
     extern "Rust" {
         type R;
+        type R2;
 
         fn r_return_primitive() -> usize;
         fn r_return_shared() -> Shared;
@@ -80,10 +81,27 @@ pub mod ffi {
         fn r_try_return_void() -> Result<()>;
         fn r_try_return_primitive() -> Result<usize>;
         fn r_fail_return_primitive() -> Result<usize>;
+
+        fn r_return_r2(n: usize) -> Box<R2>;
+        fn get(self: &R2) -> usize;
+        fn set(self: &mut R2, n: usize) -> usize;
     }
 }
 
 pub type R = usize;
+
+pub struct R2(usize);
+
+impl R2 {
+    fn get(&self) -> usize {
+        self.0
+    }
+
+    fn set(&mut self, n: usize) -> usize {
+        self.0 = n;
+        n
+    }
+}
 
 #[derive(Debug)]
 struct Error;
@@ -186,4 +204,8 @@ fn r_try_return_primitive() -> Result<usize, Error> {
 
 fn r_fail_return_primitive() -> Result<usize, Error> {
     Err(Error)
+}
+
+fn r_return_r2(n: usize) -> Box<R2> {
+    Box::new(R2(n))
 }

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -49,6 +49,9 @@ pub mod ffi {
         fn c_try_return_sliceu8(s: &[u8]) -> Result<&[u8]>;
         fn c_try_return_rust_string() -> Result<String>;
         fn c_try_return_unique_ptr_string() -> Result<UniquePtr<CxxString>>;
+
+        fn get(self: &C) -> usize;
+        fn set(self: &mut C, n: usize) -> usize;
     }
 
     extern "Rust" {

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -181,6 +181,13 @@ extern "C" const char *cxx_run_test() noexcept {
     ASSERT(std::strcmp(e.what(), "rust error") == 0);
   }
 
+  auto r2 = r_return_r2(2020);
+  ASSERT(r2->get() == 2020);
+  ASSERT(r2->set(2021) == 2021);
+  ASSERT(r2->get() == 2021);
+  ASSERT(r2->set(2020) == 2020);
+  ASSERT(r2->get() == 2020);
+
   cxx_test_suite_set_correct();
   return nullptr;
 }

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -15,6 +15,11 @@ C::C(size_t n) : n(n) {}
 
 size_t C::get() const { return this->n; }
 
+size_t C::set(size_t n) {
+  this->n = n;
+  return this->n;
+}
+
 size_t c_return_primitive() { return 2020; }
 
 Shared c_return_shared() { return Shared{2020}; }

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -12,6 +12,7 @@ class C {
 public:
   C(size_t n);
   size_t get() const;
+  size_t set(size_t n);
 
 private:
   size_t n;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -107,6 +107,18 @@ fn test_c_call_r() {
     check!(cxx_run_test());
 }
 
+#[test]
+fn test_c_method_calls() {
+    let mut unique_ptr = ffi::c_return_unique_ptr();
+
+    let old_value = unique_ptr.as_ref().unwrap().get();
+    assert_eq!(2020, old_value);
+    assert_eq!(2021, unique_ptr.as_mut().unwrap().set(2021));
+    assert_eq!(2021, unique_ptr.as_ref().unwrap().get());
+    assert_eq!(old_value, unique_ptr.as_mut().unwrap().set(old_value));
+    assert_eq!(old_value, unique_ptr.as_ref().unwrap().get())
+}
+
 #[no_mangle]
 extern "C" fn cxx_test_suite_get_box() -> *mut cxx_test_suite::R {
     Box::into_raw(Box::new(2020usize))


### PR DESCRIPTION
This adds support for calling C++ and Rust methods with the syntax suggested in #51:

fn get_name(self: &ThingC) -> &CxxString;
fn print(self: &ThingR);

It requires Rust 1.43 to use this syntax.