### PR TITLE
Switch cli arg parsing from structopt to clap

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -17,10 +17,10 @@ rust_binary(
     visibility = ["PUBLIC"],
     deps = [
         "//third-party:anyhow",
+        "//third-party:clap",
         "//third-party:codespan-reporting",
         "//third-party:proc-macro2",
         "//third-party:quote",
-        "//third-party:structopt",
         "//third-party:syn",
     ],
 )

--- a/BUILD
+++ b/BUILD
@@ -20,10 +20,10 @@ rust_binary(
     visibility = ["//visibility:public"],
     deps = [
         "//third-party:anyhow",
+        "//third-party:clap",
         "//third-party:codespan-reporting",
         "//third-party:proc-macro2",
         "//third-party:quote",
-        "//third-party:structopt",
         "//third-party:syn",
     ],
 )

--- a/gen/cmd/Cargo.toml
+++ b/gen/cmd/Cargo.toml
@@ -15,10 +15,10 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0"
+clap = "2.33"
 codespan-reporting = "0.9"
 proc-macro2 = { version = "1.0.17", default-features = false, features = ["span-locations"] }
 quote = { version = "1.0", default-features = false }
-structopt = "0.3"
 syn = { version = "1.0.20", default-features = false, features = ["parsing", "printing", "clone-impls", "full"] }
 
 [package.metadata.docs.rs]

--- a/gen/cmd/src/app.rs
+++ b/gen/cmd/src/app.rs
@@ -1,0 +1,112 @@
+use super::Opt;
+use clap::AppSettings;
+use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
+
+type App = clap::App<'static, 'static>;
+type Arg = clap::Arg<'static, 'static>;
+
+const USAGE: &str = "\
+    cxxbridge <input>.rs              Emit .cc file for bridge to stdout
+    cxxbridge <input>.rs --header     Emit .h file for bridge to stdout
+    cxxbridge --header                Emit rust/cxx.h header to stdout\
+";
+
+const TEMPLATE: &str = "\
+{bin} {version}
+David Tolnay <dtolnay@gmail.com>
+https://github.com/dtolnay/cxx
+
+USAGE:
+    {usage}
+
+ARGS:
+{positionals}
+OPTIONS:
+{unified}\
+";
+
+fn app() -> App {
+    let mut app = App::new("cxxbridge")
+        .usage(USAGE)
+        .template(TEMPLATE)
+        .setting(AppSettings::NextLineHelp)
+        .arg(arg_input())
+        .arg(arg_cxx_impl_annotations())
+        .arg(arg_header())
+        .arg(arg_include())
+        .help_message("Print help information.")
+        .version_message("Print version information.");
+    if let Some(version) = option_env!("CARGO_PKG_VERSION") {
+        app = app.version(version);
+    }
+    app
+}
+
+const INPUT: &str = "input";
+const CXX_IMPL_ANNOTATIONS: &str = "cxx-impl-annotations";
+const HEADER: &str = "header";
+const INCLUDE: &str = "include";
+
+pub(super) fn from_args() -> Opt {
+    let matches = app().get_matches();
+    Opt {
+        input: matches.value_of_os(INPUT).map(PathBuf::from),
+        cxx_impl_annotations: matches.value_of(CXX_IMPL_ANNOTATIONS).map(str::to_owned),
+        header: matches.is_present(HEADER),
+        include: matches
+            .values_of(INCLUDE)
+            .map_or_else(Vec::new, |v| v.map(str::to_owned).collect()),
+    }
+}
+
+fn validate_utf8(arg: &OsStr) -> Result<(), OsString> {
+    if arg.to_str().is_some() {
+        Ok(())
+    } else {
+        Err(OsString::from("invalid utf-8 sequence"))
+    }
+}
+
+fn arg_input() -> Arg {
+    Arg::with_name(INPUT)
+        .help("Input Rust source file containing #[cxx::bridge].")
+        .required_unless(HEADER)
+}
+
+fn arg_cxx_impl_annotations() -> Arg {
+    const HELP: &str = "\
+Optional annotation for implementations of C++ function wrappers
+that may be exposed to Rust. You may for example need to provide
+__declspec(dllexport) or __attribute__((visibility(\"default\")))
+if Rust code from one shared object or executable depends on
+these C++ functions in another.
+    ";
+    Arg::with_name(CXX_IMPL_ANNOTATIONS)
+        .long(CXX_IMPL_ANNOTATIONS)
+        .takes_value(true)
+        .value_name("annotation")
+        .validator_os(validate_utf8)
+        .help(HELP)
+}
+
+fn arg_header() -> Arg {
+    Arg::with_name(HEADER)
+        .long(HEADER)
+        .help("Emit header with declarations only.")
+}
+
+fn arg_include() -> Arg {
+    const HELP: &str = "\
+Any additional headers to #include. The cxxbridge tool does not
+parse or even require the given paths to exist; they simply go
+into the generated C++ code as #include lines.
+    ";
+    Arg::with_name(INCLUDE)
+        .long(INCLUDE)
+        .short("i")
+        .takes_value(true)
+        .multiple(true)
+        .validator_os(validate_utf8)
+        .help(HELP)
+}

--- a/gen/cmd/src/main.rs
+++ b/gen/cmd/src/main.rs
@@ -6,46 +6,19 @@
     clippy::toplevel_ref_arg
 )]
 
+mod app;
 mod gen;
 mod syntax;
 
 use gen::include;
 use std::io::{self, Write};
 use std::path::PathBuf;
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
-#[structopt(
-    name = "cxxbridge",
-    author = "David Tolnay <dtolnay@gmail.com>",
-    about = "https://github.com/dtolnay/cxx",
-    usage = "\
-    cxxbridge <input>.rs              Emit .cc file for bridge to stdout
-    cxxbridge <input>.rs --header     Emit .h file for bridge to stdout
-    cxxbridge --header                Emit rust/cxx.h header to stdout",
-    help_message = "Print help information",
-    version_message = "Print version information"
-)]
+#[derive(Debug)]
 struct Opt {
-    /// Input Rust source file containing #[cxx::bridge]
-    #[structopt(parse(from_os_str), required_unless = "header")]
     input: Option<PathBuf>,
-
-    /// Emit header with declarations only
-    #[structopt(long)]
     header: bool,
-
-    /// Optional annotation for implementations of C++ function
-    /// wrappers that may be exposed to Rust. You may for example
-    /// need to provide __declspec(dllexport) or
-    /// __attribute__((visibility("default"))) if Rust code from
-    /// one shared object or executable depends on these C++ functions
-    /// in another.
-    #[structopt(long)]
     cxx_impl_annotations: Option<String>,
-
-    /// Any additional headers to #include
-    #[structopt(short, long)]
     include: Vec<String>,
 }
 
