### PR TITLE
Attempt buck CI on windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,58 +1,17 @@
 language: rust
 
-rust:
-  - nightly
-  - beta
-
-script:
-  - cargo run --manifest-path demo-rs/Cargo.toml
-  - cargo test
-
 matrix:
   include:
-    - name: macOS
-      os: macos
-      rust: nightly
-    - name: Windows (gnu)
-      os: windows
+    - os: windows
       rust: nightly-x86_64-pc-windows-gnu
-      before_script:
-        # windows is bad at symlinks
-        - rm cmd/src/gen cmd/src/syntax gen/include macro/src/syntax src/gen src/syntax
-        - cp -r include gen; cp -r gen cmd/src; cp -r syntax cmd/src; cp -r syntax macro/src; cp -r gen src; cp -r syntax src
-    - name: Windows (msvc)
-      os: windows
-      rust: nightly-x86_64-pc-windows-msvc
-      before_script:
-        - rm cmd/src/gen cmd/src/syntax gen/include macro/src/syntax src/gen src/syntax
-        - cp -r include gen; cp -r gen cmd/src; cp -r syntax cmd/src; cp -r syntax macro/src; cp -r gen src; cp -r syntax src
-    - name: Buck
-      rust: nightly
       before_install:
-        - sudo apt-get install -y openjdk-8-jdk
-        - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-        - wget -O buck.deb https://github.com/facebook/buck/releases/download/v2019.10.17.01/buck.2019.10.17.01_all.deb
-        - sudo dpkg -i buck.deb
+        - choco install buck
       before_script:
+        - rm cmd/src/gen cmd/src/syntax gen/include macro/src/syntax src/gen src/syntax
+        - cp -r include gen; cp -r gen cmd/src; cp -r syntax cmd/src; cp -r syntax macro/src; cp -r gen src; cp -r syntax src
         - cp third-party/Cargo.lock .
         - cargo vendor --versioned-dirs --locked third-party/vendor
       script:
         - buck build :cxx#check --verbose=0
         - buck run demo-rs --verbose=0
         - buck test ... --verbose=0
-    - name: Bazel
-      rust: nightly
-      before_install:
-        - wget -O install.sh https://github.com/bazelbuild/bazel/releases/download/2.1.1/bazel-2.1.1-installer-linux-x86_64.sh
-        - chmod +x install.sh
-        - ./install.sh --user
-      before_script:
-        - cp third-party/Cargo.lock .
-        - cargo vendor --versioned-dirs --locked third-party/vendor
-      script:
-        - bazel run demo-rs --verbose_failures --noshow_progress
-        - bazel test ... --verbose_failures --noshow_progress
-    - name: Minimum rustc
-      rust: 1.42.0
-      script:
-        - cargo run --manifest-path demo-rs/Cargo.toml

--- a/third-party/BUCK
+++ b/third-party/BUCK
@@ -161,6 +161,7 @@ rust_library(
 rust_library(
     name = "termcolor",
     srcs = glob(["vendor/termcolor-1.1.0/src/**"]),
+    deps = [":winapi-util"],
 )
 
 rust_library(
@@ -201,4 +202,55 @@ rust_library(
 rust_library(
     name = "unicode-xid",
     srcs = glob(["vendor/unicode-xid-0.2.0/src/**"]),
+)
+
+rust_library(
+    name = "winapi",
+    srcs = glob(["vendor/winapi-0.3.8/src/**"]),
+    features = [
+        "basetsd",
+        "cfg",
+        "cfgmgr32",
+        "consoleapi",
+        "devpropdef",
+        "errhandlingapi",
+        "excpt",
+        "fileapi",
+        "guiddef",
+        "ktmtypes",
+        "libloaderapi",
+        "minwinbase",
+        "minwindef",
+        "ntdef",
+        "ntstatus",
+        "processenv",
+        "processthreadsapi",
+        "rpcndr",
+        "std",
+        "vadefs",
+        "vcruntime",
+        "winbase",
+        "wincon",
+        "wincontypes",
+        "windef",
+        "winerror",
+        "wingdi",
+        "winnt",
+        "winreg",
+        "wtypesbase",
+    ],
+    edition = "2015",
+    deps = [":winapi-x86_64-pc-windows-gnu"],
+)
+
+rust_library(
+    name = "winapi-util",
+    srcs = glob(["vendor/winapi-util-0.1.4/src/**"]),
+    deps = [":winapi"],
+)
+
+rust_library(
+    name = "winapi-x86_64-pc-windows-gnu",
+    srcs = glob(["vendor/winapi-x86_64-pc-windows-gnu-0.4.0/src/**"]),
+    edition = "2015",
 )


### PR DESCRIPTION
Didn't quite get this working. It fails in Travis with:

```console
$ buck run demo-rs --verbose=0

command: [C:\Users\travis\.cargo\bin\rustc.EXE, "-Clinker=C:\program files\git\usr\bin\link.EXE", -Clink-arg=@C:\Users\travis\build\dtolnay\cxx\buck-out\bin\macro#default,proc-macro\argsfile.txt, -Cmetadata=478d1e564faaf3d9, -Cextra-filename=-478d1e564faaf3d9, --crate-name=cxxbridge_macro, --crate-type=proc-macro, -Crelocation-...
<truncated>
...

stderr: error: linking with `C:\program files\git\usr\bin\link.EXE` failed: exit code: 1
  |
  = note: "C:\\program files\\git\\usr\\bin\\link.EXE" "C:\\Users\\travis\\.rustup\\toolchains\\nightly-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\dllcrt2.o" "C:\\Users\\travis\\.rustup\\toolchains\\nightly-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\rsbegin.o" "/LIBPATH:C:\\Users\\travis\\.rustup\\toolchains\\nightly-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib" "buck-out\\gen\\macro#default,proc-macro\\cxxbridge_macro-478d1e564faaf3d9.cxxbridge_macro.o310n43b-cgu.0.rcgu.o" "buck-out\\gen\\macro#default,proc-macro\\cxxbridge_macro-478d1e564faaf3d9.cxxbridge_macro.o310n43b-cgu.1.rcgu.o" "buck-out\\gen\\macro#default,proc-macro\\cxxbridge_macro-478d1e564faaf3d9.cxxbridge_macro.o310n43b-cgu.10.rcgu.o" "buck-out\\gen\\macro#default,proc-macro\\cxxbridge_macro-478d1e564faaf3d9.cxxbridge_macro.o310n43b-cgu.11.rcgu.o" "buck-out\\gen\\macro#default,proc-macro\\cxxbridge_macro-478d1e564faaf3d9.cxxbridge_macro.o310n43b-cgu.12.rcgu.o" "buck-out\\gen\\macro#default,proc-macro\\cxxbridge_macro-478d1e564faaf3d9.cxxbridge_macro.o310n43b-cgu.13.rcgu.o" "buck-out\\gen\\macro#default,proc-macro\\cxxbridge_macro-478d1e564faaf3d9.cxxbridge_macro.o310n43b-cgu.14.rcgu.o" "buck-out\\gen\\macro#default,proc-macro\\cxxbridge_macro-478d1e564faaf3d9.cxxbridge_macro.o310n43b-cgu.15.rcgu.o" "buck-out\\gen\\macro#default,proc-macro\\cxxbridge_macro-478d1e564faaf3d9.cxxbridge_macro.o310n43b-cgu.2.rcgu.o" "buck-out\\gen\\macro#default,proc-macro\\cxxbridge_macro-478d1e564faaf3d9.cxxbridge_macro.o310n43b-cgu.3.rcgu.o" "buck-out\\gen\\macro#default,proc-macro\\cxxbridge_macro-478d1e564faaf3d9.cxxbridge_macro.o310n43b-cgu.4.rcgu.o" "buck-out\\gen\\macro#default,proc-macro\\cxxbridge_macro-478d1e564faaf3d9.cxxbridge_macro.o310n43b-cgu.5.rcgu.o" "buck-out\\gen\\macro#default,proc-macro\\cxxbridge_macro-478d1e564faaf3d9.cxxbridge_macro.o310n43b-cgu.6.rcgu.o" "buck-out\\gen\\macro#default,proc-macro\\cxxbridge_macro-478d1e564faaf3d9.cxxbridge_macro.o310n43b-cgu.7.rcgu.o" "buck-out\\gen\\macro#default,proc-macro\\cxxbridge_macro-478d1e564faaf3d9.cxxbridge_macro.o310n43b-cgu.8.rcgu.o" "buck-out\\gen\\macro#default,proc-macro\\cxxbridge_macro-478d1e564faaf3d9.cxxbridge_macro.o310n43b-cgu.9.rcgu.o" "/OUT:buck-out\\gen\\macro#default,proc-macro\\cxxbridge_macro-478d1e564faaf3d9.dll" "/DEF:C:\\Users\\travis\\AppData\\Local\\Temp\\rustcNNImv2\\lib.def" "buck-out\\gen\\macro#default,proc-macro\\cxxbridge_macro-478d1e564faaf3d9.397x1mf305d9b6kl.rcgu.o" "buck-out\\gen\\macro#default,proc-macro\\cxxbridge_macro-478d1e564faaf3d9.2viduyivmsoelect.rcgu.o" "/OPT:REF,NOICF" "/DEBUG" "/NODEFAULTLIB" "/LIBPATH:C:\\Users\\travis\\build\\dtolnay\\cxx\\buck-out\\gen\\third-party\\unicode-xid#default,rlib" "/LIBPATH:C:\\Users\\travis\\build\\dtolnay\\cxx\\buck-out\\gen\\third-party\\proc-macro2#default,rlib" "/LIBPATH:C:\\Users\\travis\\build\\dtolnay\\cxx\\buck-out\\gen\\third-party\\quote#default,rlib" "/LIBPATH:C:\\Users\\travis\\.rustup\\toolchains\\nightly-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib" "C:\\Users\\travis\\build\\dtolnay\\cxx\\buck-out\\gen\\third-party\\syn#default,rlib\\libsyn-848df472225f94db.rlib" "C:\\Users\\travis\\build\\dtolnay\\cxx\\buck-out\\gen\\third-party\\quote#default,rlib\\libquote-1bff07f1b1421ce9.rlib" "C:\\Users\\travis\\build\\dtolnay\\cxx\\buck-out\\gen\\third-party\\proc-macro2#default,rlib\\libproc_macro2-73b9297ea554c23e.rlib" "C:\\Users\\travis\\build\\dtolnay\\cxx\\buck-out\\gen\\third-party\\unicode-xid#default,rlib\\libunicode_xid-6233a202fa588ab7.rlib" "C:\\Users\\travis\\.rustup\\toolchains\\nightly-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\libproc_macro-c1445e86d6103c26.rlib" "C:\\Users\\travis\\.rustup\\toolchains\\nightly-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\libstd-b5fa00f44583b78e.rlib" "C:\\Users\\travis\\.rustup\\toolchains\\nightly-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\libpanic_unwind-cc6f718ed9ed2415.rlib" "C:\\Users\\travis\\.rustup\\toolchains\\nightly-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\libhashbrown-8c30683bd61200dc.rlib" "C:\\Users\\travis\\.rustup\\toolchains\\nightly-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\librustc_std_workspace_alloc-ea03f28189cbf8a7.rlib" "C:\\Users\\travis\\.rustup\\toolchains\\nightly-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\libbacktrace-94fa6cb01ba1ca21.rlib" "C:\\Users\\travis\\.rustup\\toolchains\\nightly-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\libbacktrace_sys-c02458a9943ec4ef.rlib" "C:\\Users\\travis\\.rustup\\toolchains\\nightly-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\librustc_demangle-e1ed8532c12355af.rlib" "C:\\Users\\travis\\.rustup\\toolchains\\nightly-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\libunwind-fb2d237a8b44512b.rlib" "C:\\Users\\travis\\.rustup\\toolchains\\nightly-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\libcfg_if-12617748da815509.rlib" "C:\\Users\\travis\\.rustup\\toolchains\\nightly-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\liblibc-726def109d3ee183.rlib" "C:\\Users\\travis\\.rustup\\toolchains\\nightly-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\liballoc-2cef43d59d9656ff.rlib" "C:\\Users\\travis\\.rustup\\toolchains\\nightly-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\librustc_std_workspace_core-903e66cd3cf9e3b0.rlib" "C:\\Users\\travis\\.rustup\\toolchains\\nightly-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\libcore-4662728cab7b00e0.rlib" "C:\\Users\\travis\\.rustup\\toolchains\\nightly-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\libcompiler_builtins-bea1ba3afd75f31f.rlib" "advapi32.lib" "ws2_32.lib" "userenv.lib" "/DLL" "/IMPLIB:buck-out\\gen\\macro#default,proc-macro\\cxxbridge_macro-478d1e564faaf3d9.dll.lib" "@C:\\Users\\travis\\build\\dtolnay\\cxx\\buck-out\\bin\\macro#default,proc-macro\\argsfile.txt" "C:\\Users\\travis\\.rustup\\toolchains\\nightly-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\rsend.o"
  = note: /usr/bin/link: extra operand '/LIBPATH:C:\\Users\\travis\\.rustup\\toolchains\\nightly-x86_64-pc-windows-gnu\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib'
          Try '/usr/bin/link --help' for more information.

error: aborting due to previous error

    When running <rust-build>.
    When building rule //:macro#default,proc-macro.
```

```console
$ buck test ... --verbose=0
Buck encountered an internal error
java.lang.UnsupportedOperationException: PIC mode is not supported on Windows
	at com.facebook.buck.cxx.toolchain.WindowsCompiler.getPicFlags(WindowsCompiler.java:57)
	at com.facebook.buck.cxx.toolchain.PicType$1.getFlags(PicType.java:31)
	at com.facebook.buck.cxx.AbstractCxxSourceRuleFactory.computeCompilerFlags(AbstractCxxSourceRuleFactory.java:486)
	at com.facebook.buck.cxx.AbstractCxxSourceRuleFactory.createPreprocessAndCompileBuildRule(AbstractCxxSourceRuleFactory.java:591)
	at com.facebook.buck.cxx.AbstractCxxSourceRuleFactory.lambda$null$11(AbstractCxxSourceRuleFactory.java:754)
	at com.facebook.buck.core.rules.resolver.impl.MultiThreadedActionGraphBuilder.lambda$withCorrectTargetCheck$18(MultiThreadedActionGraphBuilder.java:282)
	at com.facebook.buck.core.rules.resolver.impl.MultiThreadedActionGraphBuilder.lambda$null$9(MultiThreadedActionGraphBuilder.java:188)
	at com.facebook.buck.core.rules.resolver.impl.MultiThreadedActionGraphBuilder$Task.tryComplete(MultiThreadedActionGraphBuilder.java:343)
	at com.facebook.buck.core.rules.resolver.impl.MultiThreadedActionGraphBuilder$Task.tryComplete(MultiThreadedActionGraphBuilder.java:332)
	at com.facebook.buck.core.rules.resolver.impl.MultiThreadedActionGraphBuilder$Task.access$500(MultiThreadedActionGraphBuilder.java:292)
	at com.facebook.buck.core.rules.resolver.impl.MultiThreadedActionGraphBuilder.transformParallel(MultiThreadedActionGraphBuilder.java:209)
	... 56 more

    When creating rule //demo-rs:gen#default,static-pic.
    When creating rule //demo-rs:demo-rs.
```

The second one is probably easy to fix but I don't know what to make of the first one and don't have access to Windows to debug further.