### PR TITLE
Add -o flag to set output file for cli

### DIFF
--- a/gen/cmd/src/test.rs
+++ b/gen/cmd/src/test.rs
@@ -31,6 +31,10 @@ OPTIONS:
             parse or even require the given paths to exist; they simply go
             into the generated C++ code as #include lines.
                \x20
+    -o, --output <output>
+            Path of file to write as output. Output goes to stdout if -o is
+            not specified.
+               \x20
     -V, --version
             Print version information.
 ";


### PR DESCRIPTION
`cxxbridge ... -o generated.cc` is equivalent to `cxxbridge ... > generated.cc` but can be more convenient to some build systems, e.g. would have avoided needing a new `run_binary_capture_stdout.sh` in https://fuchsia.googlesource.com/fuchsia/+/f43c8da66eba6353f0b8c8a3673bb31a34751b7f%5E%21/ or a new `redirect_stdout` functionality in https://fuchsia.googlesource.com/fuchsia/+/c33dc953dff0445edede5ab135b8aeb12235f6a2%5E%21/.