### PR TITLE
Fix for when std::os::raw::c_char is u8 (armv7)

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -141,7 +141,7 @@ fn test_c_call_r() {
         }
         let failure = unsafe { cxx_run_test() };
         if !failure.is_null() {
-            let msg = unsafe { CStr::from_ptr(failure) };
+            let msg = unsafe { CStr::from_ptr(failure as *mut std::os::raw::c_char) };
             eprintln!("{}", msg.to_string_lossy());
         }
     }


### PR DESCRIPTION
On some targets (e.g. armv7-unknown-linux-gnueabihf) `std::os::raw::c_char` is defined as `u8` instead of `i8`.   This change fixes the compile error that results.

The docs (https://doc.rust-lang.org/std/os/raw/type.c_char.html) say that `std::os::raw::c_char` will always be either `u8` or `i8`.