### PR TITLE
Add API to get slice from CxxVector

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1272,6 +1272,13 @@ fn write_cxx_vector(out: &mut OutFile, vector_ty: &Type, element: &Ident, types:
     writeln!(out, "}}");
     writeln!(
         out,
+        "const {} *cxxbridge04$std$vector${}$data(const ::std::vector<{}> &s) noexcept {{",
+        inner, instance, inner,
+    );
+    writeln!(out, "  return s.data();");
+    writeln!(out, "}}");
+    writeln!(
+        out,
         "const {} *cxxbridge04$std$vector${}$get_unchecked(const ::std::vector<{}> &s, size_t pos) noexcept {{",
         inner, instance, inner,
     );

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -841,6 +841,7 @@ fn expand_cxx_vector(namespace: &Namespace, elem: &Ident) -> TokenStream {
     let name = elem.to_string();
     let prefix = format!("cxxbridge04$std$vector${}{}$", namespace, elem);
     let link_size = format!("{}size", prefix);
+    let link_data = format!("{}data", prefix);
     let link_get_unchecked = format!("{}get_unchecked", prefix);
     let unique_ptr_prefix = format!("cxxbridge04$unique_ptr$std$vector${}{}$", namespace, elem);
     let link_unique_ptr_null = format!("{}null", unique_ptr_prefix);
@@ -858,6 +859,16 @@ fn expand_cxx_vector(namespace: &Namespace, elem: &Ident) -> TokenStream {
                     fn __vector_size(_: &::cxx::CxxVector<#elem>) -> usize;
                 }
                 unsafe { __vector_size(v) }
+            }
+            fn __vector_slice(v: &::cxx::CxxVector<Self>) -> &[Self] {
+                extern "C" {
+                    #[link_name = #link_size]
+                    fn __vector_size(_: &::cxx::CxxVector<#elem>) -> usize;
+                    #[link_name = #link_data]
+                    fn __vector_data(_: &::cxx::CxxVector<#elem>) -> *const #elem;
+                }
+                let ret = unsafe { std::slice::from_raw_parts(__vector_data(v), __vector_size(v)) };
+                ret
             }
             unsafe fn __get_unchecked(v: &::cxx::CxxVector<Self>, pos: usize) -> &Self {
                 extern "C" {

--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -199,6 +199,10 @@ void cxxbridge04$unique_ptr$std$string$drop(
       const std::vector<CXX_TYPE> &s) noexcept {                               \
     return s.size();                                                           \
   }                                                                            \
+  const CXX_TYPE* cxxbridge04$std$vector$##RUST_TYPE##$data(                   \
+      const std::vector<CXX_TYPE> &s) noexcept {                               \
+    return s.data();                                                           \
+  }                                                                            \
   const CXX_TYPE *cxxbridge04$std$vector$##RUST_TYPE##$get_unchecked(          \
       const std::vector<CXX_TYPE> &s, size_t pos) noexcept {                   \
     return &s[pos];                                                            \

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -151,6 +151,7 @@ pub mod ffi {
         fn r_take_enum(e: Enum);
 
         fn r_access_vector_u8_as_slice(v: &CxxVector<u8>);
+        fn r_access_vector_u8_as_slice_empty(v: &CxxVector<u8>);
 
         fn r_try_return_void() -> Result<()>;
         fn r_try_return_primitive() -> Result<usize>;
@@ -334,6 +335,11 @@ fn r_take_enum(e: ffi::Enum) {
 fn r_access_vector_u8_as_slice(v: &CxxVector<u8>) {
     let s = v.get_slice();
     assert_eq!(s, [86, 75, 30, 9]);
+}
+
+fn r_access_vector_u8_as_slice_empty(v: &CxxVector<u8>) {
+    let s = v.get_slice();
+    assert!(s.is_empty());
 }
 
 fn r_try_return_void() -> Result<(), Error> {

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -150,6 +150,8 @@ pub mod ffi {
         fn r_take_ref_rust_vec_string(v: &Vec<String>);
         fn r_take_enum(e: Enum);
 
+        fn r_access_vector_u8_as_slice(v: &CxxVector<u8>);
+
         fn r_try_return_void() -> Result<()>;
         fn r_try_return_primitive() -> Result<usize>;
         fn r_try_return_box() -> Result<Box<R>>;
@@ -164,6 +166,8 @@ pub mod ffi {
 pub type R = usize;
 
 pub struct R2(usize);
+
+use cxx::CxxVector;
 
 impl R2 {
     fn get(&self) -> usize {
@@ -325,6 +329,11 @@ fn r_take_ref_rust_vec_string(v: &Vec<String>) {
 
 fn r_take_enum(e: ffi::Enum) {
     let _ = e;
+}
+
+fn r_access_vector_u8_as_slice(v: &CxxVector<u8>) {
+    let s = v.get_slice();
+    assert_eq!(s, [86, 75, 30, 9]);
 }
 
 fn r_try_return_void() -> Result<(), Error> {

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -401,6 +401,12 @@ extern "C" const char *cxx_run_test() noexcept {
       std::unique_ptr<std::string>(new std::string("2020")));
   r_take_enum(Enum::AVal);
 
+  // Caller owns data handed into rust APIs
+  {
+    std::vector<std::uint8_t> v{86, 75, 30, 9};
+    r_access_vector_u8_as_slice(v);
+  }
+
   ASSERT(r_try_return_primitive() == 2020);
   try {
     r_fail_return_primitive();

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -406,6 +406,23 @@ extern "C" const char *cxx_run_test() noexcept {
     std::vector<std::uint8_t> v{86, 75, 30, 9};
     r_access_vector_u8_as_slice(v);
   }
+  {
+    // Empty std::vector has data() == nullptr.
+    // This shall produce an empty slice.
+    std::vector<std::uint8_t> v;
+    ASSERT(v.data() == nullptr);
+    ASSERT(v.size() == 0);
+    r_access_vector_u8_as_slice_empty(v);
+  }
+  {
+    // Empty std::vector with capacity has data() != nullptr and size() == 0.
+    // This shall produce an empty slice.
+    std::vector<std::uint8_t> v;
+    v.reserve(10);
+    ASSERT(v.data() != nullptr);
+    ASSERT(v.size() == 0);
+    r_access_vector_u8_as_slice_empty(v);
+  }
 
   ASSERT(r_try_return_primitive() == 2020);
   try {


### PR DESCRIPTION
Implementing #320 

Adds a get_slice() to CxxVector so that one can use slices in the rust code and std::vector on the C++ side.

Bear with me, new to rust.