### PR TITLE
Add cargo cfgs for opt in to newer standards

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,11 @@ exclude = ["/demo-cxx", "/gen", "/syntax", "/third-party"]
 keywords = ["ffi"]
 categories = ["development-tools::ffi", "api-bindings"]
 
+[features]
+default = [] # c++11
+"c++14" = []
+"c++17" = []
+
 [dependencies]
 cxxbridge-macro = { version = "=0.3.2", path = "macro" }
 link-cplusplus = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,13 @@ fn main() {
         .file("src/cxx.cc")
         .cpp(true)
         .cpp_link_stdlib(None) // linked via link-cplusplus crate
-        .flag_if_supported("-std=c++11")
+        .flag_if_supported(if cfg!(feature = "c++17") {
+            "-std=c++17"
+        } else if cfg!(feature = "c++14") {
+            "-std=c++14"
+        } else {
+            "-std=c++11"
+        })
         .compile("cxxbridge03");
     println!("cargo:rerun-if-changed=src/cxx.cc");
     println!("cargo:rerun-if-changed=include/cxx.h");


### PR DESCRIPTION
As described in https://github.com/dtolnay/cxx/pull/80#issuecomment-605794135. Currently unused, but will be needed when integrating std::optional or std::string_view support.

```toml
# Cargo.toml

[dependencies]
cxx = { version = "0.3", features = ["c++17"] }
```