### PR TITLE
Use more systematic naming for generated code targets

### DIFF
--- a/demo/BUCK
+++ b/demo/BUCK
@@ -4,23 +4,23 @@ rust_binary(
     name = "demo",
     srcs = glob(["src/**/*.rs"]),
     deps = [
+        ":bridge",
         ":demo-sys",
-        ":gen",
         "//:cxx",
     ],
 )
 
 cxx_library(
-    name = "gen",
-    srcs = [":gen-source"],
+    name = "bridge",
+    srcs = [":bridge/source"],
     deps = [
+        ":bridge/include",
         ":demo-include",
-        ":include",
     ],
 )
 
 genrule(
-    name = "gen-header",
+    name = "bridge/header",
     srcs = ["src/main.rs"],
     out = "src/main.rs.h",
     cmd = "$(exe //:codegen) --header ${SRCS} > ${OUT}",
@@ -28,7 +28,7 @@ genrule(
 )
 
 genrule(
-    name = "gen-source",
+    name = "bridge/source",
     srcs = ["src/main.rs"],
     out = "src/main.rs.cc",
     cmd = "$(exe //:codegen) ${SRCS} > ${OUT}",
@@ -36,8 +36,8 @@ genrule(
 )
 
 cxx_library(
-    name = "include",
-    exported_headers = [":gen-header"],
+    name = "bridge/include",
+    exported_headers = [":bridge/header"],
 )
 
 cxx_library(
@@ -45,8 +45,8 @@ cxx_library(
     srcs = ["src/demo.cc"],
     compiler_flags = ["-std=c++14"],
     deps = [
+        ":bridge/include",
         ":demo-include",
-        ":include",
     ],
 )
 

--- a/demo/BUILD
+++ b/demo/BUILD
@@ -5,23 +5,23 @@ rust_binary(
     name = "demo",
     srcs = glob(["src/**/*.rs"]),
     deps = [
+        ":bridge",
         ":demo-sys",
-        ":gen",
         "//:cxx",
     ],
 )
 
 cc_library(
-    name = "gen",
-    srcs = [":gen-source"],
+    name = "bridge",
+    srcs = [":bridge/source"],
     deps = [
+        ":bridge/include",
         ":demo-include",
-        ":include",
     ],
 )
 
 genrule(
-    name = "gen-header",
+    name = "bridge/header",
     srcs = ["src/main.rs"],
     outs = ["src/main.rs.h"],
     cmd = "$(location //:codegen) --header $< > $@",
@@ -29,7 +29,7 @@ genrule(
 )
 
 genrule(
-    name = "gen-source",
+    name = "bridge/source",
     srcs = ["src/main.rs"],
     outs = ["src/main.rs.cc"],
     cmd = "$(location //:codegen) $< > $@",
@@ -37,8 +37,8 @@ genrule(
 )
 
 cc_library(
-    name = "include",
-    hdrs = [":gen-header"],
+    name = "bridge/include",
+    hdrs = [":bridge/header"],
 )
 
 cc_library(
@@ -46,8 +46,8 @@ cc_library(
     srcs = ["src/demo.cc"],
     copts = ["-std=c++14"],
     deps = [
+        ":bridge/include",
         ":demo-include",
-        ":include",
     ],
 )
 

--- a/tests/BUCK
+++ b/tests/BUCK
@@ -23,33 +23,33 @@ cxx_library(
     name = "impl",
     srcs = [
         "ffi/tests.cc",
-        ":gen-lib-source",
-        ":gen-module-source",
+        ":bridge/source",
+        ":module/source",
     ],
     header_namespace = "cxx-test-suite",
     headers = {
-        "lib.rs.h": ":gen-lib-header",
+        "lib.rs.h": ":bridge/header",
         "tests.h": "ffi/tests.h",
     },
     deps = ["//:core"],
 )
 
 genrule(
-    name = "gen-lib-header",
+    name = "bridge/header",
     srcs = ["ffi/lib.rs"],
     out = "ffi/lib.rs.h",
     cmd = "$(exe //:codegen) --header ${SRCS} > ${OUT}",
 )
 
 genrule(
-    name = "gen-lib-source",
+    name = "bridge/source",
     srcs = ["ffi/lib.rs"],
     out = "ffi/lib.rs.cc",
     cmd = "$(exe //:codegen) ${SRCS} > ${OUT}",
 )
 
 genrule(
-    name = "gen-module-source",
+    name = "module/source",
     srcs = ["ffi/module.rs"],
     out = "ffi/module.rs.cc",
     cmd = "$(exe //:codegen) ${SRCS} > ${OUT}",

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -24,20 +24,20 @@ cc_library(
     name = "impl",
     srcs = [
         "ffi/tests.cc",
-        ":gen-lib-source",
-        ":gen-module-source",
+        ":bridge/source",
+        ":module/source",
     ],
     hdrs = ["ffi/tests.h"],
     include_prefix = "cxx-test-suite",
     strip_include_prefix = "ffi",
     deps = [
-        ":lib-include",
+        ":bridge/include",
         "//:core",
     ],
 )
 
 genrule(
-    name = "gen-lib-header",
+    name = "bridge/header",
     srcs = ["ffi/lib.rs"],
     outs = ["ffi/lib.rs.h"],
     cmd = "$(location //:codegen) --header $< > $@",
@@ -45,7 +45,7 @@ genrule(
 )
 
 genrule(
-    name = "gen-lib-source",
+    name = "bridge/source",
     srcs = ["ffi/lib.rs"],
     outs = ["ffi/lib.rs.cc"],
     cmd = "$(location //:codegen) $< > $@",
@@ -53,14 +53,14 @@ genrule(
 )
 
 cc_library(
-    name = "lib-include",
-    hdrs = [":gen-lib-header"],
+    name = "bridge/include",
+    hdrs = [":bridge/header"],
     include_prefix = "cxx-test-suite",
     strip_include_prefix = "ffi",
 )
 
 genrule(
-    name = "gen-module-source",
+    name = "module/source",
     srcs = ["ffi/module.rs"],
     outs = ["ffi/module.rs.cc"],
     cmd = "$(location //:codegen) $< > $@",


### PR DESCRIPTION
This will be more amenable to factoring out to a macro.