### PR TITLE
Add all std::iterator_traits required types to const_iterator of rust::Vec<T>

### DIFF
--- a/include/cxx.h
+++ b/include/cxx.h
@@ -235,9 +235,13 @@ public:
 
   class const_iterator {
   public:
+    using difference_type = ptrdiff_t;
     using value_type = typename std::add_const<T>::type;
+    using pointer = typename std::add_pointer<
+        typename std::add_const<T>::type>::type;
     using reference = typename std::add_lvalue_reference<
         typename std::add_const<T>::type>::type;
+    using iterator_category = std::forward_iterator_tag;
 
     const T &operator*() const { return *static_cast<const T *>(this->pos); }
     const_iterator &operator++() {

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -243,10 +243,18 @@ public:
         typename std::add_const<T>::type>::type;
     using iterator_category = std::forward_iterator_tag;
 
+    const_iterator(): pos(nullptr), stride(0) { }
+    const_iterator(const void *pos, size_t stride): pos(pos), stride(stride) { }
     const T &operator*() const { return *static_cast<const T *>(this->pos); }
+    const T *operator->() const { return static_cast<const T *>(this->pos); }
     const_iterator &operator++() {
       this->pos = static_cast<const uint8_t *>(this->pos) + this->stride;
       return *this;
+    }
+    const_iterator operator++(int) {
+      auto ret = const_iterator(this->pos, this->stride);
+      this->pos = static_cast<const uint8_t *>(this->pos) + this->stride;
+      return ret;
     }
     bool operator==(const const_iterator &other) const {
       return this->pos == other.pos;

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -243,8 +243,6 @@ public:
         typename std::add_const<T>::type>::type;
     using iterator_category = std::forward_iterator_tag;
 
-    const_iterator(): pos(nullptr), stride(0) { }
-    const_iterator(const void *pos, size_t stride): pos(pos), stride(stride) { }
     const T &operator*() const { return *static_cast<const T *>(this->pos); }
     const T *operator->() const { return static_cast<const T *>(this->pos); }
     const_iterator &operator++() {
@@ -252,7 +250,7 @@ public:
       return *this;
     }
     const_iterator operator++(int) {
-      auto ret = const_iterator(this->pos, this->stride);
+      auto ret = const_iterator(*this);
       this->pos = static_cast<const uint8_t *>(this->pos) + this->stride;
       return ret;
     }

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -52,6 +52,7 @@ pub mod ffi {
         fn c_take_rust_vec(v: Vec<u8>);
         fn c_take_rust_vec_shared(v: Vec<Shared>);
         fn c_take_ref_rust_vec(v: &Vec<u8>);
+        fn c_take_ref_rust_vec_copy(v: &Vec<u8>);
         fn c_take_callback(callback: fn(String) -> usize);
 
         fn c_try_return_void() -> Result<()>;

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -53,6 +53,7 @@ pub mod ffi {
         fn c_take_ref_vector(v: &CxxVector<u8>);
         fn c_take_rust_vec(v: Vec<u8>);
         fn c_take_rust_vec_shared(v: Vec<Shared>);
+        fn c_take_rust_vec_shared_forward_iterator(v: Vec<Shared>);
         fn c_take_ref_rust_vec(v: &Vec<u8>);
         fn c_take_ref_rust_vec_copy(v: &Vec<u8>);
         fn c_take_callback(callback: fn(String) -> usize);

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -200,6 +200,10 @@ void c_take_rust_vec_shared(rust::Vec<Shared> v) {
 }
 
 void c_take_ref_rust_vec(const rust::Vec<uint8_t> &v) {
+  // Test vector copy which was not compiling under gcc 7
+  std::vector<uint8_t> cxx_v;
+  std::copy(v.begin(), v.end(), back_inserter(cxx_v));
+
   uint8_t sum = std::accumulate(v.begin(), v.end(), 0);
   if (sum == 200) {
     cxx_test_suite_set_correct();

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -211,7 +211,9 @@ void c_take_ref_rust_vec(const rust::Vec<uint8_t> &v) {
 }
 
 void c_take_ref_rust_vec_copy(const rust::Vec<uint8_t> &v) {
-  // Test vector copy which was not compiling under gcc 7
+  // The std::copy() will make sure rust::Vec<>::const_iteerator satisfies the
+  // requirements for std::iterator_traits.
+  // https://en.cppreference.com/w/cpp/iterator/iterator_traits
   std::vector<uint8_t> cxx_v;
   std::copy(v.begin(), v.end(), back_inserter(cxx_v));
   uint8_t sum = std::accumulate(cxx_v.begin(), cxx_v.end(), 0);

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -207,7 +207,7 @@ void c_take_rust_vec_shared_forward_iterator(rust::Vec<Shared> v) {
   // Exercise requirements of ForwardIterator
   // https://en.cppreference.com/w/cpp/named_req/ForwardIterator
   uint32_t sum = 0;
-  for (auto it = v.begin(); it != v.end(); it++) {
+  for (auto it = v.begin(), it_end = v.end(); it != it_end; it++) {
     sum += it->z;
   }
   if (sum == 2021) {

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -211,7 +211,7 @@ void c_take_ref_rust_vec(const rust::Vec<uint8_t> &v) {
 }
 
 void c_take_ref_rust_vec_copy(const rust::Vec<uint8_t> &v) {
-  // The std::copy() will make sure rust::Vec<>::const_iteerator satisfies the
+  // The std::copy() will make sure rust::Vec<>::const_iterator satisfies the
   // requirements for std::iterator_traits.
   // https://en.cppreference.com/w/cpp/iterator/iterator_traits
   std::vector<uint8_t> cxx_v;

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -200,11 +200,17 @@ void c_take_rust_vec_shared(rust::Vec<Shared> v) {
 }
 
 void c_take_ref_rust_vec(const rust::Vec<uint8_t> &v) {
+  uint8_t sum = std::accumulate(v.begin(), v.end(), 0);
+  if (sum == 200) {
+    cxx_test_suite_set_correct();
+  }
+}
+
+void c_take_ref_rust_vec_copy(const rust::Vec<uint8_t> &v) {
   // Test vector copy which was not compiling under gcc 7
   std::vector<uint8_t> cxx_v;
   std::copy(v.begin(), v.end(), back_inserter(cxx_v));
-
-  uint8_t sum = std::accumulate(v.begin(), v.end(), 0);
+  uint8_t sum = std::accumulate(cxx_v.begin(), cxx_v.end(), 0);
   if (sum == 200) {
     cxx_test_suite_set_correct();
   }

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -203,6 +203,18 @@ void c_take_rust_vec_shared(rust::Vec<Shared> v) {
   }
 }
 
+void c_take_rust_vec_shared_forward_iterator(rust::Vec<Shared> v) {
+  // Exercise requirements of ForwardIterator
+  // https://en.cppreference.com/w/cpp/named_req/ForwardIterator
+  uint32_t sum = 0;
+  for (auto it = v.begin(); it != v.end(); it++) {
+    sum += it->z;
+  }
+  if (sum == 2021) {
+    cxx_test_suite_set_correct();
+  }
+}
+
 void c_take_ref_rust_vec(const rust::Vec<uint8_t> &v) {
   uint8_t sum = std::accumulate(v.begin(), v.end(), 0);
   if (sum == 200) {

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -56,6 +56,7 @@ void c_take_ref_vector(const std::vector<uint8_t> &v);
 void c_take_rust_vec(rust::Vec<uint8_t> v);
 void c_take_rust_vec_shared(rust::Vec<Shared> v);
 void c_take_ref_rust_vec(const rust::Vec<uint8_t> &v);
+void c_take_ref_rust_vec_copy(const rust::Vec<uint8_t> &v);
 void c_take_callback(rust::Fn<size_t(rust::String)> callback);
 
 void c_try_return_void();

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -57,6 +57,7 @@ void c_take_unique_ptr_vector_shared(std::unique_ptr<std::vector<Shared>> v);
 void c_take_ref_vector(const std::vector<uint8_t> &v);
 void c_take_rust_vec(rust::Vec<uint8_t> v);
 void c_take_rust_vec_shared(rust::Vec<Shared> v);
+void c_take_rust_vec_shared_forward_iterator(rust::Vec<Shared> v);
 void c_take_ref_rust_vec(const rust::Vec<uint8_t> &v);
 void c_take_ref_rust_vec_copy(const rust::Vec<uint8_t> &v);
 void c_take_callback(rust::Fn<size_t(rust::String)> callback);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -94,14 +94,14 @@ fn test_c_take() {
         ffi::c_return_unique_ptr_vector_shared()
     ));
     check!(ffi::c_take_ref_vector(&ffi::c_return_unique_ptr_vector_u8()));
-    check!(ffi::c_take_rust_vec([86_u8, 75_u8, 30_u8, 9_u8].to_vec()));
+    let test_vec = [86_u8, 75_u8, 30_u8, 9_u8].to_vec();
+    check!(ffi::c_take_rust_vec(test_vec.clone()));
     check!(ffi::c_take_rust_vec_shared(vec![
         ffi::Shared { z: 1010 },
         ffi::Shared { z: 1011 }
     ]));
-    check!(ffi::c_take_ref_rust_vec(
-        &[86_u8, 75_u8, 30_u8, 9_u8].to_vec()
-    ));
+    check!(ffi::c_take_ref_rust_vec(&test_vec));
+    check!(ffi::c_take_ref_rust_vec_copy(&test_vec));
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -100,6 +100,10 @@ fn test_c_take() {
         ffi::Shared { z: 1010 },
         ffi::Shared { z: 1011 }
     ]));
+    check!(ffi::c_take_rust_vec_shared_forward_iterator(vec![
+        ffi::Shared { z: 1010 },
+        ffi::Shared { z: 1011 }
+    ]));
     check!(ffi::c_take_ref_rust_vec(&test_vec));
     check!(ffi::c_take_ref_rust_vec_copy(&test_vec));
 }


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/iterator/iterator_traits

`std::iterator_traits` requires the following 5 types:

- `difference_type` - a signed integer type that can be used to identify distance between iterators
- `value_type` - the type of the values that can be obtained by dereferencing the iterator. This type is void for output iterators.
- `pointer` - defines a pointer to the type iterated over (value_type)
- `reference` - defines a reference to the type iterated over (value_type)
- `iterator_category` - the category of the iterator. Must be one of iterator category tags.

The current `const_iterator` for `rust::Vec<T>` only defined `value_type` and `reference` which caused an error when using `std::copy` on gcc 7.5.0 on Ubuntu but seemed to work fine on MacOS.