### PR TITLE
Write generated bridge files to OUT_DIR as-is

### DIFF
--- a/gen/build/src/paths.rs
+++ b/gen/build/src/paths.rs
@@ -58,12 +58,11 @@ fn relative_to_parent_of_target_dir(original: &Path) -> Result<PathBuf> {
 }
 
 pub(crate) fn out_with_extension(path: &Path, ext: &str) -> Result<PathBuf> {
-    let mut file_name = path.file_name().unwrap().to_owned();
-    file_name.push(ext);
-
     let out_dir = out_dir()?;
-    let rel = relative_to_parent_of_target_dir(path)?;
-    Ok(out_dir.join(rel).with_file_name(file_name))
+    let mut out = out_dir.join(path).as_os_str().to_owned();
+    out.push(ext);
+
+    Ok(out.into())
 }
 
 pub(crate) fn include_dir() -> Result<PathBuf> {


### PR DESCRIPTION
Possible way to fix #213. Currently breaks things, if this is something that might make sense I'm happy to look into making it work.

This requires consumers to add

```rust
let out_dir = env::var("OUT_DIR").unwrap();
// ...
cxx.include(out_dir);
```

to their build script.