### PR TITLE
Automatically pick up cxx crate features in cxx_build

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -51,6 +51,11 @@ rust_library(
 )
 
 rust_library(
+    name = "cxxbridge-flags",
+    srcs = glob(["flags/src/*.rs"]),
+)
+
+rust_library(
     name = "build",
     srcs = glob(["gen/build/src/**/*.rs"]),
     data = ["gen/build/src/gen/include/cxx.h"],
@@ -61,6 +66,7 @@ rust_library(
         "//third-party:proc-macro2",
         "//third-party:quote",
         "//third-party:syn",
+        "//:cxxbridge-flags",
     ],
 )
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ cxxbridge-flags = { version = "=0.4.7", path = "flags", default-features = false
 [dev-dependencies]
 cxx-build = { version = "=0.4.7", path = "gen/build" }
 cxx-test-suite = { version = "0", path = "tests/ffi" }
-cxxbridge-flags = { version = "=0.4.7", path = "flags", default-features = false }
 rustversion = "1.0"
 trybuild = { version = "1.0.33", features = ["diff"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ cxxbridge-flags = { version = "=0.4.7", path = "flags", default-features = false
 [dev-dependencies]
 cxx-build = { version = "=0.4.7", path = "gen/build" }
 cxx-test-suite = { version = "0", path = "tests/ffi" }
+cxxbridge-flags = { version = "=0.4.7", path = "flags", default-features = false }
 rustversion = "1.0"
 trybuild = { version = "1.0.33", features = ["diff"] }
 

--- a/README.md
+++ b/README.md
@@ -212,10 +212,10 @@ For builds that are orchestrated by Cargo, you will use a build script that runs
 CXX's C++ code generator and compiles the resulting C++ code along with any
 other C++ code for your crate.
 
-Set CXX features such as support of a different C++ standard - default is
-C++11 - by setting the feature on the CXX crate. This ensures that the CXX
-bridge library code in cxx.h|cc gets compiled with the same feature flags
-as your code.
+CXX create features, such as support of a different C++ standard, are
+automatically set if using cxx_build. This ensures that your code gets
+compiled with the same feature flags as the CXX bridge library code in
+cxx.h|cc. See the CXX crate for available features.
 
 The canonical build script is as follows. The indicated line returns a
 [`cc::Build`] instance (from the usual widely used `cc` crate) on which you can
@@ -233,7 +233,6 @@ cxx = "0.4"
 
 [build-dependencies]
 cxx-build = "0.4"
-cxxbridge-flags = "0.4"
 ```
 
 ```rust
@@ -242,7 +241,6 @@ cxxbridge-flags = "0.4"
 fn main() {
     cxx_build::bridge("src/main.rs")  // returns a cc::Build
         .file("src/demo.cc")
-        .flag_if_supported(cxxbridge_flags::STD)
         .compile("cxxbridge-demo");
 
     println!("cargo:rerun-if-changed=src/main.rs");

--- a/README.md
+++ b/README.md
@@ -212,6 +212,11 @@ For builds that are orchestrated by Cargo, you will use a build script that runs
 CXX's C++ code generator and compiles the resulting C++ code along with any
 other C++ code for your crate.
 
+Set CXX features such as support of a different C++ standard - default is
+C++11 - by setting the feature on the CXX crate. This ensures that the CXX
+bridge library code in cxx.h|cc gets compiled with the same feature flags
+as your code.
+
 The canonical build script is as follows. The indicated line returns a
 [`cc::Build`] instance (from the usual widely used `cc` crate) on which you can
 set up any additional source files and compiler flags as normal.
@@ -221,8 +226,14 @@ set up any additional source files and compiler flags as normal.
 ```toml
 # Cargo.toml
 
+[dependencies]
+cxx = "0.4"
+# To pick a different C++ standard:
+# cxx = { version = "0.4", features = ["c++14"] }
+
 [build-dependencies]
 cxx-build = "0.4"
+cxxbridge-flags = "0.4"
 ```
 
 ```rust
@@ -231,7 +242,7 @@ cxx-build = "0.4"
 fn main() {
     cxx_build::bridge("src/main.rs")  // returns a cc::Build
         .file("src/demo.cc")
-        .flag_if_supported("-std=c++11")
+        .flag_if_supported(cxxbridge_flags::STD)
         .compile("cxxbridge-demo");
 
     println!("cargo:rerun-if-changed=src/main.rs");

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -10,5 +10,4 @@ cxx = { path = "..", features= ["c++14"] }
 
 [build-dependencies]
 cxx-build = { path = "../gen/build" }
-cxxbridge-flags = { path = "../flags" }
 

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -6,7 +6,9 @@ edition = "2018"
 publish = false
 
 [dependencies]
-cxx = { path = ".." }
+cxx = { path = "..", features= ["c++14"] }
 
 [build-dependencies]
 cxx-build = { path = "../gen/build" }
+cxxbridge-flags = { path = "../flags" }
+

--- a/demo/build.rs
+++ b/demo/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     cxx_build::bridge("src/main.rs")
         .file("src/demo.cc")
-        .flag_if_supported("-std=c++14")
+        .flag_if_supported(cxxbridge_flags::STD)
         .compile("cxxbridge-demo");
 
     println!("cargo:rerun-if-changed=src/main.rs");

--- a/demo/build.rs
+++ b/demo/build.rs
@@ -1,7 +1,6 @@
 fn main() {
     cxx_build::bridge("src/main.rs")
         .file("src/demo.cc")
-        .flag_if_supported(cxxbridge_flags::STD)
         .compile("cxxbridge-demo");
 
     println!("cargo:rerun-if-changed=src/main.rs");

--- a/gen/build/Cargo.toml
+++ b/gen/build/Cargo.toml
@@ -16,6 +16,7 @@ codespan-reporting = "0.9"
 proc-macro2 = { version = "1.0.17", default-features = false, features = ["span-locations"] }
 quote = { version = "1.0", default-features = false }
 syn = { version = "1.0.20", default-features = false, features = ["parsing", "printing", "clone-impls", "full"] }
+cxxbridge-flags = { version = "=0.4.7", path = "../../flags", default-features = false }
 
 [dev-dependencies]
 cxx-gen = { version = "0.4", path = "../lib" }

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -4,6 +4,11 @@
 //! C++ code generator, set up any additional compiler flags depending on
 //! the use case, and make the C++ compiler invocation.
 //!
+//! Set CXX features such as support of a different C++ standard - default is
+//! C++11 - by setting the feature on the CXX crate. This ensures that the CXX
+//! bridge library code in cxx.h|cc gets compiled with the same feature flags
+//! as your code.
+//!
 //! <br>
 //!
 //! # Example
@@ -16,7 +21,7 @@
 //! fn main() {
 //!     cxx_build::bridge("src/main.rs")
 //!         .file("src/demo.cc")
-//!         .flag_if_supported("-std=c++11")
+//!         .flag_if_supported(cxxbridge_flags::STD)
 //!         .compile("cxxbridge-demo");
 //!
 //!     println!("cargo:rerun-if-changed=src/main.rs");
@@ -87,7 +92,7 @@ pub fn bridge(rust_source_file: impl AsRef<Path>) -> Build {
 /// let source_files = vec!["src/main.rs", "src/path/to/other.rs"];
 /// cxx_build::bridges(source_files)
 ///     .file("src/demo.cc")
-///     .flag_if_supported("-std=c++11")
+///     .flag_if_supported(cxxbridge_flags::STD)
 ///     .compile("cxxbridge-demo");
 /// ```
 #[must_use]

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -4,10 +4,10 @@
 //! C++ code generator, set up any additional compiler flags depending on
 //! the use case, and make the C++ compiler invocation.
 //!
-//! Set CXX features such as support of a different C++ standard - default is
-//! C++11 - by setting the feature on the CXX crate. This ensures that the CXX
-//! bridge library code in cxx.h|cc gets compiled with the same feature flags
-//! as your code.
+//! CXX create features, such as support of a different C++ standard, are
+//! automatically set if using cxx_build. This ensures that your code gets
+//! compiled with the same feature flags as the CXX bridge library code in
+//! cxx.h|cc. See the CXX crate for available features.
 //!
 //! <br>
 //!
@@ -21,7 +21,6 @@
 //! fn main() {
 //!     cxx_build::bridge("src/main.rs")
 //!         .file("src/demo.cc")
-//!         .flag_if_supported(cxxbridge_flags::STD)
 //!         .compile("cxxbridge-demo");
 //!
 //!     println!("cargo:rerun-if-changed=src/main.rs");
@@ -92,7 +91,6 @@ pub fn bridge(rust_source_file: impl AsRef<Path>) -> Build {
 /// let source_files = vec!["src/main.rs", "src/path/to/other.rs"];
 /// cxx_build::bridges(source_files)
 ///     .file("src/demo.cc")
-///     .flag_if_supported(cxxbridge_flags::STD)
 ///     .compile("cxxbridge-demo");
 /// ```
 #[must_use]

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -134,6 +134,8 @@ fn build(rust_source_files: &mut dyn Iterator<Item = impl AsRef<Path>>) -> Resul
     build.cpp(true);
     build.cpp_link_stdlib(None); // linked via link-cplusplus crate
     build.include(&include_dir);
+    // Set feature parameters, such as C++ std, for simpler usage
+    build.flag_if_supported(cxxbridge_flags::STD);
     write_header(prj);
     let crate_dir = symlink_crate(prj, &mut build);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,6 +218,11 @@
 //! runs CXX's C++ code generator and compiles the resulting C++ code along with
 //! any other C++ code for your crate.
 //!
+//! Set CXX features such as support of a different C++ standard - default is
+//! C++11 - by setting the feature on the CXX crate. This ensures that the CXX
+//! bridge library code in cxx.h|cc gets compiled with the same feature flags
+//! as your code.
+//!
 //! The canonical build script is as follows. The indicated line returns a
 //! [`cc::Build`] instance (from the usual widely used `cc` crate) on which you
 //! can set up any additional source files and compiler flags as normal.
@@ -227,8 +232,14 @@
 //! ```toml
 //! # Cargo.toml
 //!
+//! [dependencies]
+//! cxx = "0.4"
+//! # To pick a different C++ standard:
+//! # cxx = { version = "0.4", features = ["c++14"] }
+//!
 //! [build-dependencies]
 //! cxx-build = "0.4"
+//! cxxbridge-flags = "0.4"
 //! ```
 //!
 //! ```no_run
@@ -237,7 +248,7 @@
 //! fn main() {
 //!     cxx_build::bridge("src/main.rs")  // returns a cc::Build
 //!         .file("src/demo.cc")
-//!         .flag_if_supported("-std=c++11")
+//!         .flag_if_supported(cxxbridge_flags::STD)
 //!         .compile("cxxbridge-demo");
 //!
 //!     println!("cargo:rerun-if-changed=src/main.rs");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,10 +218,10 @@
 //! runs CXX's C++ code generator and compiles the resulting C++ code along with
 //! any other C++ code for your crate.
 //!
-//! Set CXX features such as support of a different C++ standard - default is
-//! C++11 - by setting the feature on the CXX crate. This ensures that the CXX
-//! bridge library code in cxx.h|cc gets compiled with the same feature flags
-//! as your code.
+//! CXX create features, such as support of a different C++ standard, are
+//! automatically set if using cxx_build. This ensures that your code gets
+//! compiled with the same feature flags as the CXX bridge library code in
+//! cxx.h|cc. See the CXX crate for available features.
 //!
 //! The canonical build script is as follows. The indicated line returns a
 //! [`cc::Build`] instance (from the usual widely used `cc` crate) on which you
@@ -239,7 +239,6 @@
 //!
 //! [build-dependencies]
 //! cxx-build = "0.4"
-//! cxxbridge-flags = "0.4"
 //! ```
 //!
 //! ```no_run
@@ -248,7 +247,6 @@
 //! fn main() {
 //!     cxx_build::bridge("src/main.rs")  // returns a cc::Build
 //!         .file("src/demo.cc")
-//!         .flag_if_supported(cxxbridge_flags::STD)
 //!         .compile("cxxbridge-demo");
 //!
 //!     println!("cargo:rerun-if-changed=src/main.rs");

--- a/tests/ffi/Cargo.toml
+++ b/tests/ffi/Cargo.toml
@@ -12,4 +12,3 @@ cxx = { path = "../.." }
 
 [build-dependencies]
 cxx-build = { path = "../../gen/build" }
-cxxbridge-flags = { path = "../../flags" }

--- a/tests/ffi/build.rs
+++ b/tests/ffi/build.rs
@@ -6,6 +6,5 @@ fn main() {
     let sources = vec!["lib.rs", "module.rs"];
     cxx_build::bridges(sources)
         .file("tests.cc")
-        .flag_if_supported(cxxbridge_flags::STD)
         .compile("cxx-test-suite");
 }

--- a/third-party/Cargo.lock
+++ b/third-party/Cargo.lock
@@ -134,6 +134,7 @@ version = "0.0.0"
 dependencies = [
  "cxx",
  "cxx-build",
+ "cxxbridge-flags",
 ]
 
 [[package]]

--- a/third-party/Cargo.lock
+++ b/third-party/Cargo.lock
@@ -78,6 +78,7 @@ dependencies = [
  "cc",
  "codespan-reporting",
  "cxx-gen",
+ "cxxbridge-flags",
  "proc-macro2",
  "quote",
  "syn",
@@ -100,7 +101,6 @@ version = "0.0.0"
 dependencies = [
  "cxx",
  "cxx-build",
- "cxxbridge-flags",
 ]
 
 [[package]]
@@ -134,7 +134,6 @@ version = "0.0.0"
 dependencies = [
  "cxx",
  "cxx-build",
- "cxxbridge-flags",
 ]
 
 [[package]]


### PR DESCRIPTION
Fix and implementation for #323 

Let's make sure that the core lib (cxx.h|cc) and the demo code is compiled with the same features, i.e. C++ standard only at this time. These are the first two commits (code + documentation update):
- b780338 Set C++ std in Cargo.toml for demo
- 1fa8579 Align documentation to use cxxbridge_flags.STD with cxx_build

I also moved the setting of features to cxx_build to avoid any potential miscompilation between core (cxx.h|cc) and any cargo-based client compilation using cxx_build. cxx_build can already set the CXX crate's features for all client code. This enables clients to define the features required on the CXX crate in Cargo.toml and not having to think about adding the feature settings to their compilation in build.rs. Well, at least for cargo-based clients. Buck and bazel builds are different.

This should make adding new feature easier as well as one only needs to update cxx_build and then clients can enable the features in their Cargo.toml. This should help with C++17 (string_view) support as well as folly support that I will be looking into.

Moving the feature setting into cxx_build are commits 3&4:
- d328816 Set C++ std in cxx_build for simpler usage
- 4602329 Align documentation to no longer set cxxbridge_flags manually


Hope my explanation makes sense.

Anyhow, food for thought. Review best done by commit.