### PR TITLE
Allow type aliases to be marked as Trivial.

### DIFF
--- a/src/extern_type.rs
+++ b/src/extern_type.rs
@@ -54,7 +54,7 @@
 /// ## Integrating with bindgen-generated types
 ///
 /// Handwritten `ExternType` impls make it possible to plug in a data structure
-/// emitted by bindgen as the definition of an opaque C++ type emitted by CXX.
+/// emitted by bindgen as the definition of a C++ type emitted by CXX.
 ///
 /// By writing the unsafe `ExternType` impl, the programmer asserts that the C++
 /// namespace and type name given in the type id refers to a C++ type that is
@@ -69,10 +69,11 @@
 /// #     pub struct StringPiece([usize; 2]);
 /// # }
 ///
-/// use cxx::{type_id, ExternType};
+/// use cxx::{type_id, ExternType, Opaque};
 ///
 /// unsafe impl ExternType for folly_sys::StringPiece {
 ///     type Id = type_id!("folly::StringPiece");
+///     type Kind = Opaque;
 /// }
 ///
 /// #[cxx::bridge(namespace = folly)]
@@ -92,6 +93,29 @@
 /// #
 /// # fn main() {}
 /// ```
+///
+/// ## Opaque and Trivial types
+///
+/// Some C++ types are safe to hold and pass around in Rust, by value.
+/// Those C++ types must have a trivial move constructor, and must
+/// have no destructor.
+///
+/// If you believe your C++ type is indeed trivial, you can specify
+/// ```
+/// # struct TypeName;
+/// # unsafe impl cxx::ExternType for TypeName {
+/// type Id = cxx::type_id!("name::space::of::TypeName");
+/// type Kind = cxx::Trivial;
+/// # }
+/// ```
+/// which will enable you to pass it into C++ functions by value,
+/// return it by value from such functions, and include it in
+/// `struct`s that you have declared to `cxx::bridge`. Your promises
+/// about the triviality of the C++ type will be checked using
+/// `static_assert`s in the generated C++.
+///
+/// Opaque types can't be passed by value, but can still be held
+/// in `UniquePtr`.
 pub unsafe trait ExternType {
     /// A type-level representation of the type's C++ namespace and type name.
     ///
@@ -101,12 +125,13 @@ pub unsafe trait ExternType {
     /// # struct TypeName;
     /// # unsafe impl cxx::ExternType for TypeName {
     /// type Id = cxx::type_id!("name::space::of::TypeName");
+    /// type Kind = cxx::Opaque;
     /// # }
     /// ```
     type Id;
 
-    /// Either `kind::Opaque` or `kind::Trivial`. If in doubt, use
-    /// `kind::Opaque`.
+    /// Either `cxx::Opaque` or `cxx::Trivial`. If in doubt, use
+    /// `cxx::Opaque`.
     type Kind;
 }
 

--- a/src/extern_type.rs
+++ b/src/extern_type.rs
@@ -104,7 +104,28 @@ pub unsafe trait ExternType {
     /// # }
     /// ```
     type Id;
+
+    /// Either `kind::Opaque` or `kind::Trivial`. If in doubt, use
+    /// `kind::Opaque`.
+    type Kind;
+}
+
+pub(crate) mod kind {
+
+    /// An opaque type which can't be passed or held by value within Rust.
+    /// For example, a C++ type with a destructor, or a non-trivial move
+    /// constructor. Rust's strict move semantics mean that we can't own
+    /// these by value in Rust, but they can still be owned by a
+    /// `UniquePtr`...
+    pub struct Opaque;
+
+    /// A type with trivial move constructors and no destructor, which
+    /// can therefore be owned and moved around in Rust code directly.
+    pub struct Trivial;
 }
 
 #[doc(hidden)]
 pub fn verify_extern_type<T: ExternType<Id = Id>, Id>() {}
+
+#[doc(hidden)]
+pub fn verify_extern_kind<T: ExternType<Kind = Kind>, Kind>() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -395,6 +395,8 @@ mod unwind;
 pub use crate::cxx_string::CxxString;
 pub use crate::cxx_vector::CxxVector;
 pub use crate::exception::Exception;
+pub use crate::extern_type::kind::Opaque;
+pub use crate::extern_type::kind::Trivial;
 pub use crate::extern_type::ExternType;
 pub use crate::unique_ptr::UniquePtr;
 pub use cxxbridge_macro::bridge;
@@ -422,6 +424,7 @@ pub type Vector<T> = CxxVector<T>;
 #[doc(hidden)]
 pub mod private {
     pub use crate::cxx_vector::VectorElement;
+    pub use crate::extern_type::verify_extern_kind;
     pub use crate::extern_type::verify_extern_type;
     pub use crate::function::FatFunction;
     pub use crate::opaque::Opaque;

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -338,6 +338,7 @@ fn is_unsized(cx: &mut Check, ty: &Type) -> bool {
         || cx.types.cxx.contains(ident)
             && !cx.types.structs.contains_key(ident)
             && !cx.types.enums.contains_key(ident)
+            && !cx.types.required_trivial_aliases.contains(ident)
         || cx.types.rust.contains(ident)
 }
 
@@ -376,7 +377,11 @@ fn describe(cx: &mut Check, ty: &Type) -> String {
             } else if cx.types.enums.contains_key(ident) {
                 "enum".to_owned()
             } else if cx.types.cxx.contains(ident) {
-                "C++ type".to_owned()
+                if cx.types.required_trivial_aliases.contains(ident) {
+                    "trivial C++ type".to_owned()
+                } else {
+                    "non-trivial C++ type".to_owned()
+                }
             } else if cx.types.rust.contains(ident) {
                 "opaque Rust type".to_owned()
             } else if Atom::from(ident) == Some(CxxString) {

--- a/tests/ui/by_value_not_supported.stderr
+++ b/tests/ui/by_value_not_supported.stderr
@@ -1,4 +1,4 @@
-error: using C++ type by value is not supported
+error: using non-trivial C++ type by value is not supported
  --> $DIR/by_value_not_supported.rs:4:9
   |
 4 |         c: C,
@@ -16,13 +16,13 @@ error: using C++ string by value is not supported
 6 |         s: CxxString,
   |         ^^^^^^^^^^^^
 
-error: passing C++ type by value is not supported
+error: passing non-trivial C++ type by value is not supported
   --> $DIR/by_value_not_supported.rs:16:14
    |
 16 |         fn f(c: C) -> C;
    |              ^^^^
 
-error: returning C++ type by value is not supported
+error: returning non-trivial C++ type by value is not supported
   --> $DIR/by_value_not_supported.rs:16:23
    |
 16 |         fn f(c: C) -> C;


### PR DESCRIPTION
Fixes #313.

This is a breaking change as it requires all implementers of `ExternType` to add another associated type. Defaults for associated types are an unstable feature, the compiler tells me. Perhaps we should avoid this by using a new trait, `ExternTypeKind`, instead.
