### PR TITLE
Reproduce issue 290 (no cause chain on errors)

### DIFF
--- a/no-causes/Cargo.toml
+++ b/no-causes/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "no-causes"
+version = "0.0.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+anyhow = "1.0"
+cxx = { path = ".." }
+
+[build-dependencies]
+cxx-build = { path = "../gen/build" }
+
+[workspace]

--- a/no-causes/build.rs
+++ b/no-causes/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    cxx_build::bridge("src/main.rs").file("src/lib.cc").compile("no-causes");
+}

--- a/no-causes/include/lib.h
+++ b/no-causes/include/lib.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void cthing();

--- a/no-causes/src/lib.cc
+++ b/no-causes/src/lib.cc
@@ -1,0 +1,6 @@
+#include "no-causes/include/lib.h"
+#include "no-causes/src/main.rs.h"
+
+void cthing() {
+  rustthing();
+}

--- a/no-causes/src/main.rs
+++ b/no-causes/src/main.rs
@@ -1,0 +1,23 @@
+use anyhow::{anyhow, Result};
+
+#[cxx::bridge]
+mod ffi {
+    extern "C" {
+        include!("no-causes/include/lib.h");
+
+        fn cthing() -> Result<()>;
+    }
+
+    extern "Rust" {
+        fn rustthing() -> Result<()>;
+    }
+}
+
+fn rustthing() -> Result<()> {
+    Err(anyhow!("no such file or directory").context("failed to open: /nonexist"))
+}
+
+fn main() -> Result<()> {
+    ffi::cthing()?;
+    Ok(())
+}


### PR DESCRIPTION
Reproduces #290. Will use this for testing a fix.

Actual:

```console
$ cargo run --manifest-path no-causes/Cargo.toml
Error: failed to open: /nonexist
```

Desired:

```console
$ cargo run --manifest-path no-causes/Cargo.toml
Error: failed to open: /nonexist

Caused by:
    no such file or directory
```