### PR TITLE
Attempt bazel CI on windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,58 +1,16 @@
 language: rust
 
-rust:
-  - nightly
-  - beta
-
-script:
-  - cargo run --manifest-path demo-rs/Cargo.toml
-  - cargo test
-
 matrix:
   include:
-    - name: macOS
-      os: macos
-      rust: nightly
-    - name: Windows (gnu)
-      os: windows
+    - os: windows
       rust: nightly-x86_64-pc-windows-gnu
-      before_script:
-        # windows is bad at symlinks
-        - rm cmd/src/gen cmd/src/syntax gen/include macro/src/syntax src/gen src/syntax
-        - cp -r include gen; cp -r gen cmd/src; cp -r syntax cmd/src; cp -r syntax macro/src; cp -r gen src; cp -r syntax src
-    - name: Windows (msvc)
-      os: windows
-      rust: nightly-x86_64-pc-windows-msvc
+      before_install:
+        - choco install bazel
       before_script:
         - rm cmd/src/gen cmd/src/syntax gen/include macro/src/syntax src/gen src/syntax
         - cp -r include gen; cp -r gen cmd/src; cp -r syntax cmd/src; cp -r syntax macro/src; cp -r gen src; cp -r syntax src
-    - name: Buck
-      rust: nightly
-      before_install:
-        - sudo apt-get install -y openjdk-8-jdk
-        - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-        - wget -O buck.deb https://github.com/facebook/buck/releases/download/v2019.10.17.01/buck.2019.10.17.01_all.deb
-        - sudo dpkg -i buck.deb
-      before_script:
-        - cp third-party/Cargo.lock .
-        - cargo vendor --versioned-dirs --locked third-party/vendor
-      script:
-        - buck build :cxx#check --verbose=0
-        - buck run demo-rs --verbose=0
-        - buck test ... --verbose=0
-    - name: Bazel
-      rust: nightly
-      before_install:
-        - wget -O install.sh https://github.com/bazelbuild/bazel/releases/download/2.1.1/bazel-2.1.1-installer-linux-x86_64.sh
-        - chmod +x install.sh
-        - ./install.sh --user
-      before_script:
         - cp third-party/Cargo.lock .
         - cargo vendor --versioned-dirs --locked third-party/vendor
       script:
         - bazel run demo-rs --verbose_failures --noshow_progress
         - bazel test ... --verbose_failures --noshow_progress
-    - name: Minimum rustc
-      rust: 1.42.0
-      script:
-        - cargo run --manifest-path demo-rs/Cargo.toml

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,3 +38,11 @@ rust_repository_set(
     iso_date = "2020-04-19",
     version = "beta",
 )
+
+rust_repository_set(
+    name = "rust_1_43_beta_windows",
+    exec_triple = "x86_64-pc-windows-gnu",
+    extra_target_triples = [],
+    iso_date = "2020-04-19",
+    version = "beta",
+)

