### PR TITLE
Make sure MaybeUninit is part of generated code for Rust functions returning Result

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -217,6 +217,7 @@ fn write_include_cxxbridge(out: &mut OutFile, apis: &[Api], types: &Types) {
                     out.include.string = true;
                     needs_rust_str = true;
                     needs_rust_error = true;
+                    needs_maybe_uninit = true;
                 }
                 for arg in &efn.args {
                     if arg.ty != RustString && types.needs_indirect_abi(&arg.ty) {


### PR DESCRIPTION
The `indirect_return` functions checks if a function signature either throws or needs indirect ABI and decides if `::rust::MaybeUninit` should be added to the generated C++ code. However the declaration for the `::rust::MaybeUninit` was only generated if the function needed indirect ABI so I ended up with functions that returned a Result generated code that used `::rust::MaybeUninit` but didn't have the declaration. This PR should make sure that the `::rust::MaybeUninit` declaration is part of the generated code if a function returns a Result.