### PR TITLE
Fix permission denied failure in bazel CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
           wget -q -O install.sh https://github.com/bazelbuild/bazel/releases/download/2.1.1/bazel-2.1.1-installer-linux-x86_64.sh
           chmod +x install.sh
           ./install.sh --user
+          echo ::add-path::$HOME/bin
       - name: Vendor dependencies
         run: |
           cp third-party/Cargo.lock .


### PR DESCRIPTION
Fixes #199. I guess the default ordering of $PATH was changed.