### PR TITLE
cxx_name attribute - function aliases, import/export static methods, …

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -353,7 +353,7 @@ fn write_struct_with_methods(out: &mut OutFile, ety: &ExternType, methods: &[&Ex
                 write!(out, "static ");
             }
             if let Some(name) = &cxx_side.name {
-                local_name = name.clone();
+                local_name = name.to_string();
             }
         }
         write_rust_function_shim_decl(out, &local_name, sig, false);
@@ -465,8 +465,8 @@ fn write_cxx_function_shim(out: &mut OutFile, efn: &ExternFn, types: &Types) {
     write!(out, " = ");
     let name = efn.cxx_side
         .as_ref()
-        .and_then(|s| s.name.as_ref().map(|n| n.clone()))
-        .unwrap_or_else(|| efn.ident.to_string());
+        .and_then(|s| s.name.as_ref())
+        .unwrap_or_else(|| &efn.ident);
     if let Some(CxxSide { class: Some(class @ _), is_static: true, .. }) = &efn.cxx_side {
         write!(out, "&{}::{}", class, name);
     } else {
@@ -639,13 +639,12 @@ fn write_rust_function_shim(out: &mut OutFile, efn: &ExternFn, types: &Types) {
         is_static = cxx_side.is_static;
         let name = cxx_side.name
             .as_ref()
-            .map(|n| n.clone())
-            .unwrap_or_else(|| efn.ident.to_string());
+            .unwrap_or_else(|| &efn.ident);
         match &efn.sig.receiver {
             None => cxx_side.class
                 .as_ref()
                 .map(|c| format!("{}::{}", c, name))
-                .unwrap_or_else(|| name),
+                .unwrap_or_else(|| name.to_string()),
             Some(receiver) => format!("{}::{}", receiver.ty, name),
         }
     } else {

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -501,8 +501,8 @@ fn expand_rust_function_shim_impl(
             None => {
                 efn.cxx_side
                     .as_ref()
-                    .and_then(|s| Some((s.class.as_ref()?, s.is_static)))
-                    .map(|(class, _)| quote!(#class::#ident))
+                    .and_then(|s| s.class.as_ref())
+                    .map(|class| quote!(#class::#ident))
                     .unwrap_or_else(|| quote!(super::#ident))
             }
             Some(receiver) => {

--- a/syntax/attrs.rs
+++ b/syntax/attrs.rs
@@ -58,8 +58,8 @@ pub(super) fn parse(cx: &mut Errors, attrs: &[Attribute], mut parser: Parser) {
                 }
                 Err(err) => return cx.push(err),
             }
-        } else if attr.path.is_ident("cxx_side") {
-            match attr.parse_args_with(|input: ParseStream| input.parse::<CxxSide>()) {
+        } else if attr.path.is_ident("cxx_name") {
+            match (|input: ParseStream| input.parse::<CxxSide>()).parse2(attr.tokens.clone()) {
                 Ok(attr) => {
                     if let Some(cxx_side) = &mut parser.cxx_side {
                         **cxx_side = Some(attr);

--- a/syntax/impls.rs
+++ b/syntax/impls.rs
@@ -28,9 +28,11 @@ impl Parse for CxxSide {
             2 => Ok(CxxSide {
                 name: name.segments.last().map(|p| p.ident.clone()),
                 class: name.segments.first().map(|p| p.ident.clone()),
-                is_static: true
             }),
-            1 => Ok(CxxSide { name: name.segments.first().map(|p| p.ident.clone()), .. Default::default() }),
+            1 => Ok(CxxSide { 
+                name: name.segments.first().map(|p| p.ident.clone()), 
+                class: None,
+            }),
             _ => Err(Error::new(begin.span(), "incorrect name")),
         }
     }

--- a/syntax/impls.rs
+++ b/syntax/impls.rs
@@ -52,7 +52,7 @@ impl Parse for CxxSide {
                 if name.contains("::") {
                     let parts: Vec<&str> = name.split("::").collect();
                     if parts.len() > 2 {
-                        return Err(Error::new(begin.span(), "namespaces and subclasses is not supported yet"));
+                        return Err(Error::new(begin.span(), "namespaces and subclasses are not supported yet"));
                     }
                     result.name = parts.last().map(|p| p.to_string());
                     result.class = parts.first().map(|p| Ident::new(p, Span::call_site()));

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -79,7 +79,6 @@ pub struct ExternFn {
 pub struct CxxSide {
     pub name: Option<Ident>,
     pub class: Option<Ident>,
-    pub is_static: bool,
 }
 
 pub struct TypeAlias {

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -75,14 +75,9 @@ pub struct ExternFn {
     pub semi_token: Token![;],
 }
 
-pub enum CxxSideItem {
-    Name(String),
-    IsStatic,
-}
-
 #[derive(Debug, Default)]
 pub struct CxxSide {
-    pub name: Option<String>,
+    pub name: Option<Ident>,
     pub class: Option<Ident>,
     pub is_static: bool,
 }

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -77,7 +77,6 @@ pub struct ExternFn {
 
 pub enum CxxSideItem {
     Name(String),
-    Class(Ident),
     IsStatic,
 }
 

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -70,8 +70,22 @@ pub struct ExternFn {
     pub lang: Lang,
     pub doc: Doc,
     pub ident: Ident,
+    pub cxx_side: Option<CxxSide>,
     pub sig: Signature,
     pub semi_token: Token![;],
+}
+
+pub enum CxxSideItem {
+    Name(String),
+    Class(Ident),
+    IsStatic,
+}
+
+#[derive(Debug, Default)]
+pub struct CxxSide {
+    pub name: Option<String>,
+    pub class: Option<Ident>,
+    pub is_static: bool,
 }
 
 pub struct TypeAlias {

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -17,6 +17,8 @@ use syn::{
 
 pub mod kw {
     syn::custom_keyword!(Result);
+    syn::custom_keyword!(name);
+    syn::custom_keyword!(class);
 }
 
 pub fn parse_items(cx: &mut Errors, items: Vec<Item>) -> Vec<Api> {
@@ -333,11 +335,13 @@ fn parse_extern_fn(cx: &mut Errors, foreign_fn: &ForeignItemFn, lang: Lang) -> R
         Lang::Cxx => Api::CxxFunction,
         Lang::Rust => Api::RustFunction,
     };
-
+    let mut cxx_side = None;
+    attrs::parse(cx, &foreign_fn.attrs, attrs::Parser { cxx_side: Some(&mut cxx_side), ..Default::default() });
     Ok(api_function(ExternFn {
         lang,
         doc,
         ident,
+        cxx_side,
         sig: Signature {
             fn_token,
             receiver,

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -49,7 +49,7 @@ fn parse_struct(cx: &mut Errors, item: ItemStruct) -> Result<Api> {
         let span = quote!(#struct_token #ident #generics #where_clause);
         return Err(Error::new_spanned(
             span,
-            "struct with generic parameters are not supported yet",
+            "struct with generic parameters is not supported yet",
         ));
     }
 

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -18,7 +18,6 @@ use syn::{
 pub mod kw {
     syn::custom_keyword!(Result);
     syn::custom_keyword!(name);
-    syn::custom_keyword!(class);
 }
 
 pub fn parse_items(cx: &mut Errors, items: Vec<Item>) -> Vec<Api> {

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -49,7 +49,7 @@ fn parse_struct(cx: &mut Errors, item: ItemStruct) -> Result<Api> {
         let span = quote!(#struct_token #ident #generics #where_clause);
         return Err(Error::new_spanned(
             span,
-            "struct with generic parameters is not supported yet",
+            "struct with generic parameters are not supported yet",
         ));
     }
 

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -86,17 +86,17 @@ pub mod ffi {
         fn set_succeed(&mut self, n: usize) -> Result<usize>;
         fn get_fail(&mut self) -> Result<usize>;
                 
-        #[cxx_side(name = "cOverloadedMethod")]
+        #[cxx_name = "cOverloadedMethod"]
         fn i32_overloaded_method(&self, x: i32) -> String;
-        #[cxx_side(name = "cOverloadedMethod")]
+        #[cxx_name = "cOverloadedMethod"]
         fn str_overloaded_method(&self, x: &str) -> String;
         
-        #[cxx_side(name = "cOverloadedFunction")]
+        #[cxx_name = "cOverloadedFunction"]
         fn i32_overloaded_function(x: i32) -> String;
-        #[cxx_side(name = "cOverloadedFunction")]
+        #[cxx_name = "cOverloadedFunction"]
         fn str_overloaded_function(x: &str) -> String;
 
-        #[cxx_side(name = "C::cStaticMethod", static)]
+        #[cxx_name = "C::cStaticMethod"]
         fn static_method() -> String;
     }
 
@@ -150,10 +150,10 @@ pub mod ffi {
         fn get(self: &R2) -> usize;
         fn set(self: &mut R2, n: usize) -> usize;
                 
-        #[cxx_side(name = "rAliasedFunction")]
+        #[cxx_name = "rAliasedFunction"]
         fn r_aliased_function(x: i32) -> String;
                 
-        #[cxx_side(name = "R2::rStaticMethod", static)]
+        #[cxx_name = "R2::rStaticMethod"]
         fn r_static_method() -> String;
     }
 }

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -96,7 +96,7 @@ pub mod ffi {
         #[cxx_side(name = "cOverloadedFunction")]
         fn str_overloaded_function(x: &str) -> String;
 
-        #[cxx_side(name = "cStaticMethod", class = "C", static)]
+        #[cxx_side(name = "C::cStaticMethod", static)]
         fn static_method() -> String;
     }
 
@@ -153,7 +153,7 @@ pub mod ffi {
         #[cxx_side(name = "rAliasedFunction")]
         fn r_aliased_function(x: i32) -> String;
                 
-        #[cxx_side(name = "rStaticMethod", class = "R2", static)]
+        #[cxx_side(name = "R2::rStaticMethod", static)]
         fn r_static_method() -> String;
     }
 }

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -85,6 +85,19 @@ pub mod ffi {
         fn set2(&mut self, n: usize) -> usize;
         fn set_succeed(&mut self, n: usize) -> Result<usize>;
         fn get_fail(&mut self) -> Result<usize>;
+                
+        #[cxx_side(name = "cOverloadedMethod")]
+        fn i32_overloaded_method(&self, x: i32) -> String;
+        #[cxx_side(name = "cOverloadedMethod")]
+        fn str_overloaded_method(&self, x: &str) -> String;
+        
+        #[cxx_side(name = "cOverloadedFunction")]
+        fn i32_overloaded_function(x: i32) -> String;
+        #[cxx_side(name = "cOverloadedFunction")]
+        fn str_overloaded_function(x: &str) -> String;
+
+        #[cxx_side(name = "cStaticMethod", class = "C", static)]
+        fn static_method() -> String;
     }
 
     extern "C" {
@@ -136,6 +149,12 @@ pub mod ffi {
         fn r_return_r2(n: usize) -> Box<R2>;
         fn get(self: &R2) -> usize;
         fn set(self: &mut R2, n: usize) -> usize;
+                
+        #[cxx_side(name = "rAliasedFunction")]
+        fn r_aliased_function(x: i32) -> String;
+                
+        #[cxx_side(name = "rStaticMethod", class = "R2", static)]
+        fn r_static_method() -> String;
     }
 }
 
@@ -151,6 +170,10 @@ impl R2 {
     fn set(&mut self, n: usize) -> usize {
         self.0 = n;
         n
+    }
+    
+    fn r_static_method() -> String {
+        "Rust static method".into()
     }
 }
 
@@ -298,4 +321,8 @@ fn r_fail_return_primitive() -> Result<usize, Error> {
 
 fn r_return_r2(n: usize) -> Box<R2> {
     Box::new(R2(n))
+}
+
+fn r_aliased_function(x: i32) -> String {
+    x.to_string()
 }

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -296,6 +296,26 @@ extern "C" std::string *cxx_test_suite_get_unique_ptr_string() noexcept {
   return std::unique_ptr<std::string>(new std::string("2020")).release();
 }
 
+rust::String C::cOverloadedMethod(int32_t x) const {
+    return rust::String(std::to_string(x));
+}
+
+rust::String C::cOverloadedMethod(rust::Str x) const {
+    return rust::String(std::string(x));
+}
+
+rust::String C::cStaticMethod() {
+    return rust::String("C/C++ static method");
+}
+
+rust::String cOverloadedFunction(int x) {
+    return rust::String(std::to_string(x));
+}
+
+rust::String cOverloadedFunction(rust::Str x) {
+    return rust::String(std::string(x));
+}
+
 extern "C" const char *cxx_run_test() noexcept {
 #define STRINGIFY(x) #x
 #define TOSTRING(x) STRINGIFY(x)
@@ -346,6 +366,10 @@ extern "C" const char *cxx_run_test() noexcept {
   ASSERT(r2->get() == 2021);
   ASSERT(r2->set(2020) == 2020);
   ASSERT(r2->get() == 2020);
+  
+  ASSERT(std::string(rAliasedFunction(2020)) == "2020");
+
+  ASSERT(std::string(R2::rStaticMethod()) == "Rust static method");
 
   cxx_test_suite_set_correct();
   return nullptr;

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -19,6 +19,9 @@ public:
   size_t set_succeed(size_t n);
   size_t get_fail();
   const std::vector<uint8_t> &get_v() const;
+  rust::String cOverloadedMethod(int32_t x) const;
+  rust::String cOverloadedMethod(rust::Str x) const;
+  static rust::String cStaticMethod();
 
 private:
   size_t n;
@@ -83,5 +86,8 @@ rust::String c_try_return_rust_string();
 std::unique_ptr<std::string> c_try_return_unique_ptr_string();
 rust::Vec<uint8_t> c_try_return_rust_vec();
 const rust::Vec<uint8_t> &c_try_return_ref_rust_vec(const C &c);
+
+rust::String cOverloadedFunction(int32_t x);
+rust::String cOverloadedFunction(rust::Str x);
 
 } // namespace tests

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -178,3 +178,14 @@ extern "C" fn cxx_test_suite_get_box() -> *mut cxx_test_suite::R {
 unsafe extern "C" fn cxx_test_suite_r_is_correct(r: *const cxx_test_suite::R) -> bool {
     *r == 2020
 }
+
+#[test]
+fn test_cxx_side_attribute() {
+    assert_eq!("2020".to_string(), ffi::i32_overloaded_function(2020));
+    assert_eq!("2020".to_string(), ffi::str_overloaded_function("2020"));
+    let unique_ptr = ffi::c_return_unique_ptr();
+    assert_eq!("2020".to_string(), unique_ptr.i32_overloaded_method(2020));
+    assert_eq!("2020".to_string(), unique_ptr.str_overloaded_method("2020"));
+    
+    assert_eq!("C/C++ static method".to_string(), ffi::C::static_method());
+}


### PR DESCRIPTION
I found a better solution for #218: cxx_side attribute
Features:
- Renaming functions/methods in C++ and Rust
- Import overloaded functions/methods
- Export/import static methods from both sides

In the future we can add new features for this attribute: replace return type to UniquePtr/Box, implement constructors, etc.