### PR TITLE
Trigger error on unrecognized ident in receiver's type

### DIFF
--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -141,6 +141,14 @@ fn check_api_struct(cx: &mut Check, strct: &Struct) {
 
 fn check_api_fn(cx: &mut Check, efn: &ExternFn) {
     if let Some(receiver) = &efn.receiver {
+        if !cx.types.structs.contains_key(&receiver.ty)
+            && !cx.types.cxx.contains(&receiver.ty)
+            && !cx.types.rust.contains(&receiver.ty)
+        {
+            let span = span_for_receiver_error(receiver);
+            cx.error(span, "unrecognized receiver type");
+        }
+
         if receiver.lifetime.is_some() {
             let span = span_for_receiver_error(receiver);
             cx.error(span, "references with explicit lifetimes are not supported");

--- a/tests/ui/unrecognized_receiver.rs
+++ b/tests/ui/unrecognized_receiver.rs
@@ -1,0 +1,8 @@
+#[cxx::bridge]
+mod ffi {
+    extern "C" {
+        fn f(self: &Unrecognized);
+    }
+}
+
+fn main() {}

--- a/tests/ui/unrecognized_receiver.stderr
+++ b/tests/ui/unrecognized_receiver.stderr
@@ -1,0 +1,5 @@
+error: unrecognized receiver type
+ --> $DIR/unrecognized_receiver.rs:4:20
+  |
+4 |         fn f(self: &Unrecognized);
+  |                    ^^^^^^^^^^^^^


### PR DESCRIPTION
```rust
mod ffi {
    extern "C" {
        fn f(self: &Unrecognized);
    }
}
```

```console
error: unrecognized receiver type
 --> $DIR/unrecognized_receiver.rs:4:20
  |
4 |         fn f(self: &Unrecognized);
  |                    ^^^^^^^^^^^^^
```

Previously this was accepted by the code generator and only produced errors later during C++ and Rust compilation.

```console
tests/ffi/lib.rs.cc:522:49: error: ‘Unrecognized’ does not name a type
 522 | void cxxbridge02$Unrecognized$f(const Unrecognized &self) noexcept {
     |                                       ^~~~~~~~~~~~
```