### PR TITLE
Option to define types once.

### DIFF
--- a/gen/cmd/src/main.rs
+++ b/gen/cmd/src/main.rs
@@ -44,6 +44,13 @@ struct Opt {
     #[structopt(long)]
     cxx_impl_annotations: Option<String>,
 
+    /// If generating the .cc file, omit definitions which would also
+    /// be included in the .h file. If you choose to do this, you should
+    /// ensure that the .h file is included within the .cc file either
+    /// directly or indirectly. The include option may help here.
+    #[structopt(long, conflicts_with("header"))]
+    skip_definitions: bool,
+
     /// Any additional headers to #include
     #[structopt(short, long)]
     include: Vec<String>,
@@ -59,6 +66,7 @@ fn main() {
     let gen = gen::Opt {
         include: opt.include,
         cxx_impl_annotations: opt.cxx_impl_annotations,
+        skip_definitions: opt.skip_definitions,
     };
 
     match (opt.input, opt.header) {

--- a/gen/src/mod.rs
+++ b/gen/src/mod.rs
@@ -23,13 +23,16 @@ struct Input {
     module: Vec<Item>,
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub(super) struct Opt {
     /// Any additional headers to #include
     pub include: Vec<String>,
     /// Whether to set __attribute__((visibility("default")))
     /// or similar annotations on function implementations.
     pub cxx_impl_annotations: Option<String>,
+    /// Whether to skip definitions of things also defined in the
+    /// header file (applies only when generating the .cc file)
+    pub skip_definitions: bool,
 }
 
 pub(super) fn do_generate_bridge(path: &Path, opt: Opt) -> Vec<u8> {

--- a/gen/src/tests.rs
+++ b/gen/src/tests.rs
@@ -9,14 +9,19 @@ const CPP_EXAMPLE: &'static str = r#"
     }
     "#;
 
+fn generate_for_test(input: &str, header: bool, opts: Opt) -> String {
+    let output = generate(input, opts, header).unwrap();
+    std::str::from_utf8(&output).unwrap().to_string()
+}
+
 #[test]
 fn test_cpp() {
     let opts = Opt {
         include: Vec::new(),
         cxx_impl_annotations: None,
+        skip_definitions: false,
     };
-    let output = generate(CPP_EXAMPLE, opts, false).unwrap();
-    let output = std::str::from_utf8(&output).unwrap();
+    let output = generate_for_test(CPP_EXAMPLE, false, opts);
     // To avoid continual breakage we won't test every byte.
     // Let's look for the major features.
     assert!(output.contains("void cxxbridge03$do_cpp_thing(::rust::Str::Repr foo)"));
@@ -27,8 +32,52 @@ fn test_annotation() {
     let opts = Opt {
         include: Vec::new(),
         cxx_impl_annotations: Some("ANNOTATION".to_string()),
+        skip_definitions: false,
     };
-    let output = generate(CPP_EXAMPLE, opts, false).unwrap();
-    let output = std::str::from_utf8(&output).unwrap();
+    let output = generate_for_test(CPP_EXAMPLE, false, opts);
     assert!(output.contains("ANNOTATION void cxxbridge03$do_cpp_thing(::rust::Str::Repr foo)"));
+}
+
+const STRUCT_EXAMPLE: &'static str = r#"
+    #[cxx::bridge]
+    mod ffi {
+        struct bob {
+            bob_field: i32,
+        }
+        enum norman {
+            norman_variant
+        }
+        extern "C" {
+            pub fn do_cpp_thing(foo: &bob, bar: norman);
+        }
+    }
+    "#;
+#[test]
+fn test_no_definitions() {
+    let opts = Opt {
+        include: Vec::new(),
+        cxx_impl_annotations: None,
+        skip_definitions: false,
+    };
+    let output = generate_for_test(STRUCT_EXAMPLE, false, opts.clone());
+    assert!(output.contains("bob_field"));
+    assert!(output.contains("norman_variant"));
+    let output = generate_for_test(STRUCT_EXAMPLE, true, opts);
+    assert!(output.contains("bob_field"));
+    assert!(output.contains("norman_variant"));
+}
+
+#[test]
+fn test_skip_definitions() {
+    let opts = Opt {
+        include: Vec::new(),
+        cxx_impl_annotations: None,
+        skip_definitions: true,
+    };
+    let output = generate_for_test(STRUCT_EXAMPLE, false, opts.clone());
+    assert!(!output.contains("bob_field"));
+    assert!(!output.contains("norman_variant"));
+    let output = generate_for_test(STRUCT_EXAMPLE, true, opts);
+    assert!(output.contains("bob_field"));
+    assert!(output.contains("norman_variant"));
 }

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -58,27 +58,29 @@ pub(super) fn gen(
         }
     }
 
-    for api in apis {
-        match api {
-            Api::Struct(strct) => {
-                out.next_section();
-                write_struct(out, strct);
-            }
-            Api::Enum(enm) => {
-                out.next_section();
-                if types.cxx.contains(&enm.ident) {
-                    check_enum(out, enm);
-                } else {
-                    write_enum(out, enm);
-                }
-            }
-            Api::RustType(ety) => {
-                if let Some(methods) = methods_for_type.get(&ety.ident) {
+    if header || !opt.skip_definitions {
+        for api in apis {
+            match api {
+                Api::Struct(strct) => {
                     out.next_section();
-                    write_struct_with_methods(out, ety, methods);
+                    write_struct(out, strct);
                 }
+                Api::Enum(enm) => {
+                    out.next_section();
+                    if types.cxx.contains(&enm.ident) {
+                        check_enum(out, enm);
+                    } else {
+                        write_enum(out, enm);
+                    }
+                }
+                Api::RustType(ety) => {
+                    if let Some(methods) = methods_for_type.get(&ety.ident) {
+                        out.next_section();
+                        write_struct_with_methods(out, ety, methods);
+                    }
+                }
+                _ => {}
             }
-            _ => {}
         }
     }
 


### PR DESCRIPTION
Previously cxxbridge emitted type definitions twice, once in the .cc and
once in the .h file.

This is undesirable when Arbitrarily Complex Build systems end up including
the .h in the .cc.

One option considered was to wrap the type definitions in a
```
  #ifndef STUFF_DEFINED
  #define STUFF_DEFINED
  ...
  #endif
```
section, but the `STUFF_DEFINED` preprocessor symbol would need to have a
unique name for every such section to avoid potential conflicts in codebases
with multiple cxxbridge invocations and potentially duplicate filenames
(`foo/path.h` and `bar/path.h`).

In any case it seems more normal to define things *once* in C++, and require
the .cc file to #include the header file. This change therefore makes that
option available. Specifically, we rely on an existing option to provide
an include path to cxxbridge, and just add another option to cease to
redefine types.

Fixes #237 (and effectively the root cause of #230).