### PR TITLE
Fix issue with indirect return for C++ member function w/no args

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -424,7 +424,7 @@ fn write_cxx_function_shim(out: &mut OutFile, efn: &ExternFn, types: &Types) {
     }
     let indirect_return = indirect_return(efn, types);
     if indirect_return {
-        if !efn.args.is_empty() {
+        if !efn.args.is_empty() || efn.receiver.is_some() {
             write!(out, ", ");
         }
         write_indirect_return_type_space(out, efn.ret.as_ref().unwrap());

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Debug, Display};
 
 /// Exception thrown from an `extern "C"` function.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Exception {
     pub(crate) what: Box<str>,
 }

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -83,6 +83,8 @@ pub mod ffi {
         fn set(self: &mut C, n: usize) -> usize;
         fn get2(&self) -> usize;
         fn set2(&mut self, n: usize) -> usize;
+        fn set_succeed(&mut self, n: usize) -> Result<usize>;
+        fn get_fail(&mut self) -> Result<usize>;
     }
 
     extern "C" {

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -28,6 +28,10 @@ size_t C::set2(size_t n) {
   return this->n;
 }
 
+size_t C::set_succeed(size_t n) { return this->set2(n); }
+
+size_t C::get_fail() { throw std::runtime_error("unimplemented"); }
+
 const std::vector<uint8_t> &C::get_v() const { return this->v; }
 
 size_t c_return_primitive() { return 2020; }

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -16,6 +16,8 @@ public:
   size_t set(size_t n);
   size_t get2() const;
   size_t set2(size_t n);
+  size_t set_succeed(size_t n);
+  size_t get_fail();
   const std::vector<uint8_t> &get_v() const;
 
 private:

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -158,7 +158,7 @@ fn test_c_method_calls() {
     assert_eq!(2021, unique_ptr.get());
     assert_eq!(old_value, unique_ptr.set2(old_value));
     assert_eq!(old_value, unique_ptr.get2());
-    assert_eq!(Ok(old_value), unique_ptr.set_succeed(2022));
+    assert_eq!(Ok(2022), unique_ptr.set_succeed(2022));
     assert!(unique_ptr.get_fail().is_err());
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -157,7 +157,9 @@ fn test_c_method_calls() {
     assert_eq!(2021, unique_ptr.set(2021));
     assert_eq!(2021, unique_ptr.get());
     assert_eq!(old_value, unique_ptr.set2(old_value));
-    assert_eq!(old_value, unique_ptr.get2())
+    assert_eq!(old_value, unique_ptr.get2());
+    assert_eq!(Ok(old_value), unique_ptr.set_succeed(2022));
+    assert!(unique_ptr.get_fail().is_err());
 }
 
 #[test]


### PR DESCRIPTION
A FFI C++ member function (i.e. function w/receiver) with no args and an indirect return (i.e. one that returns a `Result<T>`) was generating a function signature with a missing comma between the self arg and the indirect return parameter.

The `get_fail()` test member function will trigger this error.

The one-liner fix is in `gen/src/write.rs`