--- a/third-party/BUILD
+++ b/third-party/BUILD
@@ -166,6 +166,10 @@ rust_library(
 rust_library(
     name = "termcolor",
     srcs = glob(["vendor/termcolor-1.1.0/src/**"]),
+    deps = select({
+        "@io_bazel_rules_rust//rust/platform:windows": [":winapi-util"],
+        "//conditions:default": [],
+    }),
 )
 
 rust_library(
@@ -206,4 +210,55 @@ rust_library(
 rust_library(
     name = "unicode-xid",
     srcs = glob(["vendor/unicode-xid-0.2.0/src/**"]),
+)
+
+rust_library(
+    name = "winapi",
+    srcs = glob(["vendor/winapi-0.3.8/src/**"]),
+    crate_features = [
+        "basetsd",
+        "cfg",
+        "cfgmgr32",
+        "consoleapi",
+        "devpropdef",
+        "errhandlingapi",
+        "excpt",
+        "fileapi",
+        "guiddef",
+        "ktmtypes",
+        "libloaderapi",
+        "minwinbase",
+        "minwindef",
+        "ntdef",
+        "ntstatus",
+        "processenv",
+        "processthreadsapi",
+        "rpcndr",
+        "std",
+        "vadefs",
+        "vcruntime",
+        "winbase",
+        "wincon",
+        "wincontypes",
+        "windef",
+        "winerror",
+        "wingdi",
+        "winnt",
+        "winreg",
+        "wtypesbase",
+    ],
+    edition = "2015",
+    deps = [":winapi-x86_64-pc-windows-gnu"],
+)
+
+rust_library(
+    name = "winapi-util",
+    srcs = glob(["vendor/winapi-util-0.1.4/src/**"]),
+    deps = [":winapi"],
+)
+
+rust_library(
+    name = "winapi-x86_64-pc-windows-gnu",
+    srcs = glob(["vendor/winapi-x86_64-pc-windows-gnu-0.4.0/src/**"]),
+    edition = "2015",
 )


### PR DESCRIPTION
Didn't quite get this working. It fails in Travis with:

```console
$ bazel run demo-rs --verbose_failures --noshow_progress

Extracting Bazel installation...
Starting local Bazel server and connecting to it...
INFO: Analyzed target //demo-rs:demo-rs (25 packages loaded, 856 targets configured).
INFO: Found 1 target...
   Creating library bazel-out/x64_windows-fastbuild-ST-5e74b77704d3a70b08875590eb0f067cbb9a6e09f41f090f307cf0d79d4b2461/bin/core-lib.if.lib and object bazel-out/x64_windows-fastbuild-ST-5e74b77704d3a70b08875590eb0f067cbb9a6e09f41f090f307cf0d79d4b2461/bin/core-lib.if.exp
cxx.obj : error LNK2019: unresolved external symbol cxxbridge02$string$new referenced in function "public: __cdecl rust::cxxbridge02::String::String(void)" (??0String@cxxbridge02@rust@@QEAA@XZ)
cxx.obj : error LNK2019: unresolved external symbol cxxbridge02$string$clone referenced in function "public: __cdecl rust::cxxbridge02::String::String(class rust::cxxbridge02::String const &)" (??0String@cxxbridge02@rust@@QEAA@AEBV012@@Z)
cxx.obj : error LNK2019: unresolved external symbol cxxbridge02$string$from referenced in function "public: __cdecl rust::cxxbridge02::String::String(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &)" (??0String@cxxbridge02@rust@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
cxx.obj : error LNK2019: unresolved external symbol cxxbridge02$string$drop referenced in function "public: __cdecl rust::cxxbridge02::String::~String(void)" (??1String@cxxbridge02@rust@@QEAA@XZ)
cxx.obj : error LNK2019: unresolved external symbol cxxbridge02$string$ptr referenced in function "public: char const * __cdecl rust::cxxbridge02::String::data(void)const " (?data@String@cxxbridge02@rust@@QEBAPEBDXZ)
cxx.obj : error LNK2019: unresolved external symbol cxxbridge02$string$len referenced in function "public: unsigned __int64 __cdecl rust::cxxbridge02::String::size(void)const " (?size@String@cxxbridge02@rust@@QEBA_KXZ)
cxx.obj : error LNK2019: unresolved external symbol cxxbridge02$str$valid referenced in function "public: __cdecl rust::cxxbridge02::Str::Str(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &)" (??0Str@cxxbridge02@rust@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z)
bazel-out/x64_windows-fastbuild-ST-5e74b77704d3a70b08875590eb0f067cbb9a6e09f41f090f307cf0d79d4b2461/bin/core-lib.dll : fatal error LNK1120: 7 unresolved externals
```

I think this has to do with https://stackoverflow.com/a/387380/6086311. We have some symbols defined in //:cxx used by //:core-lib (e.g. `cxxbridge02$string$new`) and some symbols defined in //:core-lib used by //:cxx (e.g. `cxxbridge02$cxx_string$data`). This is fine on Unix where link resolution happens at load time, but not on Windows where resolution happens at library link time.

Somehow the Cargo-based build gets around this on Windows, since it's definitely currently working. We should update our Bazel setup to match whatever Cargo is doing.

It's possible @sayrer would be interested in pursuing this further.