### PR TITLE
Remove link-cplusplus dependency from non-Cargo builds

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -6,7 +6,6 @@ rust_library(
     deps = [
         ":core",
         ":macro",
-        "//third-party:link-cplusplus",
     ],
 )
 

--- a/BUILD
+++ b/BUILD
@@ -7,10 +7,7 @@ rust_library(
         ":cxxbridge-macro",
     ],
     visibility = ["//visibility:public"],
-    deps = [
-        ":core-lib",
-        "//third-party:link-cplusplus",
-    ],
+    deps = [":core-lib"],
 )
 
 rust_binary(

--- a/build.rs
+++ b/build.rs
@@ -7,4 +7,5 @@ fn main() {
         .compile("cxxbridge03");
     println!("cargo:rerun-if-changed=src/cxx.cc");
     println!("cargo:rerun-if-changed=include/cxx.h");
+    println!("cargo:rustc-cfg=built_with_cargo");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,6 +368,7 @@
     clippy::useless_let_if_seq
 )]
 
+#[cfg(built_with_cargo)]
 extern crate link_cplusplus;
 
 #[macro_use]

--- a/third-party/BUCK
+++ b/third-party/BUCK
@@ -39,12 +39,6 @@ rust_library(
 )
 
 rust_library(
-    name = "link-cplusplus",
-    srcs = glob(["vendor/link-cplusplus-1.0.2/src/**"]),
-    visibility = ["PUBLIC"],
-)
-
-rust_library(
     name = "proc-macro2",
     srcs = glob(["vendor/proc-macro2-1.0.19/src/**"]),
     visibility = ["PUBLIC"],

--- a/third-party/BUILD
+++ b/third-party/BUILD
@@ -44,12 +44,6 @@ rust_library(
 )
 
 rust_library(
-    name = "link-cplusplus",
-    srcs = glob(["vendor/link-cplusplus-1.0.2/src/**"]),
-    visibility = ["//visibility:public"],
-)
-
-rust_library(
     name = "proc-macro2",
     srcs = glob(["vendor/proc-macro2-1.0.19/src/**"]),
     crate_features = [


### PR DESCRIPTION
The only purpose of that crate is its Cargo build.rs, which emits rustc-link-lib flags to Cargo.