### PR TITLE
Explicitly requesting an instantiation

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1056,14 +1056,18 @@ fn write_generic_instantiations(out: &mut OutFile, types: &Types) {
             }
         } else if let Type::UniquePtr(ptr) = ty {
             if let Type::Ident(inner) = &ptr.inner {
-                if Atom::from(inner).is_none() && !types.aliases.contains_key(inner) {
+                if Atom::from(inner).is_none()
+                    && (!types.aliases.contains_key(inner) || types.explicit_impls.contains(ty))
+                {
                     out.next_section();
                     write_unique_ptr(out, inner, types);
                 }
             }
         } else if let Type::CxxVector(ptr) = ty {
             if let Type::Ident(inner) = &ptr.inner {
-                if Atom::from(inner).is_none() && !types.aliases.contains_key(inner) {
+                if Atom::from(inner).is_none()
+                    && (!types.aliases.contains_key(inner) || types.explicit_impls.contains(ty))
+                {
                     out.next_section();
                     write_cxx_vector(out, ty, inner, types);
                 }

--- a/syntax/file.rs
+++ b/syntax/file.rs
@@ -2,8 +2,8 @@ use crate::syntax::namespace::Namespace;
 use quote::quote;
 use syn::parse::{Error, Parse, ParseStream, Result};
 use syn::{
-    braced, token, Abi, Attribute, ForeignItem, Ident, Item as RustItem, ItemEnum, ItemStruct,
-    ItemUse, LitStr, Token, Visibility,
+    braced, token, Abi, Attribute, ForeignItem, Ident, Item as RustItem, ItemEnum, ItemImpl,
+    ItemStruct, ItemUse, LitStr, Token, Visibility,
 };
 
 pub struct Module {
@@ -22,6 +22,7 @@ pub enum Item {
     Enum(ItemEnum),
     ForeignMod(ItemForeignMod),
     Use(ItemUse),
+    Impl(ItemImpl),
     Other(RustItem),
 }
 
@@ -99,6 +100,7 @@ impl Parse for Item {
                 brace_token: item.brace_token,
                 items: item.items,
             })),
+            RustItem::Impl(item) => Ok(Item::Impl(ItemImpl { attrs, ..item })),
             RustItem::Use(item) => Ok(Item::Use(ItemUse { attrs, ..item })),
             other => Ok(Item::Other(other)),
         }

--- a/syntax/ident.rs
+++ b/syntax/ident.rs
@@ -20,7 +20,7 @@ pub(crate) fn check_all(cx: &mut Check, namespace: &Namespace, apis: &[Api]) {
 
     for api in apis {
         match api {
-            Api::Include(_) => {}
+            Api::Include(_) | Api::Impl(_) => {}
             Api::Struct(strct) => {
                 check(cx, &strct.ident);
                 for field in &strct.fields {

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -42,6 +42,7 @@ pub enum Api {
     RustType(ExternType),
     RustFunction(ExternFn),
     TypeAlias(TypeAlias),
+    Impl(Impl),
 }
 
 pub struct ExternType {
@@ -85,6 +86,12 @@ pub struct TypeAlias {
     pub eq_token: Token![=],
     pub ty: RustType,
     pub semi_token: Token![;],
+}
+
+pub struct Impl {
+    pub impl_token: Token![impl],
+    pub ty: Type,
+    pub brace_token: Brace,
 }
 
 pub struct Signature {

--- a/syntax/tokens.rs
+++ b/syntax/tokens.rs
@@ -1,7 +1,7 @@
 use crate::syntax::atom::Atom::*;
 use crate::syntax::{
-    Atom, Derive, Enum, ExternFn, ExternType, Receiver, Ref, Signature, Slice, Struct, Ty1, Type,
-    TypeAlias, Var,
+    Atom, Derive, Enum, ExternFn, ExternType, Impl, Receiver, Ref, Signature, Slice, Struct, Ty1,
+    Type, TypeAlias, Var,
 };
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote_spanned, ToTokens};
@@ -118,6 +118,14 @@ impl ToTokens for ExternFn {
         // Notional token range for error reporting purposes.
         self.sig.fn_token.to_tokens(tokens);
         self.semi_token.to_tokens(tokens);
+    }
+}
+
+impl ToTokens for Impl {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.impl_token.to_tokens(tokens);
+        self.ty.to_tokens(tokens);
+        self.brace_token.surround(tokens, |_tokens| {});
     }
 }
 

--- a/syntax/types.rs
+++ b/syntax/types.rs
@@ -15,6 +15,7 @@ pub struct Types<'a> {
     pub aliases: Map<&'a Ident, &'a TypeAlias>,
     pub untrusted: Map<&'a Ident, &'a ExternType>,
     pub required_trivial: Map<&'a Ident, TrivialReason<'a>>,
+    pub explicit_impls: Set<&'a Type>,
 }
 
 impl<'a> Types<'a> {
@@ -26,6 +27,7 @@ impl<'a> Types<'a> {
         let mut rust = Set::new();
         let mut aliases = Map::new();
         let mut untrusted = Map::new();
+        let mut explicit_impls = Set::new();
 
         fn visit<'a>(all: &mut Set<&'a Type>, ty: &'a Type) {
             all.insert(ty);
@@ -133,6 +135,10 @@ impl<'a> Types<'a> {
                     cxx.insert(ident);
                     aliases.insert(ident, alias);
                 }
+                Api::Impl(imp) => {
+                    visit(&mut all, &imp.ty);
+                    explicit_impls.insert(&imp.ty);
+                }
             }
         }
 
@@ -179,6 +185,7 @@ impl<'a> Types<'a> {
             aliases,
             untrusted,
             required_trivial,
+            explicit_impls,
         }
     }
 

--- a/tests/ui/bad_explicit_impl.rs
+++ b/tests/ui/bad_explicit_impl.rs
@@ -1,0 +1,10 @@
+#[cxx::bridge]
+mod ffi {
+    struct S {
+        x: u8,
+    }
+
+    impl fn() -> &S {}
+}
+
+fn main() {}

--- a/tests/ui/bad_explicit_impl.stderr
+++ b/tests/ui/bad_explicit_impl.stderr
@@ -1,0 +1,5 @@
+error: unsupported Self type of explicit impl
+ --> $DIR/bad_explicit_impl.rs:7:5
+  |
+7 |     impl fn() -> &S {}
+  |     ^^^^^^^^^^^^^^^^^^

--- a/tests/ui/impl_trait_for_type.rs
+++ b/tests/ui/impl_trait_for_type.rs
@@ -1,0 +1,10 @@
+#[cxx::bridge]
+mod ffi {
+    struct S {
+        x: u8,
+    }
+
+    impl UniquePtrTarget for S {}
+}
+
+fn main() {}

--- a/tests/ui/impl_trait_for_type.stderr
+++ b/tests/ui/impl_trait_for_type.stderr
@@ -1,0 +1,5 @@
+error: unexpected impl, expected something like `impl UniquePtr<T> {}`
+ --> $DIR/impl_trait_for_type.rs:7:10
+  |
+7 |     impl UniquePtrTarget for S {}
+  |          ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/nonempty_impl_block.rs
+++ b/tests/ui/nonempty_impl_block.rs
@@ -1,0 +1,12 @@
+#[cxx::bridge]
+mod ffi {
+    struct S {
+        x: u8,
+    }
+
+    impl UniquePtr<S> {
+        fn new() -> Self;
+    }
+}
+
+fn main() {}

--- a/tests/ui/nonempty_impl_block.stderr
+++ b/tests/ui/nonempty_impl_block.stderr
@@ -1,0 +1,8 @@
+error: expected an empty impl block
+ --> $DIR/nonempty_impl_block.rs:7:23
+  |
+7 |       impl UniquePtr<S> {
+  |  _______________________^
+8 | |         fn new() -> Self;
+9 | |     }
+  | |_____^

--- a/tests/ui/unique_ptr_twice.rs
+++ b/tests/ui/unique_ptr_twice.rs
@@ -1,0 +1,19 @@
+#[cxx::bridge]
+mod here {
+    extern "C" {
+        type C;
+    }
+
+    impl UniquePtr<C> {}
+}
+
+#[cxx::bridge]
+mod there {
+    extern "C" {
+        type C = crate::here::C;
+    }
+
+    impl UniquePtr<C> {}
+}
+
+fn main() {}

--- a/tests/ui/unique_ptr_twice.stderr
+++ b/tests/ui/unique_ptr_twice.stderr
@@ -1,0 +1,10 @@
+error[E0119]: conflicting implementations of trait `cxx::private::UniquePtrTarget` for type `here::C`:
+  --> $DIR/unique_ptr_twice.rs:10:1
+   |
+1  | #[cxx::bridge]
+   | -------------- first implementation here
+...
+10 | #[cxx::bridge]
+   | ^^^^^^^^^^^^^^ conflicting implementation for `here::C`
+   |
+   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
As discussed in #312 and elsewhere. Supersedes #329. We use the following `impl` syntax to indicate that we'd like the expansion of the ffi mod to include a given instantiation of UniquePtr, even if otherwise not mentioned in any of the extern function signatures:

```rust
#[cxx::bridge]
mod ffi {
    extern "C" {
        type C;
    }

    impl UniquePtr<C> {}
}
```

The same also works if the UniquePtr were to be an extern type alias (`type C = path::to::C;`). In that case it's up to the user whether to place the UniquePtr impl in one ffi module or the other, subject to the Rust orphan rule.

Closes #236. Closes #312. Closes #329.