### PR TITLE
Support enums defined in C++ code.

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -5,7 +5,7 @@ use crate::syntax::namespace::Namespace;
 use crate::syntax::symbol::Symbol;
 use crate::syntax::{mangle, Api, Enum, ExternFn, ExternType, Signature, Struct, Type, Types, Var};
 use proc_macro2::Ident;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 pub(super) fn gen(
     namespace: &Namespace,
@@ -46,6 +46,7 @@ pub(super) fn gen(
         }
     }
 
+    let mut cxx_types = HashSet::new();
     let mut methods_for_type = HashMap::new();
     for api in apis {
         if let Api::RustFunction(efn) = api {
@@ -55,6 +56,9 @@ pub(super) fn gen(
                     .or_insert_with(Vec::new)
                     .push(efn);
             }
+        }
+        if let Api::CxxType(enm) = api {
+            cxx_types.insert(&enm.ident);
         }
     }
 
@@ -66,7 +70,11 @@ pub(super) fn gen(
             }
             Api::Enum(enm) => {
                 out.next_section();
-                write_enum(out, enm);
+                if cxx_types.contains(&enm.ident) {
+                    check_enum(out, enm);
+                } else {
+                    write_enum(out, enm);
+                }
             }
             Api::RustType(ety) => {
                 if let Some(methods) = methods_for_type.get(&ety.ident) {
@@ -371,6 +379,34 @@ fn write_enum(out: &mut OutFile, enm: &Enum) {
         writeln!(out, ",");
     }
     writeln!(out, "}};");
+}
+
+fn check_enum(out: &mut OutFile, enm: &Enum) {
+    let discriminants = enm
+        .variants
+        .iter()
+        .scan(None, |prev_discriminant, variant| {
+            let discriminant = variant
+                .discriminant
+                .unwrap_or_else(|| prev_discriminant.map_or(0, |n| n + 1));
+            *prev_discriminant = Some(discriminant);
+            Some(discriminant)
+        });
+    writeln!(
+        out,
+        "static_assert(sizeof({}) == sizeof(uint32_t));",
+        enm.ident
+    );
+    enm.variants
+        .iter()
+        .zip(discriminants)
+        .for_each(|(variant, discriminant)| {
+            writeln!(
+                out,
+                "static_assert({}::{} == {});",
+                enm.ident, variant.ident, discriminant
+            );
+        });
 }
 
 fn write_exception_glue(out: &mut OutFile, apis: &[Api]) {

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -380,7 +380,7 @@ fn write_enum(out: &mut OutFile, enm: &Enum) {
 fn check_enum(out: &mut OutFile, enm: &Enum) {
     writeln!(
         out,
-        "static_assert(sizeof({}) == sizeof(uint32_t));",
+        "static_assert(sizeof({}) == sizeof(uint32_t), \"incorrect size\");",
         enm.ident
     );
     let mut prev_discriminant = None;

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -7,7 +7,6 @@ use crate::syntax::{
 };
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote, quote_spanned, ToTokens};
-use std::collections::HashSet;
 use syn::{parse_quote, Error, ItemMod, Result, Token};
 
 pub fn bridge(namespace: &Namespace, mut ffi: ItemMod) -> Result<TokenStream> {
@@ -40,19 +39,13 @@ fn expand(namespace: &Namespace, ffi: ItemMod, apis: &[Api], types: &Types) -> T
         }
     }
 
-    let mut enums = HashSet::new();
-    for api in apis {
-        if let Api::Enum(enm) = api {
-            enums.insert(&enm.ident);
-        }
-    }
     for api in apis {
         match api {
             Api::Include(_) | Api::RustType(_) => {}
             Api::Struct(strct) => expanded.extend(expand_struct(strct)),
             Api::Enum(enm) => expanded.extend(expand_enum(enm)),
             Api::CxxType(ety) => {
-                if !enums.contains(&ety.ident) {
+                if !types.enums.contains_key(&ety.ident) {
                     expanded.extend(expand_cxx_type(ety));
                 }
             }

--- a/syntax/types.rs
+++ b/syntax/types.rs
@@ -69,7 +69,9 @@ impl<'a> Types<'a> {
                 }
                 Api::CxxType(ety) => {
                     let ident = &ety.ident;
-                    if !type_names.insert(ident) {
+                    // We allow declaring the same type as a shared enum and as a Cxxtype, as this
+                    // means not to emit the C++ enum definition.
+                    if !type_names.insert(ident) && !enums.contains_key(ident) {
                         duplicate_name(cx, ety, ident);
                     }
                     cxx.insert(ident);

--- a/syntax/types.rs
+++ b/syntax/types.rs
@@ -61,11 +61,12 @@ impl<'a> Types<'a> {
                 }
                 Api::Enum(enm) => {
                     let ident = &enm.ident;
-                    if type_names.insert(ident) {
-                        enums.insert(ident.clone(), enm);
-                    } else {
+                    // We allow declaring the same type as a shared enum and as a Cxxtype, as this
+                    // means not to emit the C++ enum definition.
+                    if !type_names.insert(ident) && !cxx.contains(ident) {
                         duplicate_name(cx, enm, ident);
                     }
+                    enums.insert(ident.clone(), enm);
                 }
                 Api::CxxType(ety) => {
                     let ident = &ety.ident;

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -84,6 +84,15 @@ pub mod ffi {
         fn set2(&mut self, n: usize) -> usize;
     }
 
+    extern "C" {
+        type COwnedEnum;
+    }
+
+    enum COwnedEnum {
+        CVal1,
+        CVal2,
+    }
+
     extern "Rust" {
         type R;
         type R2;

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -23,6 +23,11 @@ private:
   std::vector<uint8_t> v;
 };
 
+enum COwnedEnum {
+  CVal1,
+  CVal2,
+};
+
 size_t c_return_primitive();
 Shared c_return_shared();
 rust::Box<R> c_return_box();


### PR DESCRIPTION
This allows listing an enum in an extern "C" block as well as in the shared block.  In this case, we do not emit the C++ declaration of the enum but instead emit static assertions that it has the values that we expect.

Do you know a good way to test the assertions?  The ui tests don't seem to compile the generated C++ files, so I'm not sure how to do it.

I'm also considering refactoring the discriminant generation code somewhere now that it's mostly duplicated in three different places.

Closes #177.