### PR TITLE
Support building C++ code generator with panic=abort

### DIFF
--- a/gen/build/Cargo.toml
+++ b/gen/build/Cargo.toml
@@ -14,7 +14,7 @@ travis-ci = { repository = "dtolnay/cxx" }
 anyhow = "1.0"
 cc = "1.0.49"
 codespan-reporting = "0.9"
-proc-macro2 = { version = "1.0", features = ["span-locations"] }
+proc-macro2 = { version = "1.0.11", features = ["span-locations"] }
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
 

--- a/gen/cmd/Cargo.toml
+++ b/gen/cmd/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "dtolnay/cxx" }
 [dependencies]
 anyhow = "1.0"
 codespan-reporting = "0.9"
-proc-macro2 = { version = "1.0", features = ["span-locations"] }
+proc-macro2 = { version = "1.0.11", features = ["span-locations"] }
 quote = "1.0"
 structopt = "0.3"
 syn = { version = "1.0", features = ["full"] }

--- a/gen/src/mod.rs
+++ b/gen/src/mod.rs
@@ -41,6 +41,7 @@ fn generate(path: &Path, opt: Opt, header: bool) -> Vec<u8> {
         Err(err) => format_err(path, "", Error::Io(err)),
     };
     match (|| -> Result<_> {
+        proc_macro2::fallback::force();
         let syntax = syn::parse_file(&source)?;
         let bridge = find_bridge_mod(syntax)?;
         let namespace = bridge.namespace;

--- a/third-party/BUCK
+++ b/third-party/BUCK
@@ -83,7 +83,7 @@ rust_library(
 
 rust_library(
     name = "proc-macro2",
-    srcs = glob(["vendor/proc-macro2-1.0.10/src/**"]),
+    srcs = glob(["vendor/proc-macro2-1.0.11/src/**"]),
     visibility = ["PUBLIC"],
     features = [
         "proc-macro",
@@ -99,7 +99,7 @@ rust_library(
 
 rust_library(
     name = "quote",
-    srcs = glob(["vendor/quote-1.0.3/src/**"]),
+    srcs = glob(["vendor/quote-1.0.4/src/**"]),
     visibility = ["PUBLIC"],
     features = ["proc-macro"],
     deps = [":proc-macro2"],

--- a/third-party/BUILD
+++ b/third-party/BUILD
@@ -88,7 +88,7 @@ rust_library(
 
 rust_library(
     name = "proc-macro2",
-    srcs = glob(["vendor/proc-macro2-1.0.10/src/**"]),
+    srcs = glob(["vendor/proc-macro2-1.0.11/src/**"]),
     crate_features = [
         "proc-macro",
         "span-locations",
@@ -104,7 +104,7 @@ rust_library(
 
 rust_library(
     name = "quote",
-    srcs = glob(["vendor/quote-1.0.3/src/**"]),
+    srcs = glob(["vendor/quote-1.0.4/src/**"]),
     crate_features = ["proc-macro"],
     visibility = ["//visibility:public"],
     deps = [":proc-macro2"],

--- a/third-party/Cargo.lock
+++ b/third-party/Cargo.lock
@@ -211,18 +211,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
+checksum = "9dd1c38e7b0b6b61bcfbdc08c801f3c3066e884bd8e6764bdd2e5971da1d7c4d"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+checksum = "4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7"
 dependencies = [
  "proc-macro2",
 ]


### PR DESCRIPTION
Closes #130. This pulls in https://github.com/alexcrichton/proc-macro2/pull/220.

Tested by adding this:

```toml
[profile.dev]
panic = "abort"
```

to the bottom of Cargo.toml and running `cargo run --manifest-path /git/cxx/gen/cmd/Cargo.toml -- /git/cxx/tests/ffi/lib.rs`, which aborts before this PR and succeeds after this PR.