### PR TITLE
Use Cargo's build script metadata feature to make reliable include dirs

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -48,6 +48,7 @@ rust_library(
 rust_library(
     name = "build",
     srcs = glob(["gen/build/src/**"]),
+    env = {"OUT_DIR": ""},
     visibility = ["PUBLIC"],
     deps = [
         "//third-party:cc",

--- a/BUILD
+++ b/BUILD
@@ -54,6 +54,7 @@ rust_library(
     name = "build",
     srcs = glob(["gen/build/src/**/*.rs"]),
     data = ["gen/build/src/gen/include/cxx.h"],
+    rustc_env = {"OUT_DIR": ""},
     visibility = ["//visibility:public"],
     deps = [
         "//third-party:cc",

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,6 @@
+use std::env;
+use std::path::Path;
+
 fn main() {
     cc::Build::new()
         .file("src/cxx.cc")
@@ -8,4 +11,8 @@ fn main() {
     println!("cargo:rerun-if-changed=src/cxx.cc");
     println!("cargo:rerun-if-changed=include/cxx.h");
     println!("cargo:rustc-cfg=built_with_cargo");
+    if let Some(manifest_dir) = env::var_os("CARGO_MANIFEST_DIR") {
+        let cxx_h = Path::new(&manifest_dir).join("include").join("cxx.h");
+        println!("cargo:HEADER={}", cxx_h.to_string_lossy());
+    }
 }

--- a/gen/build/src/error.rs
+++ b/gen/build/src/error.rs
@@ -1,19 +1,22 @@
 use crate::gen::fs;
 use std::error::Error as StdError;
+use std::ffi::OsString;
 use std::fmt::{self, Display};
 
 pub(super) type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug)]
 pub(super) enum Error {
-    MissingOutDir,
+    NoEnv(OsString),
     Fs(fs::Error),
 }
 
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Error::MissingOutDir => write!(f, "missing OUT_DIR environment variable"),
+            Error::NoEnv(var) => {
+                write!(f, "missing {} environment variable", var.to_string_lossy())
+            }
             Error::Fs(err) => err.fmt(f),
         }
     }

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -177,10 +177,14 @@ fn build(rust_source_files: &mut dyn Iterator<Item = impl AsRef<Path>>) -> Resul
     let mut build = Build::new();
     build.cpp(true);
     build.cpp_link_stdlib(None); // linked via link-cplusplus crate
+    build.include(include_dir);
     if let Some(crate_dir) = crate_dir {
+        // Placed after the generated code directory (include_dir) on the
+        // include line so that `#include "path/to/file.rs"` from C++
+        // "magically" works and refers to the API generated from that Rust
+        // source file.
         build.include(crate_dir);
     }
-    build.include(include_dir);
 
     for path in rust_source_files {
         generate_bridge(prj, &mut build, path.as_ref())?;

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -60,11 +60,13 @@ mod out;
 mod paths;
 mod syntax;
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::gen::error::report;
 use crate::gen::Opt;
 use crate::paths::{PathExt, TargetDir};
 use cc::Build;
+use std::env;
+use std::ffi::{OsStr, OsString};
 use std::io::{self, Write};
 use std::iter;
 use std::path::{Path, PathBuf};
@@ -100,12 +102,29 @@ pub fn bridges(rust_source_files: impl IntoIterator<Item = impl AsRef<Path>>) ->
 }
 
 struct Project {
+    package_name: OsString,
+    manifest_dir: PathBuf,
+    // Output directory as received from Cargo.
     out_dir: PathBuf,
-    target_dir: TargetDir,
+    // Directory into which to symlink all generated code.
+    //
+    // This is *not* used for an #include path, only as a debugging convenience.
+    // Normally available at target/cxxbridge/ if we are able to know where the
+    // target dir is, otherwise under a common scratch dir.
+    //
+    // The reason this isn't the #include dir is that we do not want builds to
+    // have access to headers from arbitrary other parts of the dependency
+    // graph. Using a global directory for all builds would be both a race
+    // condition depending on what order Cargo randomly executes the build
+    // scripts, as well as semantically undesirable for builds not to have to
+    // declare their real dependencies.
+    shared_dir: PathBuf,
 }
 
 impl Project {
     fn init() -> Result<Self> {
+        let package_name = env_os("CARGO_PKG_NAME")?;
+        let manifest_dir = paths::manifest_dir()?;
         let out_dir = paths::out_dir()?;
 
         let target_dir = match cargo::target_dir(&out_dir) {
@@ -114,60 +133,89 @@ impl Project {
             TargetDir::Unknown => paths::search_parents_for_target_dir(&out_dir),
         };
 
+        let shared_dir = match target_dir {
+            TargetDir::Path(target_dir) => target_dir.join("cxxbridge"),
+            // Use cxx-build's OUT_DIR.
+            TargetDir::Unknown => PathBuf::from(env!("OUT_DIR")),
+        };
+
         Ok(Project {
+            package_name,
+            manifest_dir,
             out_dir,
-            target_dir,
+            shared_dir,
         })
     }
 }
 
+// We lay out the OUT_DIR as follows. Everything is namespaced under a cxxbridge
+// subdirectory to avoid stomping on other things that the caller's build script
+// might be doing inside OUT_DIR.
+//
+//     $OUT_DIR/
+//        cxxbridge/
+//           crate/
+//              $CARGO_PKG_NAME -> $CARGO_MANIFEST_DIR
+//           include/
+//              rust/
+//                 cxx.h
+//              $CARGO_PKG_NAME/
+//                 .../
+//                    lib.rs.h
+//           sources/
+//              $CARGO_PKG_NAME/
+//                 .../
+//                    lib.rs.cc
+//
+// The crate/ and include/ directories are placed on the #include path.
 fn build(rust_source_files: &mut dyn Iterator<Item = impl AsRef<Path>>) -> Result<Build> {
     let ref prj = Project::init()?;
-    let include_dir = paths::include_dir(prj);
+
+    let ref crate_dir = make_crate_dir(prj);
+    let ref include_dir = make_include_dir(prj)?;
 
     let mut build = Build::new();
     build.cpp(true);
     build.cpp_link_stdlib(None); // linked via link-cplusplus crate
-    build.include(&include_dir);
-    write_header(prj);
-    let crate_dir = symlink_crate(prj, &mut build);
+    if let Some(crate_dir) = crate_dir {
+        build.include(crate_dir);
+    }
+    build.include(include_dir);
 
     for path in rust_source_files {
         generate_bridge(prj, &mut build, path.as_ref())?;
     }
 
     eprintln!("\nCXX include path:");
-    eprintln!("  {}", include_dir.display());
     if let Some(crate_dir) = crate_dir {
         eprintln!("  {}", crate_dir.display());
     }
+    eprintln!("  {}", include_dir.display());
     Ok(build)
 }
 
-fn write_header(prj: &Project) {
-    let ref cxx_h = prj.out_dir.join("cxxbridge").join("rust").join("cxx.h");
-    let _ = out::write(cxx_h, gen::include::HEADER.as_bytes());
-    if let TargetDir::Path(target_dir) = &prj.target_dir {
-        let ref cxx_h = target_dir.join("cxxbridge").join("rust").join("cxx.h");
-        let _ = out::write(cxx_h, gen::include::HEADER.as_bytes());
+fn make_crate_dir(prj: &Project) -> Option<PathBuf> {
+    let crate_dir = prj.out_dir.join("cxxbridge").join("crate");
+    let link = crate_dir.join(&prj.package_name);
+    if out::symlink_dir(&prj.manifest_dir, link).is_ok() {
+        Some(crate_dir)
+    } else {
+        None
     }
 }
 
-fn symlink_crate(prj: &Project, build: &mut Build) -> Option<PathBuf> {
-    let manifest_dir = match paths::manifest_dir() {
-        Some(manifest_dir) => manifest_dir,
-        None => return None,
-    };
-    let package_name = match paths::package_name() {
-        Some(package_name) => package_name,
-        None => return None,
-    };
-
-    let mut link = paths::include_dir(prj);
-    link.push("CRATE");
-    let _ = out::symlink_dir(manifest_dir, link.join(package_name));
-    build.include(&link);
-    Some(link)
+fn make_include_dir(prj: &Project) -> Result<PathBuf> {
+    let include_dir = prj.out_dir.join("cxxbridge").join("include");
+    let cxx_h = include_dir.join("rust").join("cxx.h");
+    let ref shared_cxx_h = prj.shared_dir.join("rust").join("cxx.h");
+    if let Some(ref original) = env::var_os("DEP_CXXBRIDGE04_HEADER") {
+        out::symlink_file(original, cxx_h)?;
+        out::symlink_file(original, shared_cxx_h)?;
+    } else {
+        out::write(shared_cxx_h, gen::include::HEADER.as_bytes())?;
+        out::symlink_file(shared_cxx_h, cxx_h)?;
+    }
+    Ok(include_dir)
 }
 
 fn generate_bridge(prj: &Project, build: &mut Build, rust_source_file: &Path) -> Result<()> {
@@ -175,21 +223,30 @@ fn generate_bridge(prj: &Project, build: &mut Build, rust_source_file: &Path) ->
     let generated = gen::generate_from_path(rust_source_file, &opt);
     let ref rel_path = paths::local_relative_path(rust_source_file);
 
+    let cxxbridge = prj.out_dir.join("cxxbridge");
+    let include_dir = cxxbridge.join("include").join(&prj.package_name);
+    let sources_dir = cxxbridge.join("sources").join(&prj.package_name);
+
     let ref rel_path_h = rel_path.with_appended_extension(".h");
-    let ref header_path = paths::namespaced(&prj.out_dir, rel_path_h);
+    let ref header_path = include_dir.join(rel_path_h);
     out::write(header_path, &generated.header)?;
 
-    let ref link_path = paths::namespaced(&prj.out_dir, rel_path);
+    let ref link_path = include_dir.join(rel_path);
     let _ = out::symlink_file(header_path, link_path);
-    if let TargetDir::Path(target_dir) = &prj.target_dir {
-        let ref link_path = paths::namespaced(target_dir, rel_path);
-        let _ = out::symlink_file(header_path, link_path);
-        let _ = out::symlink_file(header_path, link_path.with_appended_extension(".h"));
-    }
 
     let ref rel_path_cc = rel_path.with_appended_extension(".cc");
-    let ref implementation_path = paths::namespaced(&prj.out_dir, rel_path_cc);
+    let ref implementation_path = sources_dir.join(rel_path_cc);
     out::write(implementation_path, &generated.implementation)?;
     build.file(implementation_path);
+
+    let shared_h = prj.shared_dir.join(&prj.package_name).join(rel_path_h);
+    let shared_cc = prj.shared_dir.join(&prj.package_name).join(rel_path_cc);
+    let _ = out::symlink_file(header_path, shared_h);
+    let _ = out::symlink_file(implementation_path, shared_cc);
     Ok(())
+}
+
+fn env_os(key: impl AsRef<OsStr>) -> Result<OsString> {
+    let key = key.as_ref();
+    env::var_os(key).ok_or_else(|| Error::NoEnv(key.to_owned()))
 }


### PR DESCRIPTION
This is the second near complete rewrite of cxx-build (following #276) but I am feeling good about this one.
<br>

### Background

References:
- https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key
- https://doc.rust-lang.org/cargo/reference/build-script-examples.html#using-another-sys-crate

Cargo has some functionality for build scripts where they can emit metadata as key-value pairs to be made available as environment variables to the build scripts of **directly dependent** crates. This is exactly the limitation that we want to impose. By building on this, we're able to require that your crate declare a direct dependency on the other crate in order to be able to #include their headers in your C++ build. Headers from transitive dependencies are not made available.

Additionally, the key-value metadata feature forces the the dependency's manifest to contain a `links` key. This is important because Cargo imposes no ordering on the execution of build scripts not having a `links` key. When exposing a generated header from a dependency, we need to be sure the dependency's build script has already finished executing and emitted that generated header. Prior to this PR, there wasn't necessarily that ordering and builds which included a header from a dependency could flake depending on what order those build scripts happened to be executed by Cargo.
<br>

### Directory layout

This PR lays out the OUT_DIR as follows. Everything is namespaced under a cxxbridge subdirectory to avoid stomping on other things that the caller's build script might be doing inside OUT_DIR.

```
$OUT_DIR/
   cxxbridge/
      crate/
         $CARGO_PKG_NAME -> $CARGO_MANIFEST_DIR
      include/
         rust/
            cxx.h
         $CARGO_PKG_NAME/
            .../
               lib.rs.h
      sources/
         $CARGO_PKG_NAME/
            .../
               lib.rs.cc
```
<br>

### Include paths

The generated crate/ and include/ directories are placed on the #include path for the current build as well as for downstream builds that have a direct dependency on the current crate.

We always place include/ *before* crate/ on the include line so that `#include "path/to/file.rs"` from C++ magically works and refers to the API generated from that Rust source file. The canonical import path which we'd show in docs is still `"path/to/file.rs.h"` but I've heard some people really dig the "include a .rs file" style.