### PR TITLE
Import from libcore/liballoc where possible

### DIFF
--- a/src/cxx_string.rs
+++ b/src/cxx_string.rs
@@ -1,7 +1,7 @@
-use std::borrow::Cow;
-use std::fmt::{self, Debug, Display};
-use std::slice;
-use std::str::{self, Utf8Error};
+use alloc::borrow::Cow;
+use core::fmt::{self, Debug, Display};
+use core::slice;
+use core::str::{self, Utf8Error};
 
 extern "C" {
     #[link_name = "cxxbridge04$cxx_string$data"]

--- a/src/cxx_string.rs
+++ b/src/cxx_string.rs
@@ -1,4 +1,5 @@
 use alloc::borrow::Cow;
+use alloc::string::String;
 use core::fmt::{self, Debug, Display};
 use core::slice;
 use core::str::{self, Utf8Error};

--- a/src/cxx_vector.rs
+++ b/src/cxx_vector.rs
@@ -1,9 +1,9 @@
 use crate::cxx_string::CxxString;
-use std::ffi::c_void;
-use std::fmt::{self, Display};
-use std::marker::PhantomData;
-use std::mem;
-use std::ptr;
+use core::ffi::c_void;
+use core::fmt::{self, Display};
+use core::marker::PhantomData;
+use core::mem;
+use core::ptr;
 
 /// Binding to C++ `std::vector<T, std::allocator<T>>`.
 ///

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use core::fmt::{self, Debug, Display};
 
 /// Exception thrown from an `extern "C"` function.

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Debug, Display};
+use core::fmt::{self, Debug, Display};
 
 /// Exception thrown from an `extern "C"` function.
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,6 +348,7 @@
 //!
 //! [https://github.com/dtolnay/cxx]: https://github.com/dtolnay/cxx
 
+#![no_std]
 #![doc(html_root_url = "https://docs.rs/cxx/0.4.4")]
 #![deny(improper_ctypes)]
 #![allow(non_camel_case_types)]
@@ -371,6 +372,7 @@
 extern crate link_cplusplus;
 
 extern crate alloc;
+extern crate std;
 
 #[macro_use]
 mod macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,6 +370,8 @@
 #[cfg(built_with_cargo)]
 extern crate link_cplusplus;
 
+extern crate alloc;
+
 #[macro_use]
 mod macros;
 

--- a/src/opaque.rs
+++ b/src/opaque.rs
@@ -1,4 +1,4 @@
-use std::mem;
+use core::mem;
 
 // . size = 0
 // . align = 1

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,5 +1,7 @@
 use crate::exception::Exception;
 use crate::rust_str::RustStr;
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
 use core::fmt::Display;
 use core::ptr;
 use core::result::Result as StdResult;

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,10 +1,10 @@
 use crate::exception::Exception;
 use crate::rust_str::RustStr;
