### PR TITLE
Bump gen/lib version to match cxx.

### DIFF
--- a/gen/lib/Cargo.toml
+++ b/gen/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cxx-gen"
-version = "0.0.1"
+version = "0.4.0"
 authors = ["Adrian Taylor <adetaylor@chromium.org>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
We need to stay roughly correlated such that cargo users do not
get mismatches between `cxxbridge04$` (generated by the main cxx
crate) and `cxxbridge03$` (which is what they get when they fetch
cxx-gen 0.1 from cargo).

In other words, even if the goal is to rev this library on a
different cadence, that cadence needs to be at least as fast
as breaking changes in `cxx` itself.