### PR TITLE
Add rust::Vec accessors

### DIFF
--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -11,6 +11,7 @@ use std::fmt::{self, Display};
 
 #[cxx::bridge(namespace = tests)]
 pub mod ffi {
+    #[derive(Clone)]
     struct Shared {
         z: usize,
     }
@@ -61,8 +62,11 @@ pub mod ffi {
         fn c_take_ref_vector(v: &CxxVector<u8>);
         fn c_take_rust_vec(v: Vec<u8>);
         fn c_take_rust_vec_shared(v: Vec<Shared>);
+        fn c_take_rust_vec_index(v: Vec<u8>);
+        fn c_take_rust_vec_shared_index(v: Vec<Shared>);
         fn c_take_rust_vec_shared_forward_iterator(v: Vec<Shared>);
         fn c_take_ref_rust_vec(v: &Vec<u8>);
+        fn c_take_ref_rust_vec_index(v: &Vec<u8>);
         fn c_take_ref_rust_vec_copy(v: &Vec<u8>);
         /*
         // https://github.com/dtolnay/cxx/issues/232

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -208,6 +208,8 @@ void c_take_ref_vector(const std::vector<uint8_t> &v) {
 
 void c_take_rust_vec(rust::Vec<uint8_t> v) { c_take_ref_rust_vec(v); }
 
+void c_take_rust_vec_index(rust::Vec<uint8_t> v) { c_take_ref_rust_vec_index(v); }
+
 void c_take_rust_vec_shared(rust::Vec<Shared> v) {
   uint32_t sum = 0;
   for (auto i : v) {
@@ -230,9 +232,33 @@ void c_take_rust_vec_shared_forward_iterator(rust::Vec<Shared> v) {
   }
 }
 
+void c_take_rust_vec_shared_index(rust::Vec<Shared> v) {
+  if (v[0].z == 1010 &&
+      v.at(0).z == 1010 &&
+      v.front().z == 1010 &&
+      v[1].z == 1011 &&
+      v.at(1).z == 1011 &&
+      v.back().z == 1011) {
+    cxx_test_suite_set_correct();
+  }
+}
+
 void c_take_ref_rust_vec(const rust::Vec<uint8_t> &v) {
   uint8_t sum = std::accumulate(v.begin(), v.end(), 0);
   if (sum == 200) {
+    cxx_test_suite_set_correct();
+  }
+}
+
+void c_take_ref_rust_vec_index(const rust::Vec<uint8_t> &v) {
+  if (v[0] == 86 &&
+      v.at(0) == 86 &&
+      v.front() == 86 &&
+      v[1] == 75 &&
+      v.at(1) == 75 &&
+      v[3] == 9 &&
+      v.at(3) == 9 &&
+      v.back() == 9) {
     cxx_test_suite_set_correct();
   }
 }

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -65,9 +65,12 @@ void c_take_unique_ptr_vector_f64(std::unique_ptr<std::vector<double>> v);
 void c_take_unique_ptr_vector_shared(std::unique_ptr<std::vector<Shared>> v);
 void c_take_ref_vector(const std::vector<uint8_t> &v);
 void c_take_rust_vec(rust::Vec<uint8_t> v);
+void c_take_rust_vec_index(rust::Vec<uint8_t> v);
 void c_take_rust_vec_shared(rust::Vec<Shared> v);
+void c_take_rust_vec_shared_index(rust::Vec<Shared> v);
 void c_take_rust_vec_shared_forward_iterator(rust::Vec<Shared> v);
 void c_take_ref_rust_vec(const rust::Vec<uint8_t> &v);
+void c_take_ref_rust_vec_index(const rust::Vec<uint8_t> &v);
 void c_take_ref_rust_vec_copy(const rust::Vec<uint8_t> &v);
 /*
 // https://github.com/dtolnay/cxx/issues/232

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -108,15 +108,16 @@ fn test_c_take() {
     check!(ffi::c_take_ref_vector(&ffi::c_return_unique_ptr_vector_u8()));
     let test_vec = [86_u8, 75_u8, 30_u8, 9_u8].to_vec();
     check!(ffi::c_take_rust_vec(test_vec.clone()));
-    check!(ffi::c_take_rust_vec_shared(vec![
+    check!(ffi::c_take_rust_vec_index(test_vec.clone()));
+    let shared_test_vec = vec![
         ffi::Shared { z: 1010 },
         ffi::Shared { z: 1011 }
-    ]));
-    check!(ffi::c_take_rust_vec_shared_forward_iterator(vec![
-        ffi::Shared { z: 1010 },
-        ffi::Shared { z: 1011 }
-    ]));
+    ];
+    check!(ffi::c_take_rust_vec_shared(shared_test_vec.clone()));
+    check!(ffi::c_take_rust_vec_shared_index(shared_test_vec.clone()));
+    check!(ffi::c_take_rust_vec_shared_forward_iterator(shared_test_vec));
     check!(ffi::c_take_ref_rust_vec(&test_vec));
+    check!(ffi::c_take_ref_rust_vec_index(&test_vec));
     check!(ffi::c_take_ref_rust_vec_copy(&test_vec));
     check!(ffi::c_take_enum(ffi::Enum::AVal));
 }


### PR DESCRIPTION
Adds operator[], at(), front(), and back() to rust::Vec.

This is the read-only accessor side of #149, not sure if we want mutable accessors.