### PR TITLE
Trigger error on explicitly specified lifetimes in a reference type

### DIFF
--- a/syntax/impls.rs
+++ b/syntax/impls.rs
@@ -194,6 +194,7 @@ impl PartialEq for Receiver {
             mutability,
             var: _,
             ty,
+            shorthand: _,
         } = self;
         let Receiver {
             ampersand: _,
@@ -201,6 +202,7 @@ impl PartialEq for Receiver {
             mutability: mutability2,
             var: _,
             ty: ty2,
+            shorthand: _,
         } = other;
         lifetime == lifetime2 && mutability.is_some() == mutability2.is_some() && ty == ty2
     }
@@ -214,6 +216,7 @@ impl Hash for Receiver {
             mutability,
             var: _,
             ty,
+            shorthand: _,
         } = self;
         lifetime.hash(state);
         mutability.is_some().hash(state);

--- a/syntax/impls.rs
+++ b/syntax/impls.rs
@@ -86,15 +86,17 @@ impl PartialEq for Ref {
     fn eq(&self, other: &Ref) -> bool {
         let Ref {
             ampersand: _,
+            lifetime,
             mutability,
             inner,
         } = self;
         let Ref {
             ampersand: _,
+            lifetime: lifetime2,
             mutability: mutability2,
             inner: inner2,
         } = other;
-        mutability.is_some() == mutability2.is_some() && inner == inner2
+        lifetime == lifetime2 && mutability.is_some() == mutability2.is_some() && inner == inner2
     }
 }
 
