### PR TITLE
Switch Bazel rules from genrule to run_binary

### DIFF
--- a/tools/bazel/rust_cxx_bridge.bzl
+++ b/tools/bazel/rust_cxx_bridge.bzl
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 def rust_cxx_bridge(
@@ -6,20 +7,20 @@ def rust_cxx_bridge(
         include_prefix = None,
         strip_include_prefix = None,
         deps = []):
-    native.genrule(
+    run_binary(
         name = "%s/header" % name,
         srcs = [src],
         outs = [src + ".h"],
-        cmd = "$(location //:codegen) --header $< > $@",
-        tools = ["//:codegen"],
+        args = ["$(location %s)" % src, "-o", "$(location %s.h)" % src, "--header"],
+        tool = "//:codegen",
     )
 
-    native.genrule(
+    run_binary(
         name = "%s/source" % name,
         srcs = [src],
         outs = [src + ".cc"],
-        cmd = "$(location //:codegen) $< > $@",
-        tools = ["//:codegen"],
+        args = ["$(location %s)" % src, "-o", "$(location %s.cc)" % src],
+        tool = "//:codegen",
     )
 
     cc_library(

--- a/tools/bazel/rust_cxx_bridge.bzl
+++ b/tools/bazel/rust_cxx_bridge.bzl
@@ -11,7 +11,12 @@ def rust_cxx_bridge(
         name = "%s/header" % name,
         srcs = [src],
         outs = [src + ".h"],
-        args = ["$(location %s)" % src, "-o", "$(location %s.h)" % src, "--header"],
+        args = [
+            "$(location %s)" % src,
+            "-o",
+            "$(location %s.h)" % src,
+            "--header",
+        ],
         tool = "//:codegen",
     )
 
@@ -19,7 +24,11 @@ def rust_cxx_bridge(
         name = "%s/source" % name,
         srcs = [src],
         outs = [src + ".cc"],
-        args = ["$(location %s)" % src, "-o", "$(location %s.cc)" % src],
+        args = [
+            "$(location %s)" % src,
+            "-o",
+            "$(location %s.cc)" % src,
+        ],
         tool = "//:codegen",
     )
 


### PR DESCRIPTION
As proposed in https://github.com/dtolnay/cxx/pull/307#issuecomment-699225624. `run_binary` does not involve Bash, unlike `genrule`.