### PR TITLE
Batch parse errors

### DIFF
--- a/gen/src/mod.rs
+++ b/gen/src/mod.rs
@@ -47,8 +47,9 @@ fn generate(path: &Path, opt: Opt, header: bool) -> Vec<u8> {
         let syntax = syn::parse_file(&source)?;
         let bridge = find_bridge_mod(syntax)?;
         let ref namespace = bridge.namespace;
-        let ref apis = syntax::parse_items(bridge.module)?;
-        let ref types = Types::collect(apis)?;
+        let ref apis = syntax::parse_items(errors, bridge.module);
+        let ref types = Types::collect(errors, apis);
+        errors.propagate()?;
         check::typecheck(errors, namespace, apis, types);
         errors.propagate()?;
         let out = write::gen(namespace, apis, types, opt, header);

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -15,8 +15,9 @@ pub fn bridge(namespace: &Namespace, mut ffi: ItemMod) -> Result<TokenStream> {
         Span::call_site(),
         "#[cxx::bridge] module must have inline contents",
     ))?;
-    let ref apis = syntax::parse_items(content.1)?;
-    let ref types = Types::collect(apis)?;
+    let ref apis = syntax::parse_items(errors, content.1);
+    let ref types = Types::collect(errors, apis);
+    errors.propagate()?;
     check::typecheck(errors, namespace, apis, types);
     errors.propagate()?;
 

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -10,7 +10,6 @@ use quote::{quote, ToTokens};
 use std::collections::HashSet;
 use std::fmt::Display;
 use std::u32;
-use syn::Result;
 
 pub(crate) struct Check<'a> {
     namespace: &'a Namespace,
@@ -19,16 +18,13 @@ pub(crate) struct Check<'a> {
     errors: &'a mut Errors,
 }
 
-pub(crate) fn typecheck(namespace: &Namespace, apis: &[Api], types: &Types) -> Result<()> {
-    let mut errors = Errors::new();
-    let mut cx = Check {
+pub(crate) fn typecheck(cx: &mut Errors, namespace: &Namespace, apis: &[Api], types: &Types) {
+    do_typecheck(&mut Check {
         namespace,
         apis,
         types,
-        errors: &mut errors,
-    };
-    do_typecheck(&mut cx);
-    errors.propagate()
+        errors: cx,
+    });
 }
 
 fn do_typecheck(cx: &mut Check) {

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -10,6 +10,7 @@ mod impls;
 pub mod mangle;
 pub mod namespace;
 mod parse;
+pub mod report;
 pub mod set;
 pub mod symbol;
 mod tokens;

--- a/syntax/report.rs
+++ b/syntax/report.rs
@@ -1,0 +1,29 @@
+use quote::ToTokens;
+use std::fmt::Display;
+use syn::{Error, Result};
+
+pub struct Errors {
+    errors: Vec<Error>,
+}
+
+impl Errors {
+    pub fn new() -> Self {
+        Errors { errors: Vec::new() }
+    }
+
+    pub fn error(&mut self, sp: impl ToTokens, msg: impl Display) {
+        self.errors.push(Error::new_spanned(sp, msg));
+    }
+
+    pub fn propagate(&mut self) -> Result<()> {
+        let mut iter = self.errors.drain(..);
+        let mut all_errors = match iter.next() {
+            Some(err) => err,
+            None => return Ok(()),
+        };
+        for err in iter {
+            all_errors.combine(err);
+        }
+        Err(all_errors)
+    }
+}

--- a/syntax/report.rs
+++ b/syntax/report.rs
@@ -15,6 +15,10 @@ impl Errors {
         self.errors.push(Error::new_spanned(sp, msg));
     }
 
+    pub fn push(&mut self, error: Error) {
+        self.errors.push(error);
+    }
+
     pub fn propagate(&mut self) -> Result<()> {
         let mut iter = self.errors.drain(..);
         let mut all_errors = match iter.next() {

--- a/tests/ui/multiple_parse_error.rs
+++ b/tests/ui/multiple_parse_error.rs
@@ -1,0 +1,9 @@
+#[cxx::bridge]
+mod ffi {
+    struct Monad<T>;
+
+    extern "Haskell" {
+    }
+}
+
+fn main() {}

--- a/tests/ui/multiple_parse_error.stderr
+++ b/tests/ui/multiple_parse_error.stderr
@@ -1,0 +1,5 @@
+error: struct with generic parameters is not supported yet
+ --> $DIR/multiple_parse_error.rs:3:5
+  |
+3 |     struct Monad<T>;
+  |     ^^^^^^^^^^^^^^^

--- a/tests/ui/multiple_parse_error.stderr
+++ b/tests/ui/multiple_parse_error.stderr
@@ -3,3 +3,9 @@ error: struct with generic parameters is not supported yet
   |
 3 |     struct Monad<T>;
   |     ^^^^^^^^^^^^^^^
+
+error: unrecognized ABI
+ --> $DIR/multiple_parse_error.rs:5:5
+  |
+5 |     extern "Haskell" {
+  |     ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes #183.

Before:

```console
error: struct with generic parameters is not supported yet
 --> $DIR/multiple_parse_error.rs:3:5
  |
3 |     struct Monad<T>;
  |     ^^^^^^^^^^^^^^^
```

After:

```console
error: struct with generic parameters is not supported yet
 --> $DIR/multiple_parse_error.rs:3:5
  |
3 |     struct Monad<T>;
  |     ^^^^^^^^^^^^^^^

error: unrecognized ABI
 --> $DIR/multiple_parse_error.rs:5:5
  |
5 |     extern "Haskell" {
  |     ^^^^^^^^^^^^^^^^
```