### PR TITLE
Handle multiple outputs from the same cxxbridge invocation

### DIFF
--- a/gen/cmd/src/app.rs
+++ b/gen/cmd/src/app.rs
@@ -65,18 +65,25 @@ pub(super) fn from_args() -> Opt {
         .unwrap_or_default()
         .map(str::to_owned)
         .collect();
-    let output = match matches.value_of_os(OUTPUT) {
-        None => Output::Stdout,
-        Some(path) if path == "-" => Output::Stdout,
-        Some(path) => Output::File(PathBuf::from(path)),
-    };
+
+    let mut outputs = Vec::new();
+    for path in matches.values_of_os(OUTPUT).unwrap_or_default() {
+        outputs.push(if path == "-" {
+            Output::Stdout
+        } else {
+            Output::File(PathBuf::from(path))
+        });
+    }
+    if outputs.is_empty() {
+        outputs.push(Output::Stdout);
+    }
 
     Opt {
         input,
         cxx_impl_annotations,
         header,
         include,
-        output,
+        outputs,
     }
 }
 
@@ -142,6 +149,7 @@ not specified.
         .long(OUTPUT)
         .short("o")
         .takes_value(true)
+        .multiple(true)
         .validator_os(validate_utf8)
         .help(HELP)
 }

--- a/gen/cmd/src/test.rs
+++ b/gen/cmd/src/test.rs
@@ -32,7 +32,7 @@ OPTIONS:
             parse or even require the given paths to exist; they simply go
             into the generated C++ code as #include lines.
                \x20
-    -o, --output <output>
+    -o, --output <output>...
             Path of file to write as output. Output goes to stdout if -o is
             not specified.
                \x20

--- a/gen/src/mod.rs
+++ b/gen/src/mod.rs
@@ -50,6 +50,7 @@ pub struct Opt {
 }
 
 /// Results of code generation.
+#[derive(Default)]
 pub struct GeneratedCode {
     /// The bytes of a C++ header file.
     pub header: Vec<u8>,


### PR DESCRIPTION
Closes #64.

```console
$ cxxbridge src/lib.rs -o lib.rs.h -o lib.rs.cc
```

Based on #318 we'll detect the one ending in `.h` as the header.