### PR TITLE
Support functions having distinct Rust name and C++ name

### DIFF
--- a/syntax/attrs.rs
+++ b/syntax/attrs.rs
@@ -10,6 +10,8 @@ pub struct Parser<'a> {
     pub doc: Option<&'a mut Doc>,
     pub derives: Option<&'a mut Vec<Derive>>,
     pub repr: Option<&'a mut Option<Atom>>,
+    pub cxx_name: Option<&'a mut Option<Ident>>,
+    pub rust_name: Option<&'a mut Option<Ident>>,
 }
 
 pub(super) fn parse_doc(cx: &mut Errors, attrs: &[Attribute]) -> Doc {
@@ -57,6 +59,26 @@ pub(super) fn parse(cx: &mut Errors, attrs: &[Attribute], mut parser: Parser) {
                 }
                 Err(err) => return cx.push(err),
             }
+        } else if attr.path.is_ident("cxx_name") {
+            match parse_function_alias_attribute.parse2(attr.tokens.clone()) {
+                Ok(attr) => {
+                    if let Some(cxx_name) = &mut parser.cxx_name {
+                        **cxx_name = Some(attr);
+                        continue;
+                    }
+                }
+                Err(err) => return cx.push(err),
+            }
+        } else if attr.path.is_ident("rust_name") {
+            match parse_function_alias_attribute.parse2(attr.tokens.clone()) {
+                Ok(attr) => {
+                    if let Some(rust_name) = &mut parser.rust_name {
+                        **rust_name = Some(attr);
+                        continue;
+                    }
+                }
+                Err(err) => return cx.push(err),
+            }
         }
         return cx.error(attr, "unsupported attribute");
     }
@@ -98,4 +120,14 @@ fn parse_repr_attribute(input: ParseStream) -> Result<Atom> {
         begin.token_stream(),
         "unrecognized repr",
     ))
+}
+
+fn parse_function_alias_attribute(input: ParseStream) -> Result<Ident> {
+    input.parse::<Token![=]>()?;
+    if input.peek(LitStr) {
+        let lit: LitStr = input.parse()?;
+        lit.parse()
+    } else {
+        input.parse()
+    }
 }

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -101,6 +101,15 @@ pub mod ffi {
         fn set2(&mut self, n: usize) -> usize;
         fn set_succeed(&mut self, n: usize) -> Result<usize>;
         fn get_fail(&mut self) -> Result<usize>;
+
+        #[rust_name = "i32_overloaded_method"]
+        fn cOverloadedMethod(&self, x: i32) -> String;
+        #[rust_name = "str_overloaded_method"]
+        fn cOverloadedMethod(&self, x: &str) -> String;
+        #[rust_name = "i32_overloaded_function"]
+        fn cOverloadedFunction(x: i32) -> String;
+        #[rust_name = "str_overloaded_function"]
+        fn cOverloadedFunction(x: &str) -> String;
     }
 
     extern "C" {
@@ -160,6 +169,9 @@ pub mod ffi {
         fn r_return_r2(n: usize) -> Box<R2>;
         fn get(self: &R2) -> usize;
         fn set(self: &mut R2, n: usize) -> usize;
+
+        #[cxx_name = "rAliasedFunction"]
+        fn r_aliased_function(x: i32) -> String;
     }
 }
 
@@ -357,4 +369,8 @@ fn r_fail_return_primitive() -> Result<usize, Error> {
 
 fn r_return_r2(n: usize) -> Box<R2> {
     Box::new(R2(n))
+}
+
+fn r_aliased_function(x: i32) -> String {
+    x.to_string()
 }

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -365,6 +365,22 @@ extern "C" std::string *cxx_test_suite_get_unique_ptr_string() noexcept {
   return std::unique_ptr<std::string>(new std::string("2020")).release();
 }
 
+rust::String C::cOverloadedMethod(int32_t x) const {
+  return rust::String(std::to_string(x));
+}
+
+rust::String C::cOverloadedMethod(rust::Str x) const {
+  return rust::String(std::string(x));
+}
+
+rust::String cOverloadedFunction(int x) {
+  return rust::String(std::to_string(x));
+}
+
+rust::String cOverloadedFunction(rust::Str x) {
+  return rust::String(std::string(x));
+}
+
 extern "C" const char *cxx_run_test() noexcept {
 #define STRINGIFY(x) #x
 #define TOSTRING(x) STRINGIFY(x)
@@ -420,6 +436,8 @@ extern "C" const char *cxx_run_test() noexcept {
   ASSERT(r2->get() == 2021);
   ASSERT(r2->set(2020) == 2020);
   ASSERT(r2->get() == 2020);
+
+  ASSERT(std::string(rAliasedFunction(2020)) == "2020");
 
   cxx_test_suite_set_correct();
   return nullptr;

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -20,6 +20,8 @@ public:
   size_t get_fail();
   const std::vector<uint8_t> &get_v() const;
   std::vector<uint8_t> &get_v();
+  rust::String cOverloadedMethod(int32_t x) const;
+  rust::String cOverloadedMethod(rust::Str x) const;
 
 private:
   size_t n;
@@ -100,5 +102,8 @@ std::unique_ptr<std::string> c_try_return_unique_ptr_string();
 rust::Vec<uint8_t> c_try_return_rust_vec();
 rust::Vec<rust::String> c_try_return_rust_vec_string();
 const rust::Vec<uint8_t> &c_try_return_ref_rust_vec(const C &c);
+
+rust::String cOverloadedFunction(int32_t x);
+rust::String cOverloadedFunction(rust::Str x);
 
 } // namespace tests

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -181,3 +181,12 @@ extern "C" fn cxx_test_suite_get_box() -> *mut cxx_test_suite::R {
 unsafe extern "C" fn cxx_test_suite_r_is_correct(r: *const cxx_test_suite::R) -> bool {
     *r == 2020
 }
+
+#[test]
+fn test_rust_name_attribute() {
+    assert_eq!("2020", ffi::i32_overloaded_function(2020));
+    assert_eq!("2020", ffi::str_overloaded_function("2020"));
+    let unique_ptr = ffi::c_return_unique_ptr();
+    assert_eq!("2020", unique_ptr.i32_overloaded_method(2020));
+    assert_eq!("2020", unique_ptr.str_overloaded_method("2020"));
+}


### PR DESCRIPTION
Supersedes #218.

Within cxx::bridge we can write #\[rust_name = "..."\] or #\[cxx_name = "..."\] to make a change to either name of a function.

In general many functions can have the same C++ name (due to overloading). Every function must continue to have a unique Rust name.