### PR TITLE
Add cpp flag to cc

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,7 @@
 fn main() {
     cc::Build::new()
         .file("src/cxx.cc")
+        .cpp(true)
         .flag("-std=c++11")
         .compile("cxxbridge03");
     println!("cargo:rerun-if-changed=src/cxx.cc");

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,7 @@ fn main() {
     cc::Build::new()
         .file("src/cxx.cc")
         .cpp(true)
+        .cpp_link_stdlib(None) // linked via link-cplusplus crate
         .flag("-std=c++11")
         .compile("cxxbridge03");
     println!("cargo:rerun-if-changed=src/cxx.cc");

--- a/demo-rs/build.rs
+++ b/demo-rs/build.rs
@@ -1,7 +1,6 @@
 fn main() {
     cxx_build::bridge("src/main.rs")
         .file("../demo-cxx/demo.cc")
-        .cpp(true)
         .flag("-std=c++11")
         .compile("cxxbridge-demo");
 

--- a/demo-rs/build.rs
+++ b/demo-rs/build.rs
@@ -1,6 +1,7 @@
 fn main() {
     cxx_build::bridge("src/main.rs")
         .file("../demo-cxx/demo.cc")
+        .cpp(true)
         .flag("-std=c++11")
         .compile("cxxbridge-demo");
 

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -88,12 +88,16 @@ pub fn bridge(rust_source_file: impl AsRef<Path>) -> cc::Build {
 /// ```
 pub fn bridges(rust_source_files: impl IntoIterator<Item = impl AsRef<Path>>) -> cc::Build {
     let mut build = paths::cc_build();
+    build.cpp(true);
+    build.cpp_link_stdlib(None); // linked via link-cplusplus crate
+
     for path in rust_source_files {
         if let Err(err) = try_generate_bridge(&mut build, path.as_ref()) {
             let _ = writeln!(io::stderr(), "\n\ncxxbridge error: {:?}\n\n", anyhow!(err));
             process::exit(1);
         }
     }
+
     build
 }
 


### PR DESCRIPTION
This means that clang++ will be called instead of clang.

This was causing me issueing when trying to use the nix version of clang, not sure why.