### PR TITLE
Rewrite cxx-build crate

### DIFF
--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cxxbridge-demo"
+name = "demo"
 version = "0.0.0"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 edition = "2018"

--- a/gen/build/src/cargo.rs
+++ b/gen/build/src/cargo.rs
@@ -1,12 +1,13 @@
 use crate::paths::TargetDir;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str;
 
-pub(crate) fn target_dir() -> TargetDir {
+pub(crate) fn target_dir(out_dir: &Path) -> TargetDir {
     (|| {
         let cargo = option_env!("CARGO").unwrap_or("cargo");
         let output = Command::new(cargo)
+            .current_dir(out_dir)
             .arg("metadata")
             .arg("--no-deps")
             .arg("--format-version=1")

--- a/gen/build/src/cargo.rs
+++ b/gen/build/src/cargo.rs
@@ -1,19 +1,18 @@
-use crate::error::TargetDirError;
 use crate::paths::TargetDir;
 use std::path::PathBuf;
 use std::process::Command;
 use std::str;
 
-pub(crate) fn target_dir() -> Result<TargetDir, TargetDirError> {
-    let cargo = option_env!("CARGO").unwrap_or("cargo");
-    let output = Command::new(cargo)
-        .arg("metadata")
-        .arg("--no-deps")
-        .arg("--format-version=1")
-        .output()
-        .map_err(TargetDirError::Io)?;
-
+pub(crate) fn target_dir() -> TargetDir {
     (|| {
+        let cargo = option_env!("CARGO").unwrap_or("cargo");
+        let output = Command::new(cargo)
+            .arg("metadata")
+            .arg("--no-deps")
+            .arg("--format-version=1")
+            .output()
+            .ok()?;
+
         // Cargo only outputs utf8 encoded JSON.
         let mut metadata = str::from_utf8(&output.stdout).ok()?;
 
@@ -25,7 +24,7 @@ pub(crate) fn target_dir() -> Result<TargetDir, TargetDirError> {
         let close_quote_index = metadata.find('"')?;
         let string = &metadata[..close_quote_index];
         let target_directory = string.replace("\\\\", "\\");
-        Some(TargetDir(PathBuf::from(target_directory)))
+        Some(TargetDir::Path(PathBuf::from(target_directory)))
     })()
-    .ok_or(TargetDirError::NotFound)
+    .unwrap_or(TargetDir::Unknown)
 }

--- a/gen/build/src/error.rs
+++ b/gen/build/src/error.rs
@@ -1,28 +1,19 @@
 use crate::gen::fs;
 use std::error::Error as StdError;
 use std::fmt::{self, Display};
-use std::io;
 
 pub(super) type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug)]
 pub(super) enum Error {
     MissingOutDir,
-    TargetDir(TargetDirError),
     Fs(fs::Error),
-}
-
-#[derive(Debug)]
-pub(crate) enum TargetDirError {
-    Io(io::Error),
-    NotFound,
 }
 
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Error::MissingOutDir => write!(f, "missing OUT_DIR environment variable"),
-            Error::TargetDir(_) => write!(f, "unable to identify target dir"),
             Error::Fs(err) => err.fmt(f),
         }
     }
@@ -31,10 +22,6 @@ impl Display for Error {
 impl StdError for Error {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
-            Error::TargetDir(err) => match err {
-                TargetDirError::Io(err) => Some(err),
-                TargetDirError::NotFound => None,
-            },
             Error::Fs(err) => err.source(),
             _ => None,
         }

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -172,7 +172,9 @@ fn generate_bridge(prj: &Project, build: &mut Build, rust_source_file: &Path) ->
     let ref rel_path_h = rel_path.with_appended_extension(".h");
     let ref header_path = paths::namespaced(&prj.out_dir, rel_path_h);
     write(header_path, &generated.header)?;
-    paths::symlink_namespaced(header_path, &prj.out_dir, rel_path);
+
+    let ref link_path = paths::namespaced(&prj.out_dir, rel_path);
+    let _ = paths::symlink_or_copy(header_path, link_path);
     if let TargetDir::Path(target_dir) = &prj.target_dir {
         let ref link_path = paths::namespaced(target_dir, rel_path);
         let _ = fs::create_dir_all(link_path.parent().unwrap());

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -107,7 +107,7 @@ impl Project {
     fn init() -> Result<Self> {
         let out_dir = paths::out_dir()?;
 
-        let target_dir = match cargo::target_dir() {
+        let target_dir = match cargo::target_dir(&out_dir) {
             target_dir @ TargetDir::Path(_) => target_dir,
             // Fallback if Cargo did not work.
             TargetDir::Unknown => paths::search_parents_for_target_dir(&out_dir),

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -122,9 +122,10 @@ impl Project {
 
 fn build(rust_source_files: &mut dyn Iterator<Item = impl AsRef<Path>>) -> Result<Build> {
     let ref prj = Project::init()?;
-    let mut build = paths::cc_build(prj);
+    let mut build = Build::new();
     build.cpp(true);
     build.cpp_link_stdlib(None); // linked via link-cplusplus crate
+    build.include(paths::include_dir(prj));
     write_header(prj);
     symlink_crate(prj, &mut build);
 

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -59,7 +59,7 @@ mod gen;
 mod paths;
 mod syntax;
 
-use crate::error::{Error, Result};
+use crate::error::Result;
 use crate::gen::error::report;
 use crate::gen::{fs, Opt};
 use crate::paths::TargetDir;
@@ -99,7 +99,7 @@ pub fn bridges(rust_source_files: impl IntoIterator<Item = impl AsRef<Path>>) ->
 }
 
 fn build(rust_source_files: &mut dyn Iterator<Item = impl AsRef<Path>>) -> Result<Build> {
-    let ref target_dir = target_dir()?;
+    let ref target_dir = target_dir();
     let mut build = paths::cc_build(target_dir);
     build.cpp(true);
     build.cpp_link_stdlib(None); // linked via link-cplusplus crate
@@ -152,15 +152,10 @@ fn write(path: &Path, content: &[u8]) -> Result<()> {
     Ok(())
 }
 
-fn target_dir() -> Result<TargetDir> {
-    let fallback_err = match cargo::target_dir() {
-        Ok(target_dir) => return Ok(target_dir),
-        Err(err) => Error::TargetDir(err),
-    };
-
-    // Fallback if Cargo did not work.
-    match paths::search_parents_for_target_dir() {
-        Some(target_dir) => Ok(target_dir),
-        None => Err(fallback_err),
+fn target_dir() -> TargetDir {
+    match cargo::target_dir() {
+        target_dir @ TargetDir::Path(_) => target_dir,
+        // Fallback if Cargo did not work.
+        TargetDir::Unknown => paths::search_parents_for_target_dir(),
     }
 }

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -174,8 +174,10 @@ fn generate_bridge(prj: &Project, build: &mut Build, rust_source_file: &Path) ->
     write(header_path, &generated.header)?;
     paths::symlink_namespaced(header_path, &prj.out_dir, rel_path);
     if let TargetDir::Path(target_dir) = &prj.target_dir {
-        paths::symlink_namespaced(header_path, target_dir, rel_path);
-        paths::symlink_namespaced(header_path, target_dir, rel_path_h);
+        let ref link_path = paths::namespaced(target_dir, rel_path);
+        let _ = fs::create_dir_all(link_path.parent().unwrap());
+        let _ = paths::symlink_or_copy(header_path, link_path);
+        let _ = paths::symlink_or_copy(header_path, link_path.with_appended_extension(".h"));
     }
 
     let ref rel_path_cc = rel_path.with_appended_extension(".cc");

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -110,7 +110,7 @@ impl Project {
         let target_dir = match cargo::target_dir() {
             target_dir @ TargetDir::Path(_) => target_dir,
             // Fallback if Cargo did not work.
-            TargetDir::Unknown => paths::search_parents_for_target_dir(),
+            TargetDir::Unknown => paths::search_parents_for_target_dir(&out_dir),
         };
 
         Ok(Project {

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -137,9 +137,14 @@ fn build(rust_source_files: &mut dyn Iterator<Item = impl AsRef<Path>>) -> Resul
 }
 
 fn write_header(prj: &Project) {
-    let include_dir = paths::include_dir(prj);
-    let ref cxx_h = include_dir.join("rust").join("cxx.h");
+    let ref cxx_h = prj.out_dir.join("cxxbridge").join("rust").join("cxx.h");
     let _ = write(cxx_h, gen::include::HEADER.as_bytes());
+    if let TargetDir::Path(target_dir) = &prj.target_dir {
+        let ref header_dir = target_dir.join("cxxbridge").join("rust");
+        let _ = fs::create_dir_all(header_dir);
+        let ref cxx_h = header_dir.join("cxx.h");
+        let _ = write(cxx_h, gen::include::HEADER.as_bytes());
+    }
 }
 
 fn symlink_crate(prj: &Project, build: &mut Build) {

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -143,11 +143,11 @@ fn generate_bridge(prj: &Project, build: &mut Build, rust_source_file: &Path) ->
     let opt = Opt::default();
     let generated = gen::generate_from_path(rust_source_file, &opt);
 
-    let header_path = paths::out_with_extension(prj, rust_source_file, ".h")?;
+    let header_path = paths::out_with_extension(prj, rust_source_file, ".h");
     write(&header_path, &generated.header)?;
     paths::symlink_header(prj, &header_path, rust_source_file);
 
-    let implementation_path = paths::out_with_extension(prj, rust_source_file, ".cc")?;
+    let implementation_path = paths::out_with_extension(prj, rust_source_file, ".cc");
     write(&implementation_path, &generated.implementation)?;
     build.file(&implementation_path);
     Ok(())

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -144,7 +144,6 @@ fn generate_bridge(prj: &Project, build: &mut Build, rust_source_file: &Path) ->
     let generated = gen::generate_from_path(rust_source_file, &opt);
 
     let header_path = paths::out_with_extension(prj, rust_source_file, ".h")?;
-    fs::create_dir_all(header_path.parent().unwrap())?;
     write(&header_path, &generated.header)?;
     paths::symlink_header(prj, &header_path, rust_source_file);
 

--- a/gen/build/src/paths.rs
+++ b/gen/build/src/paths.rs
@@ -100,10 +100,10 @@ pub(crate) fn search_parents_for_target_dir(out_dir: &Path) -> TargetDir {
 }
 
 #[cfg(unix)]
-use self::fs::symlink_file as symlink_or_copy;
+pub(crate) use self::fs::symlink_file as symlink_or_copy;
 
 #[cfg(windows)]
-fn symlink_or_copy(src: &Path, dst: &Path) -> Result<()> {
+pub(crate) fn symlink_or_copy(src: &Path, dst: &Path) -> Result<()> {
     // Pre-Windows 10, symlinks require admin privileges. Since Windows 10, they
     // require Developer Mode. If it fails, fall back to copying the file.
     if fs::symlink_file(src, dst).is_err() {
@@ -113,7 +113,7 @@ fn symlink_or_copy(src: &Path, dst: &Path) -> Result<()> {
 }
 
 #[cfg(not(any(unix, windows)))]
-use self::fs::copy as symlink_or_copy;
+pub(crate) use self::fs::copy as symlink_or_copy;
 
 #[cfg(any(unix, windows))]
 pub(crate) use self::fs::symlink_dir;

--- a/gen/build/src/paths.rs
+++ b/gen/build/src/paths.rs
@@ -16,12 +16,6 @@ pub(crate) fn out_dir() -> Result<PathBuf> {
         .ok_or(Error::MissingOutDir)
 }
 
-pub(crate) fn cc_build(prj: &Project) -> cc::Build {
-    let mut build = cc::Build::new();
-    build.include(include_dir(prj));
-    build
-}
-
 // Symlink the header file into a predictable place. The header generated from
 // path/to/mod.rs gets linked to target/cxxbridge/path/to/mod.rs.h.
 pub(crate) fn symlink_header(prj: &Project, path: &Path, original: &Path) {

--- a/gen/build/src/paths.rs
+++ b/gen/build/src/paths.rs
@@ -70,20 +70,19 @@ pub(crate) fn out_with_extension(prj: &Project, path: &Path, ext: &str) -> Resul
     let mut file_name = path.file_name().unwrap().to_owned();
     file_name.push(ext);
 
-    let out_dir = out_dir()?;
     let rel = relative_to_parent_of_target_dir(prj, path)?;
-    Ok(out_dir.join(rel).with_file_name(file_name))
+    Ok(prj.out_dir.join(rel).with_file_name(file_name))
 }
 
 pub(crate) fn include_dir(prj: &Project) -> PathBuf {
     match &prj.target_dir {
         TargetDir::Path(target_dir) => target_dir.join("cxxbridge"),
-        TargetDir::Unknown => out_dir().unwrap().join("cxxbridge"), // FIXME no unwrap
+        TargetDir::Unknown => prj.out_dir.join("cxxbridge"),
     }
 }
 
-pub(crate) fn search_parents_for_target_dir() -> TargetDir {
-    let mut dir = match out_dir().and_then(canonicalize) {
+pub(crate) fn search_parents_for_target_dir(out_dir: &Path) -> TargetDir {
+    let mut dir = match out_dir.canonicalize() {
         Ok(dir) => dir,
         Err(_) => return TargetDir::Unknown,
     };

--- a/gen/build/src/paths.rs
+++ b/gen/build/src/paths.rs
@@ -87,7 +87,9 @@ pub(crate) fn search_parents_for_target_dir(out_dir: &Path) -> TargetDir {
         Err(_) => return TargetDir::Unknown,
     };
     loop {
-        if dir.ends_with("target") {
+        let is_target = dir.ends_with("target");
+        let parent_contains_cargo_toml = dir.with_file_name("Cargo.toml").exists();
+        if is_target && parent_contains_cargo_toml {
             return TargetDir::Path(dir);
         }
         if !dir.pop() {

--- a/gen/build/src/paths.rs
+++ b/gen/build/src/paths.rs
@@ -19,9 +19,6 @@ pub(crate) fn out_dir() -> Result<PathBuf> {
 pub(crate) fn cc_build(prj: &Project) -> cc::Build {
     let mut build = cc::Build::new();
     build.include(include_dir(prj));
-    if let TargetDir::Path(target_dir) = &prj.target_dir {
-        build.include(target_dir.parent().unwrap());
-    }
     build
 }
 

--- a/gen/build/src/paths.rs
+++ b/gen/build/src/paths.rs
@@ -19,6 +19,9 @@ pub(crate) fn out_dir() -> Result<PathBuf> {
 pub(crate) fn cc_build(prj: &Project) -> cc::Build {
     let mut build = cc::Build::new();
     build.include(include_dir(prj));
+    if let Some(manifest_dir) = env::var_os("CARGO_MANIFEST_DIR") {
+        build.include(manifest_dir);
+    }
     build
 }
 

--- a/gen/build/src/paths.rs
+++ b/gen/build/src/paths.rs
@@ -1,4 +1,3 @@
-use crate::cargo;
 use crate::error::{Error, Result};
 use crate::gen::fs;
 use std::env;
@@ -80,20 +79,14 @@ pub(crate) fn include_dir(target_dir: &TargetDir) -> PathBuf {
     target_dir.join("cxxbridge")
 }
 
-pub(crate) fn target_dir() -> Result<TargetDir> {
-    let fallback_err = match cargo::target_dir() {
-        Ok(target_dir) => return Ok(target_dir),
-        Err(err) => Error::TargetDir(err),
-    };
-
-    // Fallback if Cargo did not work.
-    let mut dir = out_dir().and_then(canonicalize)?;
+pub(crate) fn search_parents_for_target_dir() -> Option<TargetDir> {
+    let mut dir = out_dir().and_then(canonicalize).ok()?;
     loop {
         if dir.ends_with("target") {
-            return Ok(TargetDir(dir));
+            return Some(TargetDir(dir));
         }
         if !dir.pop() {
-            return Err(fallback_err);
+            return None;
         }
     }
 }

--- a/gen/build/src/paths.rs
+++ b/gen/build/src/paths.rs
@@ -99,9 +99,11 @@ pub(crate) fn search_parents_for_target_dir(out_dir: &Path) -> TargetDir {
 pub(crate) use self::fs::symlink_file as symlink_or_copy;
 
 #[cfg(windows)]
-pub(crate) fn symlink_or_copy(src: &Path, dst: &Path) -> Result<()> {
+pub(crate) fn symlink_or_copy(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<()> {
     // Pre-Windows 10, symlinks require admin privileges. Since Windows 10, they
     // require Developer Mode. If it fails, fall back to copying the file.
+    let src = src.as_ref();
+    let dst = dst.as_ref();
     if fs::symlink_file(src, dst).is_err() {
         fs::copy(src, dst)?;
     }

--- a/gen/build/src/paths.rs
+++ b/gen/build/src/paths.rs
@@ -82,8 +82,13 @@ pub(crate) fn include_dir(prj: &Project) -> PathBuf {
 }
 
 pub(crate) fn search_parents_for_target_dir(out_dir: &Path) -> TargetDir {
+    // fs::canonicalize on Windows produces UNC paths which cl.exe is unable to
+    // handle in includes.
+    // https://github.com/rust-lang/rust/issues/42869
+    // https://github.com/alexcrichton/cc-rs/issues/169
+    let mut also_try_canonical = cfg!(not(windows));
+
     let mut dir = out_dir.to_owned();
-    let mut also_try_canonical = true;
     loop {
         let is_target = dir.ends_with("target");
         let parent_contains_cargo_toml = dir.with_file_name("Cargo.toml").exists();

--- a/gen/build/src/paths.rs
+++ b/gen/build/src/paths.rs
@@ -19,9 +19,6 @@ pub(crate) fn out_dir() -> Result<PathBuf> {
 pub(crate) fn cc_build(prj: &Project) -> cc::Build {
     let mut build = cc::Build::new();
     build.include(include_dir(prj));
-    if let Some(manifest_dir) = env::var_os("CARGO_MANIFEST_DIR") {
-        build.include(manifest_dir);
-    }
     build
 }
 
@@ -70,7 +67,11 @@ pub(crate) fn include_dir(prj: &Project) -> PathBuf {
     }
 }
 
-fn package_name() -> Option<OsString> {
+pub(crate) fn manifest_dir() -> Option<PathBuf> {
+    env::var_os("CARGO_MANIFEST_DIR").map(PathBuf::from)
+}
+
+pub(crate) fn package_name() -> Option<OsString> {
     env::var_os("CARGO_PKG_NAME")
 }
 
@@ -117,3 +118,11 @@ fn symlink_or_copy(src: &Path, dst: &Path) -> Result<()> {
 
 #[cfg(not(any(unix, windows)))]
 use self::fs::copy as symlink_or_copy;
+
+#[cfg(any(unix, windows))]
+pub(crate) use self::fs::symlink_dir;
+
+#[cfg(not(any(unix, windows)))]
+pub(crate) fn symlink_dir(_src: impl AsRef<Path>, _dst: impl AsRef<Path>) -> Result<()> {
+    Ok(())
+}

--- a/gen/build/src/paths.rs
+++ b/gen/build/src/paths.rs
@@ -9,7 +9,7 @@ pub(crate) enum TargetDir {
     Unknown,
 }
 
-fn out_dir() -> Result<PathBuf> {
+pub(crate) fn out_dir() -> Result<PathBuf> {
     env::var_os("OUT_DIR")
         .map(PathBuf::from)
         .ok_or(Error::MissingOutDir)

--- a/gen/build/src/paths.rs
+++ b/gen/build/src/paths.rs
@@ -40,10 +40,6 @@ pub(crate) fn namespaced(base: &Path, rel_path: &Path) -> PathBuf {
     path
 }
 
-pub(crate) fn symlink_namespaced(src: &Path, base: &Path, rel_path: &Path) {
-    let _ = symlink_or_copy(src, namespaced(base, rel_path));
-}
-
 pub(crate) trait PathExt {
     fn with_appended_extension(&self, suffix: impl AsRef<OsStr>) -> PathBuf;
 }

--- a/gen/src/fs.rs
+++ b/gen/src/fs.rs
@@ -34,14 +34,6 @@ macro_rules! err {
     }
 }
 
-pub(crate) fn canonicalize(path: impl AsRef<Path>) -> Result<PathBuf> {
-    let path = path.as_ref();
-    match std::fs::canonicalize(path) {
-        Ok(string) => Ok(string),
-        Err(e) => err!(e, "Unable to canonicalize path: `{}`", path),
-    }
-}
-
 pub(crate) fn copy(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<u64> {
     let from = from.as_ref();
     let to = to.as_ref();

--- a/tests/BUCK
+++ b/tests/BUCK
@@ -24,9 +24,10 @@ cxx_library(
         ":gen-lib-source",
         ":gen-module-source",
     ],
+    header_namespace = "cxx-test-suite",
     headers = {
-        "ffi/lib.rs.h": ":gen-lib-header",
-        "ffi/tests.h": "ffi/tests.h",
+        "lib.rs.h": ":gen-lib-header",
+        "tests.h": "ffi/tests.h",
     },
     deps = ["//:core"],
 )

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -26,6 +26,8 @@ cc_library(
         ":gen-module-source",
     ],
     hdrs = ["ffi/tests.h"],
+    include_prefix = "cxx-test-suite",
+    strip_include_prefix = "ffi",
     deps = [
         ":lib-include",
         "//:core",
@@ -51,7 +53,7 @@ genrule(
 cc_library(
     name = "lib-include",
     hdrs = [":gen-lib-header"],
-    include_prefix = "tests/ffi",
+    include_prefix = "cxx-test-suite",
 )
 
 genrule(

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -23,7 +23,7 @@ pub mod ffi {
     }
 
     extern "C" {
-        include!("tests/ffi/tests.h");
+        include!("cxx-test-suite/tests.h");
 
         type C;
 

--- a/tests/ffi/module.rs
+++ b/tests/ffi/module.rs
@@ -4,7 +4,7 @@
 #[cxx::bridge(namespace = tests)]
 pub mod ffi {
     extern "C" {
-        include!("tests/ffi/tests.h");
+        include!("cxx-test-suite/tests.h");
 
         type C = crate::ffi::C;
 

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -1,5 +1,5 @@
-#include "tests/ffi/tests.h"
-#include "tests/ffi/lib.rs.h"
+#include "cxx-test-suite/tests.h"
+#include "cxx-test-suite/lib.rs.h"
 #include <cstring>
 #include <iterator>
 #include <numeric>

--- a/third-party/Cargo.lock
+++ b/third-party/Cargo.lock
@@ -115,14 +115,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cxxbridge-demo"
-version = "0.0.0"
-dependencies = [
- "cxx",
- "cxx-build",
-]
-
-[[package]]
 name = "cxxbridge-flags"
 version = "0.3.9"
 
@@ -134,6 +126,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "demo"
+version = "0.0.0"
+dependencies = [
+ "cxx",
+ "cxx-build",
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #213. Fixes #88. Supersedes #214. Supersedes #253.

The major improvement is that we no longer care where Cargo's target dir is located. Instead of doing anything based on relative paths from the target dir, we do it only based on the paths the user passes to cxx_build::bridge, which we know are relative to the manifest dir because that's the current directory when a build script runs.

For an invocation like `cxx_build::bridge("src/lib.rs")` the resulting layout of the OUT_DIR would be:

```console
$  exa -T target/debug/build/cxx-demo-1848f7a3fc5320f1/out/
target/debug/build/cxx-demo-1848f7a3fc5320f1/out
└── cxxbridge
   ├── cxx-demo
   │  └── src
   │     ├── lib.rs -> ./lib.rs.h
   │     ├── lib.rs.cc
   │     └── lib.rs.h
   └── rust
      └── cxx.h
```

and the include paths would be `#include "cxx-demo/src/lib.rs.h"`, where `cxx-demo` is the crate name and `src/lib.rs` is the path that the crate's build script gave cxx_build.