@@ -54,7 +27,7 @@ fn write(content: impl AsRef<[u8]>) {
 }
 
 fn main() {
-    let opt = Opt::from_args();
+    let opt = app::from_args();
 
     let gen = gen::Opt {
         include: opt.include,

--- a/third-party/BUCK
+++ b/third-party/BUCK
@@ -22,6 +22,7 @@ rust_library(
     name = "clap",
     srcs = glob(["vendor/clap-2.33.1/src/**"]),
     edition = "2015",
+    visibility = ["PUBLIC"],
     deps = [
         ":bitflags",
         ":textwrap",
@@ -40,13 +41,6 @@ rust_library(
 )
 
 rust_library(
-    name = "heck",
-    srcs = glob(["vendor/heck-0.3.1/src/**"]),
-    edition = "2015",
-    deps = [":unicode-segmentation"],
-)
-
-rust_library(
     name = "lazy_static",
     srcs = glob(["vendor/lazy_static-1.4.0/src/**"]),
 )
@@ -55,30 +49,6 @@ rust_library(
     name = "link-cplusplus",
     srcs = glob(["vendor/link-cplusplus-1.0.2/src/**"]),
     visibility = ["PUBLIC"],
-)
-
-rust_library(
-    name = "proc-macro-error",
-    srcs = glob(["vendor/proc-macro-error-1.0.3/src/**"]),
-    rustc_flags = ["--cfg=use_fallback"],
-    deps = [
-        ":proc-macro-error-attr",
-        ":proc-macro2",
-        ":quote",
-        ":syn",
-    ],
-)
-
-rust_library(
-    name = "proc-macro-error-attr",
-    srcs = glob(["vendor/proc-macro-error-attr-1.0.3/src/**"]),
-    proc_macro = True,
-    deps = [
-        ":proc-macro2",
-        ":quote",
-        ":syn",
-        ":syn-mid",
-    ],
 )
 
 rust_library(
@@ -106,30 +76,6 @@ rust_library(
 )
 
 rust_library(
-    name = "structopt",
-    srcs = glob(["vendor/structopt-0.3.15/src/**"]),
-    visibility = ["PUBLIC"],
-    deps = [
-        ":clap",
-        ":lazy_static",
-        ":structopt-derive",
-    ],
-)
-
-rust_library(
-    name = "structopt-derive",
-    srcs = glob(["vendor/structopt-derive-0.4.8/src/**"]),
-    proc_macro = True,
-    deps = [
-        ":heck",
-        ":proc-macro-error",
-        ":proc-macro2",
-        ":quote",
-        ":syn",
-    ],
-)
-
-rust_library(
     name = "syn",
     srcs = glob(["vendor/syn-1.0.36/src/**"]),
     visibility = ["PUBLIC"],
@@ -149,16 +95,6 @@ rust_library(
 )
 
 rust_library(
-    name = "syn-mid",
-    srcs = glob(["vendor/syn-mid-0.5.0/src/**"]),
-    deps = [
-        ":proc-macro2",
-        ":quote",
-        ":syn",
-    ],
-)
-
-rust_library(
     name = "termcolor",
     srcs = glob(["vendor/termcolor-1.1.0/src/**"]),
 )
@@ -167,12 +103,6 @@ rust_library(
     name = "textwrap",
     srcs = glob(["vendor/textwrap-0.11.0/src/**"]),
     deps = [":unicode-width"],
-)
-
-rust_library(
-    name = "unicode-segmentation",
-    srcs = glob(["vendor/unicode-segmentation-1.6.0/src/**"]),
-    edition = "2015",
 )
 
 rust_library(

--- a/third-party/BUILD
+++ b/third-party/BUILD
@@ -27,6 +27,7 @@ rust_library(
     name = "clap",
     srcs = glob(["vendor/clap-2.33.1/src/**"]),
     edition = "2015",
+    visibility = ["//visibility:public"],
     deps = [
         ":bitflags",
         ":textwrap",
@@ -45,13 +46,6 @@ rust_library(
 )
 
 rust_library(
-    name = "heck",
-    srcs = glob(["vendor/heck-0.3.1/src/**"]),
-    edition = "2015",
-    deps = [":unicode-segmentation"],
-)
-
-rust_library(
     name = "lazy_static",
     srcs = glob(["vendor/lazy_static-1.4.0/src/**"]),
 )
@@ -60,32 +54,6 @@ rust_library(
     name = "link-cplusplus",
     srcs = glob(["vendor/link-cplusplus-1.0.2/src/**"]),
     visibility = ["//visibility:public"],
-)
-
-rust_library(
-    name = "proc-macro-error",
-    srcs = glob(["vendor/proc-macro-error-1.0.3/src/**"]),
-    proc_macro_deps = [
-        ":proc-macro-error-attr",
-    ],
-    rustc_flags = ["--cfg=use_fallback"],
-    deps = [
-        ":proc-macro2",
-        ":quote",
-        ":syn",
-    ],
-)
-
-rust_library(
-    name = "proc-macro-error-attr",
-    srcs = glob(["vendor/proc-macro-error-attr-1.0.3/src/**"]),
-    crate_type = "proc-macro",
-    deps = [
-        ":proc-macro2",
-        ":quote",
-        ":syn",
-        ":syn-mid",
-    ],
 )
 
 rust_library(
@@ -113,32 +81,6 @@ rust_library(
 )
 
 rust_library(
-    name = "structopt",
-    srcs = glob(["vendor/structopt-0.3.15/src/**"]),
-    proc_macro_deps = [
-        ":structopt-derive",
-    ],
-    visibility = ["//visibility:public"],
-    deps = [
-        ":clap",
-        ":lazy_static",
-    ],
-)
-
-rust_library(
-    name = "structopt-derive",
-    srcs = glob(["vendor/structopt-derive-0.4.8/src/**"]),
-    crate_type = "proc-macro",
-    deps = [
-        ":heck",
-        ":proc-macro-error",
-        ":proc-macro2",
-        ":quote",
-        ":syn",
-    ],
-)
-
-rust_library(
     name = "syn",
     srcs = glob(["vendor/syn-1.0.36/src/**"]),
     crate_features = [
@@ -158,16 +100,6 @@ rust_library(
 )
 
 rust_library(
-    name = "syn-mid",
-    srcs = glob(["vendor/syn-mid-0.5.0/src/**"]),
-    deps = [
-        ":proc-macro2",
-        ":quote",
-        ":syn",
-    ],
-)
-
-rust_library(
     name = "termcolor",
     srcs = glob(["vendor/termcolor-1.1.0/src/**"]),
 )
@@ -176,12 +108,6 @@ rust_library(
     name = "textwrap",
     srcs = glob(["vendor/textwrap-0.11.0/src/**"]),
     deps = [":unicode-width"],
-)
-
-rust_library(
-    name = "unicode-segmentation",
-    srcs = glob(["vendor/unicode-segmentation-1.6.0/src/**"]),
-    edition = "2015",
 )
 
 rust_library(

--- a/third-party/Cargo.lock
+++ b/third-party/Cargo.lock
@@ -101,10 +101,10 @@ name = "cxxbridge-cmd"
 version = "0.3.4"
 dependencies = [
  "anyhow",
+ "clap",
  "codespan-reporting",
  "proc-macro2",
  "quote",
- "structopt",
  "syn",
 ]
 
@@ -137,15 +137,6 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
-name = "heck"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -181,32 +172,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f563b3814ea63e830e3e321206e4e2b5177854586ebe3f595795ed7053b217f5"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc175e9777c3116627248584e8f8b3e2987405cabe1c0adf7d1dd28f09dc7880"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc9795ca17eb581285ec44936da7fc2335a3f34f2ddd13118b6f4d515435c50"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "syn-mid",
- "version_check",
 ]
 
 [[package]]
@@ -282,30 +247,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
-name = "structopt"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2f5e239ee807089b62adce73e48c625e0ed80df02c7ab3f068f5db5281065c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510413f9de616762a4fbeab62509bf15c729603b72d7cd71280fbca431b1c118"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "syn"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,17 +255,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
-]
-
-[[package]]
-name = "syn-mid"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -370,12 +300,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,12 +316,6 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "version_check"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "winapi"


### PR DESCRIPTION
This eliminates several dependencies (heck, proc-macro-error, proc-macro-error-attr, structopt, structopt-derive, syn-mid, unicode-segmentation) and makes it somewhat more natural to exercise more control over the help output.
<br>

#### Before:

```console
cxxbridge 0.3.4
David Tolnay <dtolnay@gmail.com>
https://github.com/dtolnay/cxx

USAGE:
    cxxbridge <input>.rs              Emit .cc file for bridge to stdout
    cxxbridge <input>.rs --header     Emit .h file for bridge to stdout
    cxxbridge --header                Emit rust/cxx.h header to stdout

FLAGS:
    -h, --help       Print help information
        --header     Emit header with declarations only
    -V, --version    Print version information

OPTIONS:
        --cxx-impl-annotations <cxx-impl-annotations>
            Optional annotation for implementations of C++ function wrappers that may be exposed to Rust. You may for
            example need to provide __declspec(dllexport) or __attribute__((visibility("default"))) if Rust code from
            one shared object or executable depends on these C++ functions in another
    -i, --include <include>...                           Any additional headers to #include

ARGS:
    <input>    Input Rust source file containing #[cxx::bridge]
```

#### After:

```console
cxxbridge 0.3.4
David Tolnay <dtolnay@gmail.com>
https://github.com/dtolnay/cxx

USAGE:
    cxxbridge <input>.rs              Emit .cc file for bridge to stdout
    cxxbridge <input>.rs --header     Emit .h file for bridge to stdout
    cxxbridge --header                Emit rust/cxx.h header to stdout

ARGS:
    <input>
            Input Rust source file containing #[cxx::bridge].

OPTIONS:
        --cxx-impl-annotations <annotation>
            Optional annotation for implementations of C++ function wrappers
            that may be exposed to Rust. You may for example need to provide
            __declspec(dllexport) or __attribute__((visibility("default")))
            if Rust code from one shared object or executable depends on
            these C++ functions in another.

    -h, --help
            Print help information.

        --header
            Emit header with declarations only.

    -i, --include <include>...
            Any additional headers to #include. The cxxbridge tool does not
            parse or even require the given paths to exist; they simply go
            into the generated C++ code as #include lines.

    -V, --version
            Print version information.
```