### PR TITLE
Add context to i/o errors

### DIFF
--- a/gen/build/src/error.rs
+++ b/gen/build/src/error.rs
@@ -1,6 +1,6 @@
+use crate::gen::fs;
 use std::error::Error as StdError;
 use std::fmt::{self, Display};
-use std::io;
 
 pub(super) type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -8,7 +8,7 @@ pub(super) type Result<T, E = Error> = std::result::Result<T, E>;
 pub(super) enum Error {
     MissingOutDir,
     TargetDir,
-    Io(io::Error),
+    Fs(fs::Error),
 }
 
 impl Display for Error {
@@ -16,7 +16,7 @@ impl Display for Error {
         match self {
             Error::MissingOutDir => write!(f, "missing OUT_DIR environment variable"),
             Error::TargetDir => write!(f, "failed to locate target dir"),
-            Error::Io(err) => err.fmt(f),
+            Error::Fs(err) => err.fmt(f),
         }
     }
 }
@@ -24,14 +24,14 @@ impl Display for Error {
 impl StdError for Error {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
-            Error::Io(err) => err.source(),
+            Error::Fs(err) => err.source(),
             _ => None,
         }
     }
 }
 
-impl From<io::Error> for Error {
-    fn from(err: io::Error) -> Self {
-        Error::Io(err)
+impl From<fs::Error> for Error {
+    fn from(err: fs::Error) -> Self {
+        Error::Fs(err)
     }
 }

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -59,8 +59,7 @@ mod syntax;
 
 use crate::error::Result;
 use crate::gen::error::report;
-use crate::gen::Opt;
-use std::fs;
+use crate::gen::{fs, Opt};
 use std::io::{self, Write};
 use std::iter;
 use std::path::Path;

--- a/gen/src/error.rs
+++ b/gen/src/error.rs
@@ -1,3 +1,4 @@
+use crate::gen::fs;
 use crate::syntax;
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use codespan_reporting::files::SimpleFiles;
@@ -15,7 +16,7 @@ pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug)]
 pub(crate) enum Error {
     NoBridgeMod,
-    Io(io::Error),
+    Fs(fs::Error),
     Syn(syn::Error),
 }
 
@@ -23,7 +24,7 @@ impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Error::NoBridgeMod => write!(f, "no #[cxx::bridge] module found"),
-            Error::Io(err) => err.fmt(f),
+            Error::Fs(err) => err.fmt(f),
             Error::Syn(err) => err.fmt(f),
         }
     }
@@ -32,16 +33,16 @@ impl Display for Error {
 impl StdError for Error {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
-            Error::Io(err) => err.source(),
+            Error::Fs(err) => err.source(),
             Error::Syn(err) => err.source(),
             _ => None,
         }
     }
 }
 
-impl From<io::Error> for Error {
-    fn from(err: io::Error) -> Self {
-        Error::Io(err)
+impl From<fs::Error> for Error {
+    fn from(err: fs::Error) -> Self {
+        Error::Fs(err)
     }
 }
 

--- a/gen/src/fs.rs
+++ b/gen/src/fs.rs
@@ -1,0 +1,121 @@
+#![allow(dead_code)]
+
+use std::error::Error as StdError;
+use std::fmt::{self, Display};
+use std::io;
+use std::path::{Path, PathBuf};
+
+type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug)]
+pub(crate) struct Error {
+    source: io::Error,
+    message: String,
+}
+
+impl Display for Error {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl StdError for Error {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        Some(&self.source)
+    }
+}
+
+macro_rules! err {
+    ($io_error:expr, $fmt:expr $(, $path:expr)* $(,)?) => {
+        Err(Error {
+            source: $io_error,
+            message: format!($fmt $(, $path.display())*),
+        })
+    }
+}
+
+pub(crate) fn canonicalize(path: impl AsRef<Path>) -> Result<PathBuf> {
+    let path = path.as_ref();
+    match std::fs::canonicalize(path) {
+        Ok(string) => Ok(string),
+        Err(e) => err!(e, "Unable to canonicalize path: `{}`", path),
+    }
+}
+
+pub(crate) fn copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<u64> {
+    let from = from.as_ref();
+    let to = to.as_ref();
+    match std::fs::copy(from, to) {
+        Ok(n) => Ok(n),
+        Err(e) => err!(e, "Failed to copy `{}` -> `{}`", from, to),
+    }
+}
+
+pub(crate) fn create_dir_all(path: impl AsRef<Path>) -> Result<()> {
+    let path = path.as_ref();
+    match std::fs::create_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(e) => err!(e, "Failed to create directory `{}`", path),
+    }
+}
+
+pub(crate) fn current_dir() -> Result<PathBuf> {
+    match std::env::current_dir() {
+        Ok(dir) => Ok(dir),
+        Err(e) => err!(e, "Failed to determine current directory"),
+    }
+}
+
+pub(crate) fn read_to_string(path: impl AsRef<Path>) -> Result<String> {
+    let path = path.as_ref();
+    match std::fs::read_to_string(path) {
+        Ok(string) => Ok(string),
+        Err(e) => err!(e, "Failed to read file `{}`", path),
+    }
+}
+
+pub(crate) fn remove_file(path: impl AsRef<Path>) -> Result<()> {
+    let path = path.as_ref();
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) => err!(e, "Failed to remove file `{}`", path),
+    }
+}
+
+#[cfg(unix)]
+pub(crate) fn symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<()> {
+    let src = src.as_ref();
+    let dst = dst.as_ref();
+    match std::os::unix::fs::symlink(src, dst) {
+        Ok(()) => Ok(()),
+        Err(e) => err!(
+            e,
+            "Failed to create symlink `{}` pointing to `{}`",
+            dst,
+            src,
+        ),
+    }
+}
+
+#[cfg(windows)]
+pub(crate) fn symlink_file(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<()> {
+    let src = src.as_ref();
+    let dst = dst.as_ref();
+    match std::os::windows::fs::symlink_file(src, dst) {
+        Ok(()) => Ok(()),
+        Err(e) => err!(
+            e,
+            "Failed to create symlink `{}` pointing to `{}`",
+            dst,
+            src,
+        ),
+    }
+}
+
+pub(crate) fn write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> Result<()> {
+    let path = path.as_ref();
+    match std::fs::write(path, contents) {
+        Ok(()) => Ok(()),
+        Err(e) => err!(e, "Failed to write file `{}`", path),
+    }
+}

--- a/gen/src/mod.rs
+++ b/gen/src/mod.rs
@@ -3,6 +3,7 @@
 
 pub(super) mod error;
 mod file;
+pub(super) mod fs;
 pub(super) mod include;
 pub(super) mod out;
 mod write;
@@ -15,7 +16,6 @@ use self::error::{format_err, Result};
 use self::file::File;
 use crate::syntax::report::Errors;
 use crate::syntax::{self, check, Types};
-use std::fs;
 use std::path::Path;
 
 /// Options for C++ code generation.
@@ -71,7 +71,7 @@ impl Default for Opt {
 pub(super) fn generate_from_path(path: &Path, opt: &Opt) -> GeneratedCode {
     let source = match fs::read_to_string(path) {
         Ok(source) => source,
-        Err(err) => format_err(path, "", Error::Io(err)),
+        Err(err) => format_err(path, "", Error::Fs(err)),
     };
     match generate_from_string(&source, opt) {
         Ok(out) => out,


### PR DESCRIPTION
Before:

```console
cxxbridge: No such file or directory (os error 2)
```

After:

```console
cxxbridge: Failed to read file `path/to/nonexistent`

Caused by:
    No such file or directory (os error 2)
```