### PR TITLE
Choose enum discriminant type based on repr attributes, suffixes, values

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -143,6 +143,7 @@ fn expand_struct(strct: &Struct) -> TokenStream {
 fn expand_enum(enm: &Enum) -> TokenStream {
     let ident = &enm.ident;
     let doc = &enm.doc;
+    let repr = enm.repr;
     let variants = enm.variants.iter().map(|variant| {
         let variant_ident = &variant.ident;
         let discriminant = &variant.discriminant;
@@ -155,7 +156,7 @@ fn expand_enum(enm: &Enum) -> TokenStream {
         #[derive(Copy, Clone, PartialEq, Eq)]
         #[repr(transparent)]
         pub struct #ident {
-            pub repr: u32,
+            pub repr: #repr,
         }
 
         #[allow(non_upper_case_globals)]

--- a/syntax/atom.rs
+++ b/syntax/atom.rs
@@ -23,8 +23,12 @@ pub enum Atom {
 
 impl Atom {
     pub fn from(ident: &Ident) -> Option<Self> {
+        Self::from_str(ident.to_string().as_str())
+    }
+
+    pub fn from_str(s: &str) -> Option<Self> {
         use self::Atom::*;
-        match ident.to_string().as_str() {
+        match s {
             "bool" => Some(Bool),
             "u8" => Some(U8),
             "u16" => Some(U16),

--- a/syntax/discriminant.rs
+++ b/syntax/discriminant.rs
@@ -1,0 +1,99 @@
+use proc_macro2::{Literal, Span, TokenStream};
+use quote::ToTokens;
+use std::collections::HashSet;
+use std::fmt::{self, Display};
+use std::str::FromStr;
+use syn::{Error, Expr, Lit, Result};
+
+pub struct DiscriminantSet {
+    values: HashSet<Discriminant>,
+    previous: Option<Discriminant>,
+}
+
+#[derive(Copy, Clone, Hash, Eq, PartialEq)]
+pub struct Discriminant {
+    magnitude: u32,
+}
+
+impl DiscriminantSet {
+    pub fn new() -> Self {
+        DiscriminantSet {
+            values: HashSet::new(),
+            previous: None,
+        }
+    }
+
+    pub fn insert(&mut self, expr: &Expr) -> Result<Discriminant> {
+        let discriminant = expr_to_discriminant(expr)?;
+        insert(self, discriminant)
+    }
+
+    pub fn insert_next(&mut self) -> Result<Discriminant> {
+        let discriminant = match self.previous {
+            None => Discriminant::zero(),
+            Some(mut discriminant) => {
+                if discriminant.magnitude == u32::MAX {
+                    let msg = format!("discriminant overflow on value after {}", u32::MAX);
+                    return Err(Error::new(Span::call_site(), msg));
+                }
+                discriminant.magnitude += 1;
+                discriminant
+            }
+        };
+        insert(self, discriminant)
+    }
+}
+
+fn expr_to_discriminant(expr: &Expr) -> Result<Discriminant> {
+    if let Expr::Lit(expr) = expr {
+        if let Lit::Int(lit) = &expr.lit {
+            return lit.base10_parse::<Discriminant>();
+        }
+    }
+    Err(Error::new_spanned(
+        expr,
+        "enums with non-integer literal discriminants are not supported yet",
+    ))
+}
+
+fn insert(set: &mut DiscriminantSet, discriminant: Discriminant) -> Result<Discriminant> {
+    if set.values.insert(discriminant) {
+        set.previous = Some(discriminant);
+        Ok(discriminant)
+    } else {
+        let msg = format!("discriminant value `{}` already exists", discriminant);
+        Err(Error::new(Span::call_site(), msg))
+    }
+}
+
+impl Discriminant {
+    fn zero() -> Self {
+        Discriminant { magnitude: 0 }
+    }
+}
+
+impl Display for Discriminant {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&self.magnitude, f)
+    }
+}
+
+impl ToTokens for Discriminant {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        Literal::u32_unsuffixed(self.magnitude).to_tokens(tokens);
+    }
+}
+
+impl FromStr for Discriminant {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s.parse::<u32>() {
+            Ok(magnitude) => Ok(Discriminant { magnitude }),
+            Err(_) => Err(Error::new(
+                Span::call_site(),
+                "discriminant value outside of supported range",
+            )),
+        }
+    }
+}

--- a/syntax/discriminant.rs
+++ b/syntax/discriminant.rs
@@ -16,7 +16,7 @@ pub struct DiscriminantSet {
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Discriminant {
     negative: bool,
-    magnitude: u32,
+    magnitude: u64,
 }
 
 impl DiscriminantSet {
@@ -52,8 +52,8 @@ impl DiscriminantSet {
                 discriminant
             }
             Some(mut discriminant) => {
-                if discriminant.magnitude == u32::MAX {
-                    let msg = format!("discriminant overflow on value after {}", u32::MAX);
+                if discriminant.magnitude == u64::MAX {
+                    let msg = format!("discriminant overflow on value after {}", u64::MAX);
                     return Err(Error::new(Span::call_site(), msg));
                 }
                 discriminant.magnitude += 1;
@@ -139,22 +139,22 @@ impl Discriminant {
         }
     }
 
-    const fn pos(u: u32) -> Self {
+    const fn pos(u: u64) -> Self {
         Discriminant {
             negative: false,
             magnitude: u,
         }
     }
 
-    const fn neg(i: i32) -> Self {
+    const fn neg(i: i64) -> Self {
         Discriminant {
             negative: i < 0,
-            // This is `i.abs() as u32` but without overflow on MIN. Uses the
+            // This is `i.abs() as u64` but without overflow on MIN. Uses the
             // fact that MIN.wrapping_abs() wraps back to MIN whose binary
-            // representation is 1<<31, and thus the `as u32` conversion
-            // produces 1<<31 too which happens to be the correct unsigned
+            // representation is 1<<63, and thus the `as u64` conversion
+            // produces 1<<63 too which happens to be the correct unsigned
             // magnitude.
-            magnitude: i.wrapping_abs() as u32,
+            magnitude: i.wrapping_abs() as u64,
         }
     }
 }
@@ -173,7 +173,7 @@ impl ToTokens for Discriminant {
         if self.negative {
             Token![-](Span::call_site()).to_tokens(tokens);
         }
-        Literal::u32_unsuffixed(self.magnitude).to_tokens(tokens);
+        Literal::u64_unsuffixed(self.magnitude).to_tokens(tokens);
     }
 }
 
@@ -185,7 +185,7 @@ impl FromStr for Discriminant {
         if negative {
             s = &s[1..];
         }
-        match s.parse::<u32>() {
+        match s.parse::<u64>() {
             Ok(magnitude) => Ok(Discriminant {
                 negative,
                 magnitude,
@@ -235,35 +235,45 @@ struct Bounds {
     max: Discriminant,
 }
 
-const BOUNDS: [Bounds; 6] = [
+const BOUNDS: [Bounds; 8] = [
     Bounds {
         repr: U8,
         min: Discriminant::zero(),
-        max: Discriminant::pos(u8::MAX as u32),
+        max: Discriminant::pos(u8::MAX as u64),
     },
     Bounds {
         repr: I8,
-        min: Discriminant::neg(i8::MIN as i32),
-        max: Discriminant::pos(i8::MAX as u32),
+        min: Discriminant::neg(i8::MIN as i64),
+        max: Discriminant::pos(i8::MAX as u64),
     },
     Bounds {
         repr: U16,
         min: Discriminant::zero(),
-        max: Discriminant::pos(u16::MAX as u32),
+        max: Discriminant::pos(u16::MAX as u64),
     },
     Bounds {
         repr: I16,
-        min: Discriminant::neg(i16::MIN as i32),
-        max: Discriminant::pos(i16::MAX as u32),
+        min: Discriminant::neg(i16::MIN as i64),
+        max: Discriminant::pos(i16::MAX as u64),
     },
     Bounds {
         repr: U32,
         min: Discriminant::zero(),
-        max: Discriminant::pos(u32::MAX),
+        max: Discriminant::pos(u32::MAX as u64),
     },
     Bounds {
         repr: I32,
-        min: Discriminant::neg(i32::MIN),
-        max: Discriminant::pos(i32::MAX as u32),
+        min: Discriminant::neg(i32::MIN as i64),
+        max: Discriminant::pos(i32::MAX as u64),
+    },
+    Bounds {
+        repr: U64,
+        min: Discriminant::zero(),
+        max: Discriminant::pos(u64::MAX),
+    },
+    Bounds {
+        repr: I64,
+        min: Discriminant::neg(i64::MIN),
+        max: Discriminant::pos(i64::MAX as u64),
     },
 ];

--- a/syntax/discriminant.rs
+++ b/syntax/discriminant.rs
@@ -100,6 +100,21 @@ fn expr_to_discriminant(expr: &Expr) -> Result<(Discriminant, Option<Atom>)> {
 }
 
 fn insert(set: &mut DiscriminantSet, discriminant: Discriminant) -> Result<Discriminant> {
+    if let Some(expected_repr) = set.repr {
+        for bounds in &BOUNDS {
+            if bounds.repr != expected_repr {
+                continue;
+            }
+            if bounds.min <= discriminant && discriminant <= bounds.max {
+                break;
+            }
+            let msg = format!(
+                "discriminant value `{}` is outside the limits of {}",
+                discriminant, expected_repr,
+            );
+            return Err(Error::new(Span::call_site(), msg));
+        }
+    }
     if set.values.insert(discriminant) {
         set.previous = Some(discriminant);
         Ok(discriminant)

--- a/syntax/discriminant.rs
+++ b/syntax/discriminant.rs
@@ -5,6 +5,7 @@ use std::cmp::Ordering;
 use std::collections::BTreeSet;
 use std::fmt::{self, Display};
 use std::str::FromStr;
+use std::u64;
 use syn::{Error, Expr, Lit, Result, Token, UnOp};
 
 pub struct DiscriminantSet {
@@ -239,41 +240,41 @@ const BOUNDS: [Bounds; 8] = [
     Bounds {
         repr: U8,
         min: Discriminant::zero(),
-        max: Discriminant::pos(u8::MAX as u64),
+        max: Discriminant::pos(std::u8::MAX as u64),
     },
     Bounds {
         repr: I8,
-        min: Discriminant::neg(i8::MIN as i64),
-        max: Discriminant::pos(i8::MAX as u64),
+        min: Discriminant::neg(std::i8::MIN as i64),
+        max: Discriminant::pos(std::i8::MAX as u64),
     },
     Bounds {
         repr: U16,
         min: Discriminant::zero(),
-        max: Discriminant::pos(u16::MAX as u64),
+        max: Discriminant::pos(std::u16::MAX as u64),
     },
     Bounds {
         repr: I16,
-        min: Discriminant::neg(i16::MIN as i64),
-        max: Discriminant::pos(i16::MAX as u64),
+        min: Discriminant::neg(std::i16::MIN as i64),
+        max: Discriminant::pos(std::i16::MAX as u64),
     },
     Bounds {
         repr: U32,
         min: Discriminant::zero(),
-        max: Discriminant::pos(u32::MAX as u64),
+        max: Discriminant::pos(std::u32::MAX as u64),
     },
     Bounds {
         repr: I32,
-        min: Discriminant::neg(i32::MIN as i64),
-        max: Discriminant::pos(i32::MAX as u64),
+        min: Discriminant::neg(std::i32::MIN as i64),
+        max: Discriminant::pos(std::i32::MAX as u64),
     },
     Bounds {
         repr: U64,
         min: Discriminant::zero(),
-        max: Discriminant::pos(u64::MAX),
+        max: Discriminant::pos(std::u64::MAX),
     },
     Bounds {
         repr: I64,
-        min: Discriminant::neg(i64::MIN),
-        max: Discriminant::pos(i64::MAX as u64),
+        min: Discriminant::neg(std::i64::MIN),
+        max: Discriminant::pos(std::i64::MAX as u64),
     },
 ];

--- a/syntax/discriminant.rs
+++ b/syntax/discriminant.rs
@@ -20,9 +20,9 @@ pub struct Discriminant {
 }
 
 impl DiscriminantSet {
-    pub fn new() -> Self {
+    pub fn new(repr: Option<Atom>) -> Self {
         DiscriminantSet {
-            repr: None,
+            repr,
             values: BTreeSet::new(),
             previous: None,
         }

--- a/syntax/discriminant.rs
+++ b/syntax/discriminant.rs
@@ -30,7 +30,14 @@ impl DiscriminantSet {
 
     pub fn insert(&mut self, expr: &Expr) -> Result<Discriminant> {
         let (discriminant, repr) = expr_to_discriminant(expr)?;
-        self.repr = self.repr.or(repr);
+        match (self.repr, repr) {
+            (None, _) => self.repr = repr,
+            (Some(prev), Some(repr)) if prev != repr => {
+                let msg = format!("expected {}, found {}", prev, repr);
+                return Err(Error::new(Span::call_site(), msg));
+            }
+            _ => {}
+        }
         insert(self, discriminant)
     }
 

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -63,6 +63,7 @@ pub struct Enum {
     pub ident: Ident,
     pub brace_token: Brace,
     pub variants: Vec<Variant>,
+    pub repr: Atom,
 }
 
 pub struct ExternFn {

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -4,6 +4,7 @@ pub mod atom;
 mod attrs;
 pub mod check;
 mod derive;
+mod discriminant;
 mod doc;
 pub mod error;
 pub mod ident;
@@ -17,6 +18,7 @@ pub mod symbol;
 mod tokens;
 pub mod types;
 
+use self::discriminant::Discriminant;
 use self::parse::kw;
 use proc_macro2::{Ident, Span};
 use syn::punctuated::Punctuated;
@@ -106,7 +108,7 @@ pub struct Receiver {
 
 pub struct Variant {
     pub ident: Ident,
-    pub discriminant: u32,
+    pub discriminant: Discriminant,
 }
 
 pub enum Type {

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -23,7 +23,7 @@ use self::parse::kw;
 use proc_macro2::{Ident, Span};
 use syn::punctuated::Punctuated;
 use syn::token::{Brace, Bracket, Paren};
-use syn::{Lifetime, LitStr, Token, Type as RustType};
+use syn::{Expr, Lifetime, LitStr, Token, Type as RustType};
 
 pub use self::atom::Atom;
 pub use self::derive::Derive;
@@ -109,6 +109,7 @@ pub struct Receiver {
 pub struct Variant {
     pub ident: Ident,
     pub discriminant: Discriminant,
+    pub expr: Option<Expr>,
 }
 
 pub enum Type {

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -60,6 +60,7 @@ fn parse_struct(cx: &mut Errors, item: ItemStruct) -> Result<Api> {
         attrs::Parser {
             doc: Some(&mut doc),
             derives: Some(&mut derives),
+            ..Default::default()
         },
     );
 
@@ -103,10 +104,20 @@ fn parse_enum(cx: &mut Errors, item: ItemEnum) -> Result<Api> {
         ));
     }
 
-    let doc = attrs::parse_doc(cx, &item.attrs);
+    let mut doc = Doc::new();
+    let mut repr = None;
+    attrs::parse(
+        cx,
+        &item.attrs,
+        attrs::Parser {
+            doc: Some(&mut doc),
+            repr: Some(&mut repr),
+            ..Default::default()
+        },
+    );
 
     let mut variants = Vec::new();
-    let mut discriminants = DiscriminantSet::new();
+    let mut discriminants = DiscriminantSet::new(repr);
     for variant in item.variants {
         match variant.fields {
             Fields::Unit => {}

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -126,9 +126,11 @@ fn parse_enum(cx: &mut Errors, item: ItemEnum) -> Result<Api> {
             Ok(discriminant) => discriminant,
             Err(err) => return Err(Error::new_spanned(variant, err)),
         };
+        let expr = variant.discriminant.map(|(_, expr)| expr);
         variants.push(Variant {
             ident: variant.ident,
             discriminant,
+            expr,
         });
     }
 

--- a/syntax/tokens.rs
+++ b/syntax/tokens.rs
@@ -1,6 +1,6 @@
 use crate::syntax::atom::Atom::*;
 use crate::syntax::{
-    Derive, Enum, ExternFn, ExternType, Receiver, Ref, Signature, Slice, Struct, Ty1, Type,
+    Atom, Derive, Enum, ExternFn, ExternType, Receiver, Ref, Signature, Slice, Struct, Ty1, Type,
     TypeAlias, Var,
 };
 use proc_macro2::{Ident, Span, TokenStream};
@@ -70,6 +70,12 @@ impl ToTokens for Slice {
 }
 
 impl ToTokens for Derive {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        Ident::new(self.as_ref(), Span::call_site()).to_tokens(tokens);
+    }
+}
+
+impl ToTokens for Atom {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         Ident::new(self.as_ref(), Span::call_site()).to_tokens(tokens);
     }

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -44,7 +44,7 @@ pub mod ffi {
         fn c_return_ref_rust_vec(c: &C) -> &Vec<u8>;
         fn c_return_identity(_: usize) -> usize;
         fn c_return_sum(_: usize, _: usize) -> usize;
-        fn c_return_enum(n: u32) -> Enum;
+        fn c_return_enum(n: u16) -> Enum;
 
         fn c_take_primitive(n: usize);
         fn c_take_shared(shared: Shared);
@@ -89,6 +89,7 @@ pub mod ffi {
         type COwnedEnum;
     }
 
+    #[repr(u32)]
     enum COwnedEnum {
         CVal1,
         CVal2,

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -107,10 +107,10 @@ size_t c_return_identity(size_t n) { return n; }
 
 size_t c_return_sum(size_t n1, size_t n2) { return n1 + n2; }
 
-Enum c_return_enum(uint32_t n) {
-  if (n <= static_cast<uint32_t>(Enum::AVal)) {
+Enum c_return_enum(uint16_t n) {
+  if (n <= static_cast<uint16_t>(Enum::AVal)) {
     return Enum::AVal;
-  } else if (n <= static_cast<uint32_t>(Enum::BVal)) {
+  } else if (n <= static_cast<uint16_t>(Enum::BVal)) {
     return Enum::BVal;
   } else {
     return Enum::CVal;

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -7,7 +7,7 @@ namespace tests {
 
 struct R;
 struct Shared;
-enum class Enum : uint32_t;
+enum class Enum : uint16_t;
 
 class C {
 public:
@@ -46,7 +46,7 @@ rust::Vec<uint8_t> c_return_rust_vec();
 const rust::Vec<uint8_t> &c_return_ref_rust_vec(const C &c);
 size_t c_return_identity(size_t n);
 size_t c_return_sum(size_t n1, size_t n2);
-Enum c_return_enum(uint32_t n);
+Enum c_return_enum(uint16_t n);
 
 void c_take_primitive(size_t n);
 void c_take_shared(Shared shared);

--- a/tests/ui/enum_inconsistent.rs
+++ b/tests/ui/enum_inconsistent.rs
@@ -1,0 +1,9 @@
+#[cxx::bridge]
+mod ffi {
+    enum Bad {
+        A = 1u16,
+        B = 2i64,
+    }
+}
+
+fn main() {}

--- a/tests/ui/enum_inconsistent.stderr
+++ b/tests/ui/enum_inconsistent.stderr
@@ -1,0 +1,5 @@
+error: expected u16, found i64
+ --> $DIR/enum_inconsistent.rs:5:9
+  |
+5 |         B = 2i64,
+  |         ^^^^^^^^

--- a/tests/ui/enum_match_without_wildcard.stderr
+++ b/tests/ui/enum_match_without_wildcard.stderr
@@ -1,11 +1,11 @@
-error[E0004]: non-exhaustive patterns: `A { repr: 2u32..=std::u32::MAX }` not covered
+error[E0004]: non-exhaustive patterns: `A { repr: 2u8..=std::u8::MAX }` not covered
   --> $DIR/enum_match_without_wildcard.rs:12:11
    |
 1  | #[cxx::bridge]
    | -------------- `ffi::A` defined here
 ...
 12 |     match a {
-   |           ^ pattern `A { repr: 2u32..=std::u32::MAX }` not covered
+   |           ^ pattern `A { repr: 2u8..=std::u8::MAX }` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `ffi::A`

--- a/tests/ui/enum_out_of_bounds.rs
+++ b/tests/ui/enum_out_of_bounds.rs
@@ -1,0 +1,9 @@
+#[cxx::bridge]
+mod ffi {
+    #[repr(u32)]
+    enum Bad {
+        A = 0xFFFF_FFFF_FFFF_FFFF,
+    }
+}
+
+fn main() {}

--- a/tests/ui/enum_out_of_bounds.stderr
+++ b/tests/ui/enum_out_of_bounds.stderr
@@ -1,0 +1,5 @@
+error: discriminant value `18446744073709551615` is outside the limits of u32
+ --> $DIR/enum_out_of_bounds.rs:5:9
+  |
+5 |         A = 0xFFFF_FFFF_FFFF_FFFF,
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/enum_overflows.rs
+++ b/tests/ui/enum_overflows.rs
@@ -1,14 +1,14 @@
 #[cxx::bridge]
 mod ffi {
     enum Good1 {
-        A = 0xffffffff,
+        A = 0xFFFF_FFFF_FFFF_FFFF,
     }
     enum Good2 {
-        B = 0xffffffff,
+        B = 0xFFFF_FFFF_FFFF_FFFF,
         C = 2020,
     }
     enum Bad {
-        D = 0xfffffffe,
+        D = 0xFFFF_FFFF_FFFF_FFFE,
         E,
         F,
     }

--- a/tests/ui/enum_overflows.stderr
+++ b/tests/ui/enum_overflows.stderr
@@ -1,4 +1,4 @@
-error: discriminant overflow on value after 4294967295
+error: discriminant overflow on value after 18446744073709551615
   --> $DIR/enum_overflows.rs:13:9
    |
 13 |         F,

--- a/tests/ui/enum_unsatisfiable.rs
+++ b/tests/ui/enum_unsatisfiable.rs
@@ -1,0 +1,9 @@
+#[cxx::bridge]
+mod ffi {
+    enum Bad {
+        A = -0xFFFF_FFFF_FFFF_FFFF,
+        B = 0xFFFF_FFFF_FFFF_FFFF,
+    }
+}
+
+fn main() {}

--- a/tests/ui/enum_unsatisfiable.stderr
+++ b/tests/ui/enum_unsatisfiable.stderr
@@ -1,0 +1,8 @@
+error: these discriminant values do not fit in any supported enum repr type
+ --> $DIR/enum_unsatisfiable.rs:3:5
+  |
+3 | /     enum Bad {
+4 | |         A = -0xFFFF_FFFF_FFFF_FFFF,
+5 | |         B = 0xFFFF_FFFF_FFFF_FFFF,
+6 | |     }
+  | |_____^


### PR DESCRIPTION
Fixes #175.

In order, the choice of repr is based on:

- **#\[repr(...)\] attribute**

    ```rust
    #[repr(u16)]
    enum E {  //:u16
        A,
        B,
    }
    ```

- otherwise, **integer suffix**

    ```rust
    enum E {  //:isize
        A = 0isize,
        B,
    }
    ```

- otherwise, **range of discriminant values**

    The first of `u8`, `i8`, `u16`, `i16`, `u32`, `i32`, `u64`, `i64` that can fit all of the values.

    ```rust
    enum E {  //:i16
        A = -1,
        B = 2020,
    }
    ```

FYI @jgalenson 