### PR TITLE
Tweak wording of the triviality requirement

### DIFF
--- a/src/extern_type.rs
+++ b/src/extern_type.rs
@@ -123,7 +123,7 @@ pub unsafe trait ExternType {
     /// [move constructor is trivial]: https://en.cppreference.com/w/cpp/types/is_move_constructible
     ///
     /// If you believe your C++ type reflected by this ExternType impl is indeed
-    /// trivial, you can specify:
+    /// fine to hold by value and move in Rust, you can specify:
     ///
     /// ```
     /// # struct TypeName;


### PR DESCRIPTION
It isn't actually a requirement that the type have no destructor as brought up by the previous paragraph. Rather, it just needs to be safe for values of that type to be moved via Rust's memcpy-based move semantics.

The distinction is relevant e.g. for `struct S { s: String }` which would have a C++ destructor and nontrivial implicitly defined move constructor but still be safely memcpy movable. C++ has no analogue of "trivially destructive-movable" which is the semantic we are really interested in.