### PR TITLE
Parse include!(<path/to/bracketed>)

### DIFF
--- a/gen/src/include.rs
+++ b/gen/src/include.rs
@@ -47,8 +47,8 @@ impl Includes {
         Includes::default()
     }
 
-    pub fn insert(&mut self, include: String) {
-        self.custom.push(include);
+    pub fn insert(&mut self, include: impl AsRef<str>) {
+        self.custom.push(include.as_ref().to_owned());
     }
 }
 

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -24,7 +24,7 @@ pub(super) fn gen(
     out.include.extend(opt.include);
     for api in apis {
         if let Api::Include(include) = api {
-            out.include.insert(include.value());
+            out.include.insert(include);
         }
     }
 

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -23,7 +23,7 @@ use self::parse::kw;
 use proc_macro2::{Ident, Span};
 use syn::punctuated::Punctuated;
 use syn::token::{Brace, Bracket, Paren};
-use syn::{Expr, Lifetime, LitStr, Token, Type as RustType};
+use syn::{Expr, Lifetime, Token, Type as RustType};
 
 pub use self::atom::Atom;
 pub use self::derive::Derive;
@@ -32,7 +32,7 @@ pub use self::parse::parse_items;
 pub use self::types::Types;
 
 pub enum Api {
-    Include(LitStr),
+    Include(String),
     Struct(Struct),
     Enum(Enum),
     CxxType(ExternType),

--- a/tests/ui/include.rs
+++ b/tests/ui/include.rs
@@ -1,0 +1,12 @@
+#[cxx::bridge]
+mod ffi {
+    extern "C" {
+        include!("path/to" what);
+        include!(<path/to> what);
+        include!(<path/to);
+        include!(<path[to]>);
+        include!(...);
+    }
+}
+
+fn main() {}

--- a/tests/ui/include.stderr
+++ b/tests/ui/include.stderr
@@ -1,0 +1,29 @@
+error: unexpected token
+ --> $DIR/include.rs:4:28
+  |
+4 |         include!("path/to" what);
+  |                            ^^^^
+
+error: unexpected token
+ --> $DIR/include.rs:5:28
+  |
+5 |         include!(<path/to> what);
+  |                            ^^^^
+
+error: expected `>`
+ --> $DIR/include.rs:6:17
+  |
+6 |         include!(<path/to);
+  |                 ^^^^^^^^^^
+
+error: unexpected token in include path
+ --> $DIR/include.rs:7:23
+  |
+7 |         include!(<path[to]>);
+  |                       ^^^^
+
+error: expected "quoted/path/to" or <bracketed/path/to>
+ --> $DIR/include.rs:8:18
+  |
+8 |         include!(...);
+  |                  ^^^


### PR DESCRIPTION
For example:

```rust
#[cxx::bridge]
mod ffi {
    extern "C" {
        include!("path/to/quoted");
        include!(<path/to/bracketed>);

        ...
    }
}
```

Emitted as:

```cpp
#include "path/to/quoted"
#include <path/to/bracketed>
```