### PR TITLE
Update bazel Rust rules repo

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -3,10 +3,12 @@ load("//tools/bazel:rust.bzl", "rust_binary", "rust_library")
 rust_library(
     name = "cxx",
     srcs = glob(["src/**/*.rs"]),
+    proc_macro_deps = [
+        ":cxxbridge-macro",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         ":core-lib",
-        ":cxxbridge-macro",
         "//third-party:link-cplusplus",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,10 +2,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_rust",
-    sha256 = "b83154a58f95618e06845b774b079000e0c39830e185db4c7bf46e79896cb3a1",
-    strip_prefix = "rules_rust-0deef6dd8180cd3bc610878558bb26921b4e8de1",
-    # Master branch as of 2020-03-07
-    url = "https://github.com/bazelbuild/rules_rust/archive/0deef6dd8180cd3bc610878558bb26921b4e8de1.tar.gz",
+    sha256 = "5ed804fcd10a506a5b8e9e59bc6b3b7f43bc30c87ce4670e6f78df43604894fd",
+    strip_prefix = "rules_rust-fdf9655ba95616e0314b4e0ebab40bb0c5fe005c",
+    # Master branch as of 2020-07-30
+    url = "https://github.com/bazelbuild/rules_rust/archive/fdf9655ba95616e0314b4e0ebab40bb0c5fe005c.tar.gz",
 )
 
 http_archive(

--- a/third-party/BUILD
+++ b/third-party/BUILD
@@ -65,9 +65,11 @@ rust_library(
 rust_library(
     name = "proc-macro-error",
     srcs = glob(["vendor/proc-macro-error-1.0.3/src/**"]),
+    proc_macro_deps = [
+        ":proc-macro-error-attr",
+    ],
     rustc_flags = ["--cfg=use_fallback"],
     deps = [
-        ":proc-macro-error-attr",
         ":proc-macro2",
         ":quote",
         ":syn",
@@ -113,11 +115,13 @@ rust_library(
 rust_library(
     name = "structopt",
     srcs = glob(["vendor/structopt-0.3.15/src/**"]),
+    proc_macro_deps = [
+        ":structopt-derive",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         ":clap",
         ":lazy_static",
-        ":structopt-derive",
     ],
 )
 


### PR DESCRIPTION
Proc macro dependencies are now required to be declared separately from ordinary `deps`.

This is the failure otherwise:

```console
ERROR: /git/cxx/third-party/BUILD:65:1: in rust_library rule //third-party:proc-macro-error: 
Traceback (most recent call last):
	File "/git/cxx/third-party/BUILD", line 65
		rust_library(name = 'proc-macro-error')
	File "/home/.cache/bazel/ebce1d0721fb68dda9c70c0dd1405803/external/io_bazel_rules_rust/rust/private/rust.bzl", line 115, in _rust_library_impl
		rustc_compile_action(ctx = ctx, toolchain = toolchain, cr...), ...)
	File "/home/.cache/bazel/ebce1d0721fb68dda9c70c0dd1405803/external/io_bazel_rules_rust/rust/private/rustc.bzl", line 444, in rustc_compile_action
		collect_deps(ctx.label, crate_info.deps, crate_in..., <2 more arguments>)
	File "/home/.cache/bazel/ebce1d0721fb68dda9c70c0dd1405803/external/io_bazel_rules_rust/rust/private/rustc.bzl", line 126, in collect_deps
		fail("{} listed {} in its deps, but i...))
//third-party:proc-macro-error listed //third-party:proc-macro-error-attr in its deps, but it is a proc-macro. It should instead be in the bazel property proc_macro_deps.
ERROR: Analysis of target '//tests:impl' failed; build aborted: Analysis of target '//third-party:proc-macro-error' failed; build aborted
```