### PR TITLE
Expose control of import prefix to Cargo builds

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -53,6 +53,7 @@ rust_library(
     deps = [
         "//third-party:cc",
         "//third-party:codespan-reporting",
+        "//third-party:lazy_static",
         "//third-party:proc-macro2",
         "//third-party:quote",
         "//third-party:syn",

--- a/BUILD
+++ b/BUILD
@@ -59,6 +59,7 @@ rust_library(
     deps = [
         "//third-party:cc",
         "//third-party:codespan-reporting",
+        "//third-party:lazy_static",
         "//third-party:proc-macro2",
         "//third-party:quote",
         "//third-party:syn",

--- a/gen/build/Cargo.toml
+++ b/gen/build/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["development-tools::ffi"]
 [dependencies]
 cc = "1.0.49"
 codespan-reporting = "0.9"
+lazy_static = "1.4"
 proc-macro2 = { version = "1.0.17", default-features = false, features = ["span-locations"] }
 quote = { version = "1.0", default-features = false }
 syn = { version = "1.0.20", default-features = false, features = ["parsing", "printing", "clone-impls", "full"] }

--- a/gen/build/src/cfg.rs
+++ b/gen/build/src/cfg.rs
@@ -1,0 +1,131 @@
+use std::fmt::{self, Debug};
+use std::marker::PhantomData;
+
+pub struct Cfg<'a> {
+    pub include_prefix: &'a str,
+    marker: PhantomData<*const ()>, // !Send + !Sync
+}
+
+#[cfg(doc)]
+pub static mut CFG: Cfg = Cfg {
+    include_prefix: "",
+    marker: PhantomData,
+};
+
+impl<'a> Debug for Cfg<'a> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter
+            .debug_struct("Cfg")
+            .field("include_prefix", &self.include_prefix)
+            .finish()
+    }
+}
+
+#[cfg(not(doc))]
+pub use self::r#impl::Cfg::CFG;
+
+#[cfg(not(doc))]
+mod r#impl {
+    use lazy_static::lazy_static;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+    use std::fmt::{self, Debug};
+    use std::marker::PhantomData;
+    use std::ops::{Deref, DerefMut};
+    use std::sync::{PoisonError, RwLock};
+
+    lazy_static! {
+        static ref PACKAGE_NAME: Box<str> = {
+            crate::env_os("CARGO_PKG_NAME")
+                .map(|pkg| pkg.to_string_lossy().into_owned().into_boxed_str())
+                .unwrap_or_default()
+        };
+        static ref INCLUDE_PREFIX: RwLock<Vec<&'static str>> = RwLock::new(vec![&PACKAGE_NAME]);
+    }
+
+    thread_local! {
+        static CONST_DEREFS: RefCell<HashMap<Handle, Box<super::Cfg<'static>>>> = RefCell::default();
+    }
+
+    #[derive(Eq, PartialEq, Hash)]
+    struct Handle(*const Cfg<'static>);
+
+    impl<'a> Cfg<'a> {
+        fn current() -> super::Cfg<'a> {
+            let include_prefix = *INCLUDE_PREFIX
+                .read()
+                .unwrap_or_else(PoisonError::into_inner)
+                .last()
+                .unwrap();
+            super::Cfg {
+                include_prefix,
+                marker: PhantomData,
+            }
+        }
+
+        const fn handle(self: &Cfg<'a>) -> Handle {
+            Handle(<*const Cfg>::cast(self))
+        }
+    }
+
+    // Since super::Cfg is !Send and !Sync, all Cfg are thread local and will
+    // drop on the same thread where they were created.
+    pub enum Cfg<'a> {
+        Mut(super::Cfg<'a>),
+        CFG,
+    }
+
+    impl<'a> Debug for Cfg<'a> {
+        fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            if let Cfg::Mut(cfg) = self {
+                Debug::fmt(cfg, formatter)
+            } else {
+                Debug::fmt(&Cfg::current(), formatter)
+            }
+        }
+    }
+
+    impl<'a> Deref for Cfg<'a> {
+        type Target = super::Cfg<'a>;
+
+        fn deref(&self) -> &Self::Target {
+            if let Cfg::Mut(cfg) = self {
+                cfg
+            } else {
+                let cfg = CONST_DEREFS.with(|derefs| -> *mut super::Cfg {
+                    &mut **derefs
+                        .borrow_mut()
+                        .entry(self.handle())
+                        .or_insert_with(|| Box::new(Cfg::current()))
+                });
+                unsafe { &mut *cfg }
+            }
+        }
+    }
+
+    impl<'a> DerefMut for Cfg<'a> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            if let Cfg::CFG = self {
+                CONST_DEREFS.with(|derefs| derefs.borrow_mut().remove(&self.handle()));
+                *self = Cfg::Mut(Cfg::current());
+            }
+            match self {
+                Cfg::Mut(cfg) => cfg,
+                Cfg::CFG => unreachable!(),
+            }
+        }
+    }
+
+    impl<'a> Drop for Cfg<'a> {
+        fn drop(&mut self) {
+            if let Cfg::Mut(cfg) = self {
+                INCLUDE_PREFIX
+                    .write()
+                    .unwrap_or_else(PoisonError::into_inner)
+                    .push(Box::leak(Box::from(cfg.include_prefix)));
+            } else {
+                CONST_DEREFS.with(|derefs| derefs.borrow_mut().remove(&self.handle()));
+            }
+        }
+    }
+}

--- a/gen/build/src/cfg.rs
+++ b/gen/build/src/cfg.rs
@@ -1,11 +1,64 @@
 use std::fmt::{self, Debug};
 use std::marker::PhantomData;
 
+/// Build configuration. See [CFG].
 pub struct Cfg<'a> {
     pub include_prefix: &'a str,
     marker: PhantomData<*const ()>, // !Send + !Sync
 }
 
+/// Global configuration of the current build.
+///
+/// <br>
+///
+/// ## **`CFG.include_prefix`**
+///
+/// Presently the only exposed configuration is the `include_prefix`, the prefix
+/// at which C++ code from your crate as well as directly dependent crates can
+/// access the code generated during this build.
+///
+/// By default, the `include_prefix` is equal to the name of the current crate.
+/// That means if our crate is called `demo` and has Rust source files in a
+/// *src/* directory and maybe some handwritten C++ header files in an
+/// *include/* directory, then the current crate as well as downstream crates
+/// might include them as follows:
+///
+/// ```
+/// # const _: &str = stringify! {
+///   // include one of the handwritten headers:
+/// #include "demo/include/wow.h"
+///
+///   // include a header generated from Rust cxx::bridge:
+/// #include "demo/src/lib.rs.h"
+/// # };
+/// ```
+///
+/// By modifying `CFG.include_prefix` we can substitute a prefix that is
+/// different from the crate name if desired. Here we'll change it to
+/// `"path/to"` which will make import paths take the form
+/// `"path/to/include/wow.h"` and `"path/to/src/lib.rs.h"`.
+///
+/// ```no_run
+/// // build.rs
+///
+/// use cxx_build::CFG;
+///
+/// fn main() {
+///     CFG.include_prefix = "path/to";
+///
+///     cxx_build::bridge("src/lib.rs")
+///         .file("src/demo.cc") // probably contains `#include "path/to/src/lib.rs.h"`
+///         /* ... */
+///         .compile("demo");
+/// }
+/// ```
+///
+/// Note that cross-crate imports are only made available between **direct
+/// dependencies**. Another crate must directly depend on your crate in order to
+/// #include its headers; a transitive dependency is not sufficient.
+/// Additionally, headers from a direct dependency are only importable if the
+/// dependency's Cargo.toml manifest contains a `links` key. If not, its headers
+/// will not be importable from outside of the same crate.
 #[cfg(doc)]
 pub static mut CFG: Cfg = Cfg {
     include_prefix: "",

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -129,7 +129,6 @@ impl Project {
     fn init() -> Result<Self> {
         let include_prefix = Path::new(CFG.include_prefix);
         assert!(include_prefix.is_relative());
-        assert!(!include_prefix.as_os_str().is_empty());
         let include_prefix = include_prefix.components().collect();
 
         let manifest_dir = paths::manifest_dir()?;
@@ -246,6 +245,11 @@ fn env_include_dirs() -> impl Iterator<Item = PathBuf> {
 }
 
 fn make_crate_dir(prj: &Project) -> Option<PathBuf> {
+    if prj.include_prefix.as_os_str().is_empty() {
+        let crate_dir = prj.manifest_dir.clone();
+        println!("cargo:CXXBRIDGE_CRATE={}", crate_dir.to_string_lossy());
+        return Some(crate_dir);
+    }
     let crate_dir = prj.out_dir.join("cxxbridge").join("crate");
     let link = crate_dir.join(&prj.include_prefix);
     if out::symlink_dir(&prj.manifest_dir, link).is_ok() {

--- a/tests/BUCK
+++ b/tests/BUCK
@@ -26,10 +26,9 @@ cxx_library(
         ":bridge/source",
         ":module/source",
     ],
-    header_namespace = "cxx-test-suite",
     headers = {
-        "lib.rs.h": ":bridge/header",
-        "tests.h": "ffi/tests.h",
+        "ffi/lib.rs.h": ":bridge/header",
+        "ffi/tests.h": "ffi/tests.h",
     },
     deps = ["//:core"],
 )

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -29,8 +29,6 @@ cc_library(
         ":module/source",
     ],
     hdrs = ["ffi/tests.h"],
-    include_prefix = "cxx-test-suite",
-    strip_include_prefix = "ffi",
     deps = [
         ":bridge/include",
         "//:core",
@@ -40,15 +38,11 @@ cc_library(
 rust_cxx_bridge(
     name = "bridge",
     src = "ffi/lib.rs",
-    include_prefix = "cxx-test-suite",
-    strip_include_prefix = "ffi",
     deps = [":impl"],
 )
 
 rust_cxx_bridge(
     name = "module",
     src = "ffi/module.rs",
-    include_prefix = "cxx-test-suite",
-    strip_include_prefix = "ffi",
     deps = [":impl"],
 )

--- a/tests/ffi/build.rs
+++ b/tests/ffi/build.rs
@@ -1,8 +1,11 @@
+use cxx_build::CFG;
+
 fn main() {
     if cfg!(trybuild) {
         return;
     }
 
+    CFG.include_prefix = "tests/ffi";
     let sources = vec!["lib.rs", "module.rs"];
     cxx_build::bridges(sources)
         .file("tests.cc")

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -23,7 +23,7 @@ pub mod ffi {
     }
 
     extern "C" {
-        include!("cxx-test-suite/tests.h");
+        include!("tests/ffi/tests.h");
 
         type C;
 

--- a/tests/ffi/module.rs
+++ b/tests/ffi/module.rs
@@ -4,7 +4,7 @@
 #[cxx::bridge(namespace = tests)]
 pub mod ffi {
     extern "C" {
-        include!("cxx-test-suite/tests.h");
+        include!("tests/ffi/tests.h");
 
         type C = crate::ffi::C;
 

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -1,5 +1,5 @@
-#include "cxx-test-suite/tests.h"
-#include "cxx-test-suite/lib.rs.h"
+#include "tests/ffi/tests.h"
+#include "tests/ffi/lib.rs.h"
 #include <cstring>
 #include <iterator>
 #include <numeric>

--- a/third-party/BUCK
+++ b/third-party/BUCK
@@ -36,6 +36,7 @@ rust_library(
 rust_library(
     name = "lazy_static",
     srcs = glob(["vendor/lazy_static-1.4.0/src/**"]),
+    visibility = ["PUBLIC"],
 )
 
 rust_library(

--- a/third-party/BUILD
+++ b/third-party/BUILD
@@ -41,6 +41,7 @@ rust_library(
 rust_library(
     name = "lazy_static",
     srcs = glob(["vendor/lazy_static-1.4.0/src/**"]),
+    visibility = ["//visibility:public"],
 )
 
 rust_library(

--- a/third-party/Cargo.lock
+++ b/third-party/Cargo.lock
@@ -79,6 +79,7 @@ dependencies = [
  "cc",
  "codespan-reporting",
  "cxx-gen",
+ "lazy_static",
  "proc-macro2",
  "quote",
  "syn",

--- a/tools/bazel/rust_cxx_bridge.bzl
+++ b/tools/bazel/rust_cxx_bridge.bzl
@@ -1,12 +1,7 @@
 load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
-def rust_cxx_bridge(
-        name,
-        src,
-        include_prefix = None,
-        strip_include_prefix = None,
-        deps = []):
+def rust_cxx_bridge(name, src, deps = []):
     native.alias(
         name = "%s/header" % name,
         actual = src + ".h",
@@ -43,6 +38,4 @@ def rust_cxx_bridge(
     cc_library(
         name = "%s/include" % name,
         hdrs = [src + ".h"],
-        include_prefix = include_prefix,
-        strip_include_prefix = strip_include_prefix,
     )


### PR DESCRIPTION
This PR adds a global configuration object called cxx_build::CFG.

<br>

- #### `CFG.include_prefix`

Presently the only exposed configuration is the `include_prefix`, the prefix at which C++ code from your crate as well as directly dependent crates can access the code generated during this build.

By default, the `include_prefix` is equal to the name of the current crate. That means if our crate is called `demo` and has Rust source files in a *src/* directory and maybe some handwritten C++ header files in an *include/* directory, then the current crate as well as downstream crates might include them as follows:

```cpp
  // include one of the handwritten headers:
#include "demo/include/wow.h"

  // include a header generated from Rust cxx::bridge:
#include "demo/src/lib.rs.h"
```

By modifying `CFG.include_prefix` we can substitute a prefix that is different from the crate name if desired. Here we'll change it to `"path/to"` which will make import paths take the form `"path/to/include/wow.h"` and `"path/to/src/lib.rs.h"`.

```rust
// build.rs

use cxx_bridge::CFG;

fn main() {
    CFG.include_prefix = "path/to";

    cxx_build::bridge("src/lib.rs")
        .file("src/demo.cc") // probably contains `#include "path/to/src/lib.rs.h"`
        /* ... */
        .compile("demo");
}
```

Note that cross-crate imports are only made available between **direct dependencies**. Another crate must directly depend on your crate in order to #include its headers; a transitive dependency is not sufficient. Additionally, headers from a direct dependency are only importable if the dependency's Cargo.toml manifest contains a `links` key. If not, its headers will not be importable from outside of the same crate.