### PR TITLE
Allow DSO export for C Rust bindings.

### DIFF
--- a/gen/cmd/src/main.rs
+++ b/gen/cmd/src/main.rs
@@ -35,6 +35,15 @@ struct Opt {
     #[structopt(long)]
     header: bool,
 
+    /// Optional annotation for implementations of C++ function
+    /// wrappers that may be exposed to Rust. You may for example
+    /// need to provide __declspec(dllexport) or
+    /// __attribute__((visibility("default"))) if Rust code from
+    /// one shared object or executable depends on these C++ functions
+    /// in another.
+    #[structopt(long)]
+    cxx_impl_annotations: Option<String>,
+
     /// Any additional headers to #include
     #[structopt(short, long)]
     include: Vec<String>,
@@ -49,6 +58,7 @@ fn main() {
 
     let gen = gen::Opt {
         include: opt.include,
+        cxx_impl_annotations: opt.cxx_impl_annotations,
     };
 
     match (opt.input, opt.header) {

--- a/gen/src/mod.rs
+++ b/gen/src/mod.rs
@@ -24,6 +24,9 @@ struct Input {
 pub(super) struct Opt {
     /// Any additional headers to #include
     pub include: Vec<String>,
+    /// Whether to set __attribute__((visibility("default")))
+    /// or similar annotations on function implementations.
+    pub cxx_impl_annotations: Option<String>,
 }
 
 pub(super) fn do_generate_bridge(path: &Path, opt: Opt) -> Vec<u8> {

--- a/gen/src/mod.rs
+++ b/gen/src/mod.rs
@@ -31,34 +31,74 @@ pub(super) struct Opt {
 
 pub(super) fn do_generate_bridge(path: &Path, opt: Opt) -> Vec<u8> {
     let header = false;
-    generate(path, opt, header)
+    generate_from_path(path, opt, header)
 }
 
 pub(super) fn do_generate_header(path: &Path, opt: Opt) -> Vec<u8> {
     let header = true;
-    generate(path, opt, header)
+    generate_from_path(path, opt, header)
 }
 
-fn generate(path: &Path, opt: Opt, header: bool) -> Vec<u8> {
+fn generate_from_path(path: &Path, opt: Opt, header: bool) -> Vec<u8> {
     let source = match fs::read_to_string(path) {
         Ok(source) => source,
         Err(err) => format_err(path, "", Error::Io(err)),
     };
-    match (|| -> Result<_> {
-        proc_macro2::fallback::force();
-        let ref mut errors = Errors::new();
-        let syntax = syn::parse_file(&source)?;
-        let bridge = find::find_bridge_mod(syntax)?;
-        let ref namespace = bridge.namespace;
-        let ref apis = syntax::parse_items(errors, bridge.module);
-        let ref types = Types::collect(errors, apis);
-        errors.propagate()?;
-        check::typecheck(errors, namespace, apis, types);
-        errors.propagate()?;
-        let out = write::gen(namespace, apis, types, opt, header);
-        Ok(out)
-    })() {
-        Ok(out) => out.content(),
+    match generate(&source, opt, header) {
+        Ok(out) => out,
         Err(err) => format_err(path, &source, err),
+    }
+}
+
+fn generate(source: &str, opt: Opt, header: bool) -> Result<Vec<u8>> {
+    proc_macro2::fallback::force();
+    let ref mut errors = Errors::new();
+    let syntax = syn::parse_file(&source)?;
+    let bridge = find::find_bridge_mod(syntax)?;
+    let ref namespace = bridge.namespace;
+    let ref apis = syntax::parse_items(errors, bridge.module);
+    let ref types = Types::collect(errors, apis);
+    errors.propagate()?;
+    check::typecheck(errors, namespace, apis, types);
+    errors.propagate()?;
+    let out = write::gen(namespace, apis, types, opt, header);
+    Ok(out.content())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::gen::{generate, Opt};
+
+    const CPP_EXAMPLE: &'static str = r#"
+        #[cxx::bridge]
+        mod ffi {
+            extern "C" {
+                pub fn do_cpp_thing(foo: &str);
+            }
+        }
+        "#;
+
+    #[test]
+    fn test_cpp() {
+        let opts = Opt {
+            include: Vec::new(),
+            cxx_impl_annotations: None,
+        };
+        let output = generate(CPP_EXAMPLE, opts, false).unwrap();
+        let output = std::str::from_utf8(&output).unwrap();
+        // To avoid continual breakage we won't test every byte.
+        // Let's look for the major features.
+        assert!(output.contains("void cxxbridge03$do_cpp_thing(::rust::Str::Repr foo)"));
+    }
+
+    #[test]
+    fn test_annotation() {
+        let opts = Opt {
+            include: Vec::new(),
+            cxx_impl_annotations: Some("ANNOTATION".to_string()),
+        };
+        let output = generate(CPP_EXAMPLE, opts, false).unwrap();
+        let output = std::str::from_utf8(&output).unwrap();
+        assert!(output.contains("ANNOTATION void cxxbridge03$do_cpp_thing(::rust::Str::Repr foo)"));
     }
 }


### PR DESCRIPTION
This option to the 'cxxbridge' command line tool allows
users to specify (for example)

  ```__attribute__((visibility("default")))```
or
  ```__declspec(dllexport)```

on C functions which may be exported from a shared object
as they may be required by Rust code in different binaries.

Fixes #219.