### PR TITLE
Share function link name mangling logic

### DIFF
--- a/syntax/mangle.rs
+++ b/syntax/mangle.rs
@@ -1,0 +1,10 @@
+use crate::syntax::namespace::Namespace;
+use crate::syntax::ExternFn;
+
+pub fn extern_fn(namespace: &Namespace, efn: &ExternFn) -> String {
+    let receiver_type = match &efn.receiver {
+        Some(receiver) => receiver.ident.to_string(),
+        None => "_".to_string(),
+    };
+    format!("{}cxxbridge02${}${}", namespace, receiver_type, efn.ident)
+}

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -7,6 +7,7 @@ mod doc;
 pub mod error;
 pub mod ident;
 mod impls;
+pub mod mangle;
 pub mod namespace;
 mod parse;
 pub mod set;


### PR DESCRIPTION
I'd like to centralize the mangling scheme (anything dealing with symbols containing `$`) in one place to make it easier to identify potential collisions and mitigate them. For example we need to be sure that the symbols we take up for built in types like std::string can't collide with some symbol derived from some user-defined type. More PRs will follow to fix the remaining places that are using `format!` to paste together ad hoc symbols.