### PR TITLE
Properly handle enum discriminant overflows.

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -127,14 +127,19 @@ fn expand_struct(strct: &Struct) -> TokenStream {
 fn expand_enum(enm: &Enum) -> TokenStream {
     let ident = &enm.ident;
     let doc = &enm.doc;
-    let variants = enm.variants.iter().scan(0, |next_discriminant, variant| {
-        let variant_ident = &variant.ident;
-        let discriminant = variant.discriminant.unwrap_or(*next_discriminant);
-        *next_discriminant = discriminant + 1;
-        Some(quote! {
-            pub const #variant_ident: Self = #ident(#discriminant);
-        })
-    });
+    let variants = enm
+        .variants
+        .iter()
+        .scan(None, |prev_discriminant, variant| {
+            let variant_ident = &variant.ident;
+            let discriminant = variant
+                .discriminant
+                .unwrap_or_else(|| prev_discriminant.map_or(0, |n| n + 1));
+            *prev_discriminant = Some(discriminant);
+            Some(quote! {
+                pub const #variant_ident: Self = #ident(#discriminant);
+            })
+        });
     quote! {
         #doc
         #[derive(Copy, Clone, PartialEq, Eq)]

--- a/tests/ui/enum_overflows.rs
+++ b/tests/ui/enum_overflows.rs
@@ -1,0 +1,17 @@
+#[cxx::bridge]
+mod ffi {
+    enum Good1 {
+        A = 0xffffffff,
+    }
+    enum Good2 {
+        B = 0xffffffff,
+        C = 2020,
+    }
+    enum Bad {
+        D = 0xfffffffe,
+        E,
+        F,
+    }
+}
+
+fn main() {}

--- a/tests/ui/enum_overflows.stderr
+++ b/tests/ui/enum_overflows.stderr
@@ -1,0 +1,9 @@
+error: overflowed on value after 4294967295
+  --> $DIR/enum_overflows.rs:10:5
+   |
+10 | /     enum Bad {
+11 | |         D = 0xfffffffe,
+12 | |         E,
+13 | |         F,
+14 | |     }
+   | |_____^


### PR DESCRIPTION
This both checks for enum values that are illegal due to overflow and
ensures we do not overflow on valid enums.

Fixes #176.