### PR TITLE
Accept `-` to mean stdin in command line code generator

### DIFF
--- a/gen/src/fs.rs
+++ b/gen/src/fs.rs
@@ -2,7 +2,7 @@
 
 use std::error::Error as StdError;
 use std::fmt::{self, Display};
-use std::io;
+use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;
@@ -63,6 +63,14 @@ pub(crate) fn read(path: impl AsRef<Path>) -> Result<Vec<u8>> {
     match std::fs::read(path) {
         Ok(string) => Ok(string),
         Err(e) => err!(e, "Failed to read file `{}`", path),
+    }
+}
+
+pub(crate) fn read_stdin() -> Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    match io::stdin().read_to_end(&mut bytes) {
+        Ok(_len) => Ok(bytes),
+        Err(e) => err!(e, "Failed to read input from stdin"),
     }
 }
 

--- a/gen/src/mod.rs
+++ b/gen/src/mod.rs
@@ -80,7 +80,11 @@ pub(super) fn generate_from_path(path: &Path, opt: &Opt) -> GeneratedCode {
 }
 
 fn read_to_string(path: &Path) -> Result<String> {
-    let bytes = fs::read(path)?;
+    let bytes = if path == Path::new("-") {
+        fs::read_stdin()
+    } else {
+        fs::read(path)
+    }?;
     match String::from_utf8(bytes) {
         Ok(string) => Ok(string),
         Err(err) => Err(Error::Utf8(path.to_owned(), err.utf8_error())),


### PR DESCRIPTION
Closes #278.

Tested with:

```console
$ echo '#[cxx::bridge] mod ffi { struct S { x: u8 } }' | target/debug/cxxbridge -
```