### PR TITLE
Defer computing the Self type of methods

### DIFF
--- a/tests/ui/unnamed_receiver.rs
+++ b/tests/ui/unnamed_receiver.rs
@@ -1,0 +1,14 @@
+#[cxx::bridge]
+mod ffi {
+    extern "C" {
+        type One;
+        type Two;
+        fn f(&mut self);
+    }
+
+    extern "Rust" {
+        fn f(self: &Self);
+    }
+}
+
+fn main() {}

--- a/tests/ui/unnamed_receiver.stderr
+++ b/tests/ui/unnamed_receiver.stderr
@@ -1,0 +1,11 @@
+error: unnamed receiver type is only allowed if the surrounding extern block contains exactly one extern type; use `self: &mut TheType`
+ --> $DIR/unnamed_receiver.rs:6:14
+  |
+6 |         fn f(&mut self);
+  |              ^^^^^^^^^
+
+error: unnamed receiver type is only allowed if the surrounding extern block contains exactly one extern type; use `self: &TheType`
+  --> $DIR/unnamed_receiver.rs:10:20
+   |
+10 |         fn f(self: &Self);
+   |                    ^^^^^


### PR DESCRIPTION
This implementation avoids aborting the parser so that we can emit more than one error at a time, and also works well for `self: &Self` syntax.