### PR TITLE
Support C-style enums

### DIFF
--- a/syntax/ident.rs
+++ b/syntax/ident.rs
@@ -23,6 +23,12 @@ pub(crate) fn check_all(apis: &[Api], errors: &mut Vec<Error>) {
                     errors.extend(check(&field.ident).err());
                 }
             }
+            Api::Enum(enm) => {
+                errors.extend(check(&enm.ident).err());
+                for variant in &enm.variants {
+                    errors.extend(check(&variant.ident).err());
+                }
+            }
             Api::CxxType(ety) | Api::RustType(ety) => {
                 errors.extend(check(&ety.ident).err());
             }

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -29,6 +29,7 @@ pub use self::types::Types;
 pub enum Api {
     Include(LitStr),
     Struct(Struct),
+    Enum(Enum),
     CxxType(ExternType),
     CxxFunction(ExternFn),
     RustType(ExternType),
@@ -48,6 +49,14 @@ pub struct Struct {
     pub ident: Ident,
     pub brace_token: Brace,
     pub fields: Vec<Var>,
+}
+
+pub struct Enum {
+    pub doc: Doc,
+    pub enum_token: Token![enum],
+    pub ident: Ident,
+    pub brace_token: Brace,
+    pub variants: Vec<Variant>,
 }
 
 pub struct ExternFn {
@@ -81,6 +90,11 @@ pub struct Receiver {
     pub var: Token![self],
     pub ty: Ident,
     pub shorthand: bool,
+}
+
+pub struct Variant {
+    pub ident: Ident,
+    pub discriminant: Option<u32>,
 }
 
 pub enum Type {

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -13,6 +13,12 @@ pub mod ffi {
         z: usize,
     }
 
+    enum Enum {
+        AVal,
+        BVal = 2020,
+        CVal,
+    }
+
     extern "C" {
         include!("tests/ffi/tests.h");
 
@@ -36,6 +42,7 @@ pub mod ffi {
         fn c_return_ref_rust_vec(c: &C) -> &Vec<u8>;
         fn c_return_identity(_: usize) -> usize;
         fn c_return_sum(_: usize, _: usize) -> usize;
+        fn c_return_enum(n: u32) -> Enum;
 
         fn c_take_primitive(n: usize);
         fn c_take_shared(shared: Shared);
@@ -57,6 +64,7 @@ pub mod ffi {
         fn c_take_ref_rust_vec(v: &Vec<u8>);
         fn c_take_ref_rust_vec_copy(v: &Vec<u8>);
         fn c_take_callback(callback: fn(String) -> usize);
+        fn c_take_enum(e: Enum);
 
         fn c_try_return_void() -> Result<()>;
         fn c_try_return_primitive() -> Result<usize>;
@@ -92,6 +100,7 @@ pub mod ffi {
         fn r_return_ref_rust_vec(shared: &Shared) -> &Vec<u8>;
         fn r_return_identity(_: usize) -> usize;
         fn r_return_sum(_: usize, _: usize) -> usize;
+        fn r_return_enum(n: u32) -> Enum;
 
         fn r_take_primitive(n: usize);
         fn r_take_shared(shared: Shared);
@@ -105,6 +114,7 @@ pub mod ffi {
         fn r_take_unique_ptr_string(s: UniquePtr<CxxString>);
         fn r_take_rust_vec(v: Vec<u8>);
         fn r_take_ref_rust_vec(v: &Vec<u8>);
+        fn r_take_enum(e: Enum);
 
         fn r_try_return_void() -> Result<()>;
         fn r_try_return_primitive() -> Result<usize>;
@@ -198,6 +208,16 @@ fn r_return_sum(n1: usize, n2: usize) -> usize {
     n1 + n2
 }
 
+fn r_return_enum(n: u32) -> ffi::Enum {
+    if n <= 0 {
+        ffi::Enum::AVal
+    } else if n <= 2020 {
+        ffi::Enum::BVal
+    } else {
+        ffi::Enum::CVal
+    }
+}
+
 fn r_take_primitive(n: usize) {
     assert_eq!(n, 2020);
 }
@@ -245,6 +265,10 @@ fn r_take_rust_vec(v: Vec<u8>) {
 
 fn r_take_ref_rust_vec(v: &Vec<u8>) {
     let _ = v;
+}
+
+fn r_take_enum(e: ffi::Enum) {
+    let _ = e;
 }
 
 fn r_try_return_void() -> Result<(), Error> {

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -106,6 +106,16 @@ size_t c_return_identity(size_t n) { return n; }
 
 size_t c_return_sum(size_t n1, size_t n2) { return n1 + n2; }
 
+Enum c_return_enum(uint32_t n) {
+  if (n <= static_cast<uint32_t>(Enum::AVal)) {
+    return Enum::AVal;
+  } else if (n <= static_cast<uint32_t>(Enum::BVal)) {
+    return Enum::BVal;
+  } else {
+    return Enum::CVal;
+  }
+}
+
 void c_take_primitive(size_t n) {
   if (n == 2020) {
     cxx_test_suite_set_correct();
@@ -238,6 +248,12 @@ void c_take_callback(rust::Fn<size_t(rust::String)> callback) {
   callback("2020");
 }
 
+void c_take_enum(Enum e) {
+  if (e == Enum::AVal) {
+    cxx_test_suite_set_correct();
+  }
+}
+
 void c_try_return_void() {}
 
 size_t c_try_return_primitive() { return 2020; }
@@ -295,6 +311,9 @@ extern "C" const char *cxx_run_test() noexcept {
   ASSERT(*r_return_unique_ptr_string() == "2020");
   ASSERT(r_return_identity(2020) == 2020);
   ASSERT(r_return_sum(2020, 1) == 2021);
+  ASSERT(r_return_enum(0) == Enum::AVal);
+  ASSERT(r_return_enum(1) == Enum::BVal);
+  ASSERT(r_return_enum(2021) == Enum::CVal);
 
   r_take_primitive(2020);
   r_take_shared(Shared{2020});
@@ -306,6 +325,7 @@ extern "C" const char *cxx_run_test() noexcept {
   r_take_rust_string(rust::String("2020"));
   r_take_unique_ptr_string(
       std::unique_ptr<std::string>(new std::string("2020")));
+  r_take_enum(Enum::AVal);
 
   ASSERT(r_try_return_primitive() == 2020);
   try {

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -7,6 +7,7 @@ namespace tests {
 
 struct R;
 struct Shared;
+enum class Enum : uint32_t;
 
 class C {
 public:
@@ -40,6 +41,7 @@ rust::Vec<uint8_t> c_return_rust_vec();
 const rust::Vec<uint8_t> &c_return_ref_rust_vec(const C &c);
 size_t c_return_identity(size_t n);
 size_t c_return_sum(size_t n1, size_t n2);
+Enum c_return_enum(uint32_t n);
 
 void c_take_primitive(size_t n);
 void c_take_shared(Shared shared);
@@ -61,6 +63,7 @@ void c_take_rust_vec_shared_forward_iterator(rust::Vec<Shared> v);
 void c_take_ref_rust_vec(const rust::Vec<uint8_t> &v);
 void c_take_ref_rust_vec_copy(const rust::Vec<uint8_t> &v);
 void c_take_callback(rust::Fn<size_t(rust::String)> callback);
+void c_take_enum(Enum e);
 
 void c_try_return_void();
 size_t c_try_return_primitive();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -51,6 +51,18 @@ fn test_c_return() {
     );
     assert_eq!(2020, ffi::c_return_identity(2020));
     assert_eq!(2021, ffi::c_return_sum(2020, 1));
+    match ffi::c_return_enum(0) {
+        ffi::Enum::AVal => {}
+        _ => assert!(false),
+    }
+    match ffi::c_return_enum(1) {
+        ffi::Enum::BVal => {}
+        _ => assert!(false),
+    }
+    match ffi::c_return_enum(2021) {
+        ffi::Enum::CVal => {}
+        _ => assert!(false),
+    }
 }
 
 #[test]
@@ -106,6 +118,7 @@ fn test_c_take() {
     ]));
     check!(ffi::c_take_ref_rust_vec(&test_vec));
     check!(ffi::c_take_ref_rust_vec_copy(&test_vec));
+    check!(ffi::c_take_enum(ffi::Enum::AVal));
 }
 
 #[test]

--- a/tests/ui/data_enums.rs
+++ b/tests/ui/data_enums.rs
@@ -1,0 +1,8 @@
+#[cxx::bridge]
+mod ffi {
+    enum A {
+        Field(u64),
+    }
+}
+
+fn main() {}

--- a/tests/ui/data_enums.stderr
+++ b/tests/ui/data_enums.stderr
@@ -1,0 +1,5 @@
+error: enums with data are not allowed
+ --> $DIR/data_enums.rs:4:9
+  |
+4 |         Field(u64),
+  |         ^^^^^^^^^^

--- a/tests/ui/duplicate_enum_discriminants.rs
+++ b/tests/ui/duplicate_enum_discriminants.rs
@@ -1,0 +1,15 @@
+#[cxx::bridge]
+mod ffi {
+    enum A {
+        V1 = 10,
+        V2 = 10,
+    }
+
+    enum B {
+        V1 = 10,
+        V2,
+        V3 = 11,
+    }
+}
+
+fn main() {}

--- a/tests/ui/duplicate_enum_discriminants.stderr
+++ b/tests/ui/duplicate_enum_discriminants.stderr
@@ -1,0 +1,18 @@
+error: discriminant value `10` already exists
+ --> $DIR/duplicate_enum_discriminants.rs:3:5
+  |
+3 | /     enum A {
+4 | |         V1 = 10,
+5 | |         V2 = 10,
+6 | |     }
+  | |_____^
+
+error: discriminant value `11` already exists
+  --> $DIR/duplicate_enum_discriminants.rs:8:5
+   |
+8  | /     enum B {
+9  | |         V1 = 10,
+10 | |         V2,
+11 | |         V3 = 11,
+12 | |     }
+   | |_____^

--- a/tests/ui/empty_enum.rs
+++ b/tests/ui/empty_enum.rs
@@ -1,0 +1,8 @@
+#[cxx::bridge]
+mod ffi {
+    enum A {
+
+    }
+}
+
+fn main() {}

--- a/tests/ui/empty_enum.stderr
+++ b/tests/ui/empty_enum.stderr
@@ -1,0 +1,7 @@
+error: enums without any variants are not supported
+ --> $DIR/empty_enum.rs:3:5
+  |
+3 | /     enum A {
+4 | |
+5 | |     }
+  | |_____^

--- a/tests/ui/enum_match_without_wildcard.rs
+++ b/tests/ui/enum_match_without_wildcard.rs
@@ -1,0 +1,16 @@
+#[cxx::bridge]
+mod ffi {
+    enum A {
+        FieldA,
+        FieldB,
+    }
+}
+
+fn main() {}
+
+fn matcher(a: ffi::A) -> u32 {
+    match a {
+        ffi::A::FieldA => 2020,
+        ffi::A::FieldB => 2021,
+    }
+}

--- a/tests/ui/enum_match_without_wildcard.stderr
+++ b/tests/ui/enum_match_without_wildcard.stderr
@@ -1,0 +1,10 @@
+error[E0004]: non-exhaustive patterns: `A(2u32..=std::u32::MAX)` not covered
+  --> $DIR/enum_match_without_wildcard.rs:12:11
+   |
+1  | #[cxx::bridge]
+   | -------------- `ffi::A` defined here
+...
+12 |     match a {
+   |           ^ pattern `A(2u32..=std::u32::MAX)` not covered
+   |
+   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms

--- a/tests/ui/enum_match_without_wildcard.stderr
+++ b/tests/ui/enum_match_without_wildcard.stderr
@@ -8,3 +8,4 @@ error[E0004]: non-exhaustive patterns: `A(2u32..=std::u32::MAX)` not covered
    |           ^ pattern `A(2u32..=std::u32::MAX)` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `ffi::A`

--- a/tests/ui/generic_enum.rs
+++ b/tests/ui/generic_enum.rs
@@ -1,0 +1,8 @@
+#[cxx::bridge]
+mod ffi {
+    enum A<T> {
+        Field,
+    }
+}
+
+fn main() {}

--- a/tests/ui/generic_enum.stderr
+++ b/tests/ui/generic_enum.stderr
@@ -1,0 +1,5 @@
+error: enums with generic parameters are not allowed
+ --> $DIR/generic_enum.rs:3:5
+  |
+3 |     enum A<T> {
+  |     ^^^^^^^^^

--- a/tests/ui/non_integer_discriminant_enum.rs
+++ b/tests/ui/non_integer_discriminant_enum.rs
@@ -1,0 +1,8 @@
+#[cxx::bridge]
+mod ffi {
+    enum A {
+        Field = 2020 + 1,
+    }
+}
+
+fn main() {}

--- a/tests/ui/non_integer_discriminant_enum.stderr
+++ b/tests/ui/non_integer_discriminant_enum.stderr
@@ -1,0 +1,5 @@
+error: enums with non-integer literal discriminants are not supported
+ --> $DIR/non_integer_discriminant_enum.rs:4:9
+  |
+4 |         Field = 2020 + 1,
+  |         ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This adds support for passing C-style enums between Rust and C++.

We use the Rust representation for enums suggested by dtolnay in #132.
Note that as this does not use real enums, Rust code cannot treat them
as normal enums, e.g., by converting them to integers.  But common
uses such as pattern matching remain unchanged.