### PR TITLE
avoid MSVC warning via flag_if_supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ cxx-build = "0.3"
 fn main() {
     cxx_build::bridge("src/main.rs")  // returns a cc::Build
         .file("../demo-cxx/demo.cc")
-        .flag("-std=c++11")
+        .flag_if_supported("-std=c++11")
         .compile("cxxbridge-demo");
 
     println!("cargo:rerun-if-changed=src/main.rs");

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,7 @@ fn main() {
         .file("src/cxx.cc")
         .cpp(true)
         .cpp_link_stdlib(None) // linked via link-cplusplus crate
-        .flag("-std=c++11")
+        .flag_if_supported("-std=c++11")
         .compile("cxxbridge03");
     println!("cargo:rerun-if-changed=src/cxx.cc");
     println!("cargo:rerun-if-changed=include/cxx.h");

--- a/demo-rs/build.rs
+++ b/demo-rs/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     cxx_build::bridge("src/main.rs")
         .file("../demo-cxx/demo.cc")
-        .flag("-std=c++11")
+        .flag_if_supported("-std=c++11")
         .compile("cxxbridge-demo");
 
     println!("cargo:rerun-if-changed=src/main.rs");

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -16,7 +16,7 @@
 //! fn main() {
 //!     cxx_build::bridge("src/main.rs")
 //!         .file("../demo-cxx/demo.cc")
-//!         .flag("-std=c++11")
+//!         .flag_if_supported("-std=c++11")
 //!         .compile("cxxbridge-demo");
 //!
 //!     println!("cargo:rerun-if-changed=src/main.rs");
@@ -83,7 +83,7 @@ pub fn bridge(rust_source_file: impl AsRef<Path>) -> cc::Build {
 /// let source_files = vec!["src/main.rs", "src/path/to/other.rs"];
 /// cxx_build::bridges(source_files)
 ///     .file("../demo-cxx/demo.cc")
-///     .flag("-std=c++11")
+///     .flag_if_supported("-std=c++11")
 ///     .compile("cxxbridge-demo");
 /// ```
 pub fn bridges(rust_source_files: impl IntoIterator<Item = impl AsRef<Path>>) -> cc::Build {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,7 @@
 //! fn main() {
 //!     cxx_build::bridge("src/main.rs")  // returns a cc::Build
 //!         .file("../demo-cxx/demo.cc")
-//!         .flag("-std=c++11")
+//!         .flag_if_supported("-std=c++11")
 //!         .compile("cxxbridge-demo");
 //!
 //!     println!("cargo:rerun-if-changed=src/main.rs");

--- a/tests/ffi/build.rs
+++ b/tests/ffi/build.rs
@@ -6,6 +6,6 @@ fn main() {
     let sources = vec!["lib.rs", "module.rs"];
     cxx_build::bridges(sources)
         .file("tests.cc")
-        .flag("-std=c++11")
+        .flag_if_supported("-std=c++11")
         .compile("cxx-test-suite");
 }


### PR DESCRIPTION
To avoid a compiler warning on MSVC, use `flag_if_supported` rather than `flag` for setting `-std=c++11`

Fixes #44 