@@ -102,9 +104,11 @@ impl Hash for Ref {
     fn hash<H: Hasher>(&self, state: &mut H) {
         let Ref {
             ampersand: _,
+            lifetime,
             mutability,
             inner,
         } = self;
+        lifetime.hash(state);
         mutability.is_some().hash(state);
         inner.hash(state);
     }
@@ -186,17 +190,19 @@ impl PartialEq for Receiver {
     fn eq(&self, other: &Receiver) -> bool {
         let Receiver {
             ampersand: _,
+            lifetime,
             mutability,
             var: _,
             ty,
         } = self;
         let Receiver {
             ampersand: _,
+            lifetime: lifetime2,
             mutability: mutability2,
             var: _,
             ty: ty2,
         } = other;
-        mutability.is_some() == mutability2.is_some() && ty == ty2
+        lifetime == lifetime2 && mutability.is_some() == mutability2.is_some() && ty == ty2
     }
 }
 
@@ -204,10 +210,12 @@ impl Hash for Receiver {
     fn hash<H: Hasher>(&self, state: &mut H) {
         let Receiver {
             ampersand: _,
+            lifetime,
             mutability,
             var: _,
             ty,
         } = self;
+        lifetime.hash(state);
         mutability.is_some().hash(state);
         ty.hash(state);
     }

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -80,6 +80,7 @@ pub struct Receiver {
     pub mutability: Option<Token![mut]>,
     pub var: Token![self],
     pub ty: Ident,
+    pub shorthand: bool,
 }
 
 pub enum Type {

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -19,7 +19,7 @@ use self::parse::kw;
 use proc_macro2::{Ident, Span};
 use syn::punctuated::Punctuated;
 use syn::token::{Brace, Bracket, Paren};
-use syn::{LitStr, Token};
+use syn::{Lifetime, LitStr, Token};
 
 pub use self::atom::Atom;
 pub use self::doc::Doc;
@@ -76,6 +76,7 @@ pub struct Var {
 
 pub struct Receiver {
     pub ampersand: Token![&],
+    pub lifetime: Option<Lifetime>,
     pub mutability: Option<Token![mut]>,
     pub var: Token![self],
     pub ty: Ident,
@@ -102,6 +103,7 @@ pub struct Ty1 {
 
 pub struct Ref {
     pub ampersand: Token![&],
+    pub lifetime: Option<Lifetime>,
     pub mutability: Option<Token![mut]>,
     pub inner: Type,
 }

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -182,7 +182,7 @@ fn parse_extern_fn(
                             ampersand: *ampersand,
                             lifetime: lifetime.clone(),
                             mutability: arg.mutability,
-                            var: Token![self](ety.ident.span()),
+                            var: arg.self_token,
                             ty: ety.ident.clone(),
                             shorthand: true,
                         });

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -184,6 +184,7 @@ fn parse_extern_fn(
                             mutability: arg.mutability,
                             var: Token![self](ety.ident.span()),
                             ty: ety.ident.clone(),
+                            shorthand: true,
                         });
                         continue;
                     }
@@ -211,6 +212,7 @@ fn parse_extern_fn(
                             mutability: reference.mutability,
                             var: Token![self](ident.span()),
                             ty: ident,
+                            shorthand: false,
                         });
                         continue;
                     }

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -177,9 +177,10 @@ fn parse_extern_fn(
         match arg {
             FnArg::Receiver(arg) => {
                 if let Some(ety) = single_type {
-                    if let Some((ampersand, _)) = arg.reference {
+                    if let Some((ampersand, lifetime)) = &arg.reference {
                         receiver = Some(Receiver {
-                            ampersand,
+                            ampersand: *ampersand,
+                            lifetime: lifetime.clone(),
                             mutability: arg.mutability,
                             var: Token![self](ety.ident.span()),
                             ty: ety.ident.clone(),
@@ -206,6 +207,7 @@ fn parse_extern_fn(
                     if let Type::Ident(ident) = reference.inner {
                         receiver = Some(Receiver {
                             ampersand: reference.ampersand,
+                            lifetime: reference.lifetime,
                             mutability: reference.mutability,
                             var: Token![self](ident.span()),
                             ty: ident,
@@ -273,6 +275,7 @@ fn parse_type_reference(ty: &TypeReference) -> Result<Type> {
     };
     Ok(which(Box::new(Ref {
         ampersand: ty.and_token,
+        lifetime: ty.lifetime.clone(),
         mutability: ty.mutability,
         inner,
     })))

--- a/syntax/tokens.rs
+++ b/syntax/tokens.rs
@@ -47,6 +47,7 @@ impl ToTokens for Ty1 {
 impl ToTokens for Ref {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         self.ampersand.to_tokens(tokens);
+        self.lifetime.to_tokens(tokens);
         self.mutability.to_tokens(tokens);
         self.inner.to_tokens(tokens);
     }
@@ -110,6 +111,7 @@ impl Receiver {
 impl ToTokens for ReceiverType<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         self.0.ampersand.to_tokens(tokens);
+        self.0.lifetime.to_tokens(tokens);
         self.0.mutability.to_tokens(tokens);
         self.0.ty.to_tokens(tokens);
     }

--- a/tests/ui/disallow_lifetime.rs
+++ b/tests/ui/disallow_lifetime.rs
@@ -1,0 +1,13 @@
+#[cxx::bridge]
+mod ffi {
+    extern "C" {
+        type C;
+        fn f(&'static self);
+    }
+
+    extern "Rust" {
+        fn f(string: &'a String);
+    }
+}
+
+fn main() {}

--- a/tests/ui/disallow_lifetime.stderr
+++ b/tests/ui/disallow_lifetime.stderr
@@ -1,0 +1,11 @@
+error: references with explicit lifetimes are not supported
+ --> $DIR/disallow_lifetime.rs:9:22
+  |
+9 |         fn f(string: &'a String);
+  |                      ^^^^^^^^^^
+
+error: references with explicit lifetimes are not supported
+ --> $DIR/disallow_lifetime.rs:5:14
+  |
+5 |         fn f(&'static self);
+  |              ^^^^^^^^^^^^^


### PR DESCRIPTION
Previously these were being silently accepted and ignored.

```console
error: references with explicit lifetimes are not supported
 --> $DIR/disallow_lifetime.rs:9:22
  |
9 |         fn f(string: &'a String);
  |                      ^^^^^^^^^^

error: references with explicit lifetimes are not supported
 --> $DIR/disallow_lifetime.rs:5:14
  |
5 |         fn f(&'static self);
  |              ^^^^^^^^^^^^^
```