### PR TITLE
Improve error message on a conflicting explicit impl

### DIFF
--- a/syntax/impls.rs
+++ b/syntax/impls.rs
@@ -1,4 +1,5 @@
-use crate::syntax::{ExternFn, Receiver, Ref, Signature, Slice, Ty1, Type};
+use crate::syntax::{ExternFn, Impl, Receiver, Ref, Signature, Slice, Ty1, Type};
+use std::borrow::Borrow;
 use std::hash::{Hash, Hasher};
 use std::mem;
 use std::ops::{Deref, DerefMut};
@@ -236,5 +237,40 @@ impl Hash for Receiver {
         lifetime.hash(state);
         mutability.is_some().hash(state);
         ty.hash(state);
+    }
+}
+
+impl Hash for Impl {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let Impl {
+            impl_token: _,
+            ty,
+            brace_token: _,
+        } = self;
+        ty.hash(state);
+    }
+}
+
+impl Eq for Impl {}
+
+impl PartialEq for Impl {
+    fn eq(&self, other: &Impl) -> bool {
+        let Impl {
+            impl_token: _,
+            ty,
+            brace_token: _,
+        } = self;
+        let Impl {
+            impl_token: _,
+            ty: ty2,
+            brace_token: _,
+        } = other;
+        ty == ty2
+    }
+}
+
+impl Borrow<Type> for &Impl {
+    fn borrow(&self) -> &Type {
+        &self.ty
     }
 }

--- a/syntax/set.rs
+++ b/syntax/set.rs
@@ -35,6 +35,14 @@ where
     {
         self.set.contains(value)
     }
+
+    pub fn get<Q>(&self, value: &Q) -> Option<&'a T>
+    where
+        &'a T: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        self.set.get(value).copied()
+    }
 }
 
 impl<'s, 'a, T> IntoIterator for &'s OrderedSet<&'a T> {

--- a/syntax/types.rs
+++ b/syntax/types.rs
@@ -1,7 +1,7 @@
 use crate::syntax::atom::Atom::{self, *};
 use crate::syntax::report::Errors;
 use crate::syntax::set::OrderedSet as Set;
-use crate::syntax::{Api, Derive, Enum, ExternFn, ExternType, Struct, Type, TypeAlias};
+use crate::syntax::{Api, Derive, Enum, ExternFn, ExternType, Impl, Struct, Type, TypeAlias};
 use proc_macro2::Ident;
 use quote::ToTokens;
 use std::collections::{BTreeMap as Map, HashSet as UnorderedSet};
@@ -15,7 +15,7 @@ pub struct Types<'a> {
     pub aliases: Map<&'a Ident, &'a TypeAlias>,
     pub untrusted: Map<&'a Ident, &'a ExternType>,
     pub required_trivial: Map<&'a Ident, TrivialReason<'a>>,
-    pub explicit_impls: Set<&'a Type>,
+    pub explicit_impls: Set<&'a Impl>,
 }
 
 impl<'a> Types<'a> {
@@ -137,7 +137,7 @@ impl<'a> Types<'a> {
                 }
                 Api::Impl(imp) => {
                     visit(&mut all, &imp.ty);
-                    explicit_impls.insert(&imp.ty);
+                    explicit_impls.insert(imp);
                 }
             }
         }

--- a/tests/ui/unique_ptr_twice.stderr
+++ b/tests/ui/unique_ptr_twice.stderr
@@ -1,10 +1,8 @@
 error[E0119]: conflicting implementations of trait `cxx::private::UniquePtrTarget` for type `here::C`:
-  --> $DIR/unique_ptr_twice.rs:10:1
+  --> $DIR/unique_ptr_twice.rs:16:5
    |
-1  | #[cxx::bridge]
-   | -------------- first implementation here
+7  |     impl UniquePtr<C> {}
+   |     ----------------- first implementation here
 ...
-10 | #[cxx::bridge]
-   | ^^^^^^^^^^^^^^ conflicting implementation for `here::C`
-   |
-   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+16 |     impl UniquePtr<C> {}
+   |     ^^^^^^^^^^^^^^^^^ conflicting implementation for `here::C`


### PR DESCRIPTION
Before:

```console
error[E0119]: conflicting implementations of trait `cxx::private::UniquePtrTarget` for type `here::C`:
  --> $DIR/unique_ptr_twice.rs:10:1
   |
1  | #[cxx::bridge]
   | -------------- first implementation here
...
10 | #[cxx::bridge]
   | ^^^^^^^^^^^^^^ conflicting implementation for `here::C`
   |
   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

After:

```console
error[E0119]: conflicting implementations of trait `cxx::private::UniquePtrTarget` for type `here::C`:
  --> $DIR/unique_ptr_twice.rs:16:5
   |
7  |     impl UniquePtr<C> {}
   |     ----------------- first implementation here
...
16 |     impl UniquePtr<C> {}
   |     ^^^^^^^^^^^^^^^^^ conflicting implementation for `here::C`
```

Cleanup of #336.