-use std::fmt::Display;
-use std::ptr;
-use std::result::Result as StdResult;
-use std::slice;
-use std::str;
+use core::fmt::Display;
+use core::ptr;
+use core::result::Result as StdResult;
+use core::slice;
+use core::str;
 
 #[repr(C)]
 pub union Result {

--- a/src/rust_sliceu8.rs
+++ b/src/rust_sliceu8.rs
@@ -1,6 +1,6 @@
-use std::mem;
-use std::ptr::NonNull;
-use std::slice;
+use core::mem;
+use core::ptr::NonNull;
+use core::slice;
 
 // Not necessarily ABI compatible with &[u8]. Codegen performs the translation.
 #[repr(C)]

--- a/src/rust_str.rs
+++ b/src/rust_str.rs
@@ -1,7 +1,7 @@
-use std::mem;
-use std::ptr::NonNull;
-use std::slice;
-use std::str;
+use core::mem;
+use core::ptr::NonNull;
+use core::slice;
+use core::str;
 
 // Not necessarily ABI compatible with &str. Codegen performs the translation.
 #[repr(C)]

--- a/src/rust_string.rs
+++ b/src/rust_string.rs
@@ -1,3 +1,4 @@
+use alloc::string::String;
 use core::mem;
 
 #[repr(C)]

--- a/src/rust_string.rs
+++ b/src/rust_string.rs
@@ -1,4 +1,4 @@
-use std::mem;
+use core::mem;
 
 #[repr(C)]
 pub struct RustString {

--- a/src/rust_vec.rs
+++ b/src/rust_vec.rs
@@ -1,4 +1,6 @@
 use crate::rust_string::RustString;
+use alloc::string::String;
+use alloc::vec::Vec;
 use core::mem::ManuallyDrop;
 
 #[repr(C)]

--- a/src/rust_vec.rs
+++ b/src/rust_vec.rs
@@ -1,5 +1,5 @@
 use crate::rust_string::RustString;
-use std::mem::ManuallyDrop;
+use core::mem::ManuallyDrop;
 
 #[repr(C)]
 pub struct RustVec<T> {

--- a/src/symbols/exception.rs
+++ b/src/symbols/exception.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+use alloc::string::String;
 use core::slice;
 
 #[export_name = "cxxbridge04$exception"]

--- a/src/symbols/exception.rs
+++ b/src/symbols/exception.rs
@@ -1,4 +1,4 @@
-use std::slice;
+use core::slice;
 
 #[export_name = "cxxbridge04$exception"]
 unsafe extern "C" fn exception(ptr: *const u8, len: usize) -> *const u8 {

--- a/src/symbols/rust_str.rs
+++ b/src/symbols/rust_str.rs
@@ -1,5 +1,5 @@
-use std::slice;
-use std::str;
+use core::slice;
+use core::str;
 
 #[export_name = "cxxbridge04$str$valid"]
 unsafe extern "C" fn str_valid(ptr: *const u8, len: usize) -> bool {

--- a/src/symbols/rust_string.rs
+++ b/src/symbols/rust_string.rs
@@ -1,7 +1,7 @@
-use std::mem::{ManuallyDrop, MaybeUninit};
-use std::ptr;
-use std::slice;
-use std::str;
+use core::mem::{ManuallyDrop, MaybeUninit};
+use core::ptr;
+use core::slice;
+use core::str;
 
 #[export_name = "cxxbridge04$string$new"]
 unsafe extern "C" fn string_new(this: &mut MaybeUninit<String>) {

--- a/src/symbols/rust_string.rs
+++ b/src/symbols/rust_string.rs
@@ -1,3 +1,5 @@
+use alloc::borrow::ToOwned;
+use alloc::string::String;
 use core::mem::{ManuallyDrop, MaybeUninit};
 use core::ptr;
 use core::slice;

--- a/src/symbols/rust_vec.rs
+++ b/src/symbols/rust_vec.rs
@@ -1,7 +1,7 @@
 use crate::rust_string::RustString;
 use crate::rust_vec::RustVec;
-use std::mem;
-use std::ptr;
+use core::mem;
+use core::ptr;
 
 macro_rules! rust_vec_shims {
     ($segment:expr, $ty:ty) => {

--- a/src/symbols/rust_vec.rs
+++ b/src/symbols/rust_vec.rs
@@ -1,5 +1,6 @@
 use crate::rust_string::RustString;
 use crate::rust_vec::RustVec;
+use alloc::vec::Vec;
 use core::mem;
 use core::ptr;
 

--- a/src/unique_ptr.rs
+++ b/src/unique_ptr.rs
@@ -1,11 +1,11 @@
 use crate::cxx_string::CxxString;
 use crate::cxx_vector::{self, CxxVector, VectorElement};
-use std::ffi::c_void;
-use std::fmt::{self, Debug, Display};
-use std::marker::PhantomData;
-use std::mem;
-use std::ops::{Deref, DerefMut};
-use std::ptr;
+use core::ffi::c_void;
+use core::fmt::{self, Debug, Display};
+use core::marker::PhantomData;
+use core::mem;
+use core::ops::{Deref, DerefMut};
+use core::ptr;
 
 /// Binding to C++ `std::unique_ptr<T, std::default_delete<T>>`.
 #[repr(C)]


### PR DESCRIPTION
This makes it easier to see where libstd is really being needed, and evaluate possible no-std support.

Answer: currently used almost nowhere. We use liballoc in a couple places related to error handling, and for https://docs.rs/cxx/0.4.4/cxx/struct.CxxString.html#method.to_string_lossy which can easily be put behind a feature cfg. And we use libstd currently *only* for catching and aborting on unwind across the FFI. Seeing as `cfg(panic = "abort")` is getting ready to land (https://github.com/rust-lang/rust/pull/74754), it will likely be quite easy to support no-std in `panic = "abort"` mode at least, which is potentially relevant to Fuchsia. For `panic = "unwind"` mode we'll have to think about how else to rule out the UB from unwinding a Rust panic into C++ code.