### PR TITLE
Detect when symlink not enabled

### DIFF
--- a/gen/build/Cargo.toml
+++ b/gen/build/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "C++ code generator for integrating `cxx` crate into a Cargo build."
 repository = "https://github.com/dtolnay/cxx"
+exclude = ["build.rs"]
 keywords = ["ffi"]
 categories = ["development-tools::ffi"]
 

--- a/gen/build/build.rs
+++ b/gen/build/build.rs
@@ -1,0 +1,29 @@
+use std::io::{self, Write};
+use std::path::Path;
+use std::process;
+
+const NOSYMLINK: &str = "
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When building `cxx` from a git clone, git's symlink support needs
+to be enabled on platforms that have it off by default (Windows).
+Either use:
+
+   $ git config --global core.symlinks true
+
+prior to cloning, or else use:
+
+   $ git clone -c core.symlinks=true ...
+
+for the clone.
+
+Symlinks are only required for local development, not for building
+`cxx` as a (possibly transitive) dependency from crates.io.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+";
+
+fn main() {
+    if !Path::new("src/syntax/mod.rs").exists() {
+        let _ = io::stderr().lock().write_all(NOSYMLINK.as_bytes());
+        process::exit(1);
+    }
+}

--- a/gen/cmd/Cargo.toml
+++ b/gen/cmd/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "C++ code generator for integrating `cxx` crate into a non-Cargo build."
 repository = "https://github.com/dtolnay/cxx"
+exclude = ["build.rs"]
 keywords = ["ffi"]
 categories = ["development-tools::ffi"]
 

--- a/gen/cmd/build.rs
+++ b/gen/cmd/build.rs
@@ -1,0 +1,29 @@
+use std::io::{self, Write};
+use std::path::Path;
+use std::process;
+
+const NOSYMLINK: &str = "
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When building `cxx` from a git clone, git's symlink support needs
+to be enabled on platforms that have it off by default (Windows).
+Either use:
+
+   $ git config --global core.symlinks true
+
+prior to cloning, or else use:
+
+   $ git clone -c core.symlinks=true ...
+
+for the clone.
+
+Symlinks are only required for local development, not for building
+`cxx` as a (possibly transitive) dependency from crates.io.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+";
+
+fn main() {
+    if !Path::new("src/syntax/mod.rs").exists() {
+        let _ = io::stderr().lock().write_all(NOSYMLINK.as_bytes());
+        process::exit(1);
+    }
+}

--- a/gen/lib/Cargo.toml
+++ b/gen/lib/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "C++ code generator for integrating `cxx` crate into higher level tools."
 repository = "https://github.com/dtolnay/cxx"
+exclude = ["build.rs"]
 keywords = ["ffi"]
 categories = ["development-tools::ffi"]
 

--- a/gen/lib/build.rs
+++ b/gen/lib/build.rs
@@ -1,0 +1,29 @@
+use std::io::{self, Write};
+use std::path::Path;
+use std::process;
+
+const NOSYMLINK: &str = "
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When building `cxx` from a git clone, git's symlink support needs
+to be enabled on platforms that have it off by default (Windows).
+Either use:
+
+   $ git config --global core.symlinks true
+
+prior to cloning, or else use:
+
+   $ git clone -c core.symlinks=true ...
+
+for the clone.
+
+Symlinks are only required for local development, not for building
+`cxx` as a (possibly transitive) dependency from crates.io.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+";
+
+fn main() {
+    if !Path::new("src/syntax/mod.rs").exists() {
+        let _ = io::stderr().lock().write_all(NOSYMLINK.as_bytes());
+        process::exit(1);
+    }
+}

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Implementation detail of the `cxx` crate."
 repository = "https://github.com/dtolnay/cxx"
-exclude = ["README.md"]
+exclude = ["build.rs", "README.md"]
 keywords = ["ffi"]
 categories = ["development-tools::ffi"]
 

--- a/macro/build.rs
+++ b/macro/build.rs
@@ -1,0 +1,29 @@
+use std::io::{self, Write};
+use std::path::Path;
+use std::process;
+
+const NOSYMLINK: &str = "
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When building `cxx` from a git clone, git's symlink support needs
+to be enabled on platforms that have it off by default (Windows).
+Either use:
+
+   $ git config --global core.symlinks true
+
+prior to cloning, or else use:
+
+   $ git clone -c core.symlinks=true ...
+
+for the clone.
+
+Symlinks are only required for local development, not for building
+`cxx` as a (possibly transitive) dependency from crates.io.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+";
+
+fn main() {
+    if !Path::new("src/syntax/mod.rs").exists() {
+        let _ = io::stderr().lock().write_all(NOSYMLINK.as_bytes());
+        process::exit(1);
+    }
+}


### PR DESCRIPTION
Only needed for local development (not for building `cxx` as a dependency from crates.io).