### PR TITLE
Combine buck codegen steps into one run of cxxbridge

### DIFF
--- a/tools/buck/rust_cxx_bridge.bzl
+++ b/tools/buck/rust_cxx_bridge.bzl
@@ -3,17 +3,21 @@ load("//tools/buck:genrule.bzl", "genrule")
 def rust_cxx_bridge(name, src, deps = []):
     genrule(
         name = "%s/header" % name,
-        srcs = [src],
         out = src + ".h",
-        cmd = "$(exe //:codegen) ${SRCS} -o ${OUT}",
-        type = "cxxbridge",
+        cmd = "cp $(location :%s/generated)/generated.h ${OUT}" % name,
     )
 
     genrule(
         name = "%s/source" % name,
-        srcs = [src],
         out = src + ".cc",
-        cmd = "$(exe //:codegen) ${SRCS} -o ${OUT}",
+        cmd = "cp $(location :%s/generated)/generated.cc ${OUT}" % name,
+    )
+
+    genrule(
+        name = "%s/generated" % name,
+        srcs = [src],
+        out = ".",
+        cmd = "$(exe //:codegen) ${SRCS} -o ${OUT}/generated.h -o ${OUT}/generated.cc",
         type = "cxxbridge",
     )
 

--- a/tools/buck/rust_cxx_bridge.bzl
+++ b/tools/buck/rust_cxx_bridge.bzl
@@ -5,7 +5,7 @@ def rust_cxx_bridge(name, src, deps = []):
         name = "%s/header" % name,
         srcs = [src],
         out = src + ".h",
-        cmd = "$(exe //:codegen) --header ${SRCS} > ${OUT}",
+        cmd = "$(exe //:codegen) ${SRCS} -o ${OUT}",
         type = "cxxbridge",
     )
 
@@ -13,7 +13,7 @@ def rust_cxx_bridge(name, src, deps = []):
         name = "%s/source" % name,
         srcs = [src],
         out = src + ".cc",
-        cmd = "$(exe //:codegen) ${SRCS} > ${OUT}",
+        cmd = "$(exe //:codegen) ${SRCS} -o ${OUT}",
         type = "cxxbridge",
     )
 


### PR DESCRIPTION
This is preferable because if the input contains an error, we don't want to see a duplicate diagnostic printed by each separate genrule.