### PR TITLE
Automatically run cargo vendor from bazel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,10 +90,6 @@ jobs:
           chmod +x install.sh
           ./install.sh --user
           echo ::add-path::$HOME/bin
-      - name: Vendor dependencies
-        run: |
-          cp third-party/Cargo.lock .
-          cargo vendor --versioned-dirs --locked third-party/vendor
       - run: bazel run demo --verbose_failures --noshow_progress
       - run: bazel test ... --verbose_failures --noshow_progress
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//tools/bazel:vendor.bzl", "vendor")
 
 http_archive(
     name = "io_bazel_rules_rust",
@@ -33,4 +34,9 @@ rust_repository_set(
     name = "rust_1_47_darwin",
     exec_triple = "x86_64-apple-darwin",
     version = "1.47.0",
+)
+
+vendor(
+    name = "third-party",
+    lockfile = "//third-party:Cargo.lock",
 )

--- a/third-party/BUILD
+++ b/third-party/BUILD
@@ -1,5 +1,6 @@
 load(
     "//tools/bazel:rust.bzl",
+    glob = "third_party_glob",
     rust_binary = "third_party_rust_binary",
     rust_library = "third_party_rust_library",
 )

--- a/tools/bazel/rust.bzl
+++ b/tools/bazel/rust.bzl
@@ -4,6 +4,10 @@ load(
     _rust_library = "rust_library",
     _rust_test = "rust_test",
 )
+load("@third-party//:vendor.bzl", "vendored")
+
+def third_party_glob(include):
+    return vendored and native.glob(include)
 
 def rust_binary(edition = "2018", **kwargs):
     _rust_binary(edition = edition, **kwargs)

--- a/tools/bazel/vendor.bzl
+++ b/tools/bazel/vendor.bzl
@@ -1,0 +1,54 @@
+def _impl(repository_ctx):
+    # Link cxx repository into @third-party.
+    lockfile = repository_ctx.path(repository_ctx.attr.lockfile)
+    workspace = lockfile.dirname.dirname
+    repository_ctx.symlink(workspace, "workspace")
+
+    # Copy third-party/Cargo.lock since those are the crate versions that the
+    # BUILD file is written against.
+    vendor_lockfile = repository_ctx.path("workspace/third-party/Cargo.lock")
+    root_lockfile = repository_ctx.path("workspace/Cargo.lock")
+    _copy_file(repository_ctx, src = vendor_lockfile, dst = root_lockfile)
+
+    # Execute cargo vendor.
+    cmd = ["cargo", "vendor", "--versioned-dirs", "third-party/vendor"]
+    result = repository_ctx.execute(
+        cmd,
+        quiet = True,
+        working_directory = "workspace",
+    )
+    _log_cargo_vendor(repository_ctx, result)
+    if result.return_code != 0:
+        fail("failed to execute `{}`".format(" ".join(cmd)))
+
+    # Copy lockfile back to third-party/Cargo.lock to reflect any modification
+    # performed by Cargo.
+    _copy_file(repository_ctx, src = root_lockfile, dst = vendor_lockfile)
+
+    # Produce a token for third_party_glob to depend on so that the necessary
+    # sequencing is visible to Bazel.
+    repository_ctx.file("BUILD", executable = False)
+    repository_ctx.file("vendor.bzl", "vendored = True", executable = False)
+
+def _copy_file(repository_ctx, *, src, dst):
+    content = repository_ctx.read(src)
+    if not dst.exists or content != repository_ctx.read(dst):
+        repository_ctx.file(dst, content = content, executable = False)
+
+def _log_cargo_vendor(repository_ctx, result):
+    relevant = ""
+    for line in result.stderr.splitlines(True):
+        if line.strip() and not line.startswith("To use vendored sources,"):
+            relevant += line
+    if relevant:
+        # Render it as command output.
+        # If we just use print(), Bazel will cache and repeat the output even
+        # when not rerunning the command.
+        print = ["echo", relevant]
+        repository_ctx.execute(print, quiet = False)
+
+vendor = repository_rule(
+    attrs = {"lockfile": attr.label()},
+    local = True,
+    implementation = _impl,
+)


### PR DESCRIPTION
This should make all bazel commands just work without needing to have run `cargo vendor --versioned-dirs third-party/vendor` manually beforehand.

It also updates third-party/Cargo.lock when required by changes to Cargo.toml.