### PR TITLE
Add ui tests for missing UniquePtr and CxxVector impls with aliases

### DIFF
--- a/tests/ui/alias_missing_cxx_vector_impl.rs
+++ b/tests/ui/alias_missing_cxx_vector_impl.rs
@@ -1,0 +1,27 @@
+#[cxx::bridge]
+mod here {
+    struct Shared {
+        z: usize,
+    }
+
+    extern "C" {
+        type C;
+    }
+}
+
+// Rustfmt mangles the extern type alias.
+// https://github.com/rust-lang/rustfmt/issues/4159
+#[rustfmt::skip]
+#[cxx::bridge]
+mod there {
+    type Shared = crate::here::Shared;
+
+    extern "C" {
+        type C = crate::here::C;
+
+        fn c_take_unique_ptr_vector(s: UniquePtr<CxxVector<C>>);
+        fn c_take_unique_ptr_vector_shared(s: UniquePtr<CxxVector<Shared>>);
+    }
+}
+
+fn main() {}

--- a/tests/ui/alias_missing_cxx_vector_impl.stderr
+++ b/tests/ui/alias_missing_cxx_vector_impl.stderr
@@ -1,0 +1,25 @@
+error[E0277]: the trait bound `here::C: VectorElement` is not satisfied
+  --> $DIR/alias_missing_cxx_vector_impl.rs:15:1
+   |
+15 | #[cxx::bridge]
+   | ^^^^^^^^^^^^^^ the trait `VectorElement` is not implemented for `here::C`
+   |
+  ::: $WORKSPACE/src/unique_ptr.rs
+   |
+   |     T: UniquePtrTarget,
+   |        --------------- required by this bound in `UniquePtr`
+   |
+   = note: required because of the requirements on the impl of `UniquePtrTarget` for `CxxVector<here::C>`
+
+error[E0277]: the trait bound `here::Shared: VectorElement` is not satisfied
+  --> $DIR/alias_missing_cxx_vector_impl.rs:15:1
+   |
+15 | #[cxx::bridge]
+   | ^^^^^^^^^^^^^^ the trait `VectorElement` is not implemented for `here::Shared`
+   |
+  ::: $WORKSPACE/src/unique_ptr.rs
+   |
+   |     T: UniquePtrTarget,
+   |        --------------- required by this bound in `UniquePtr`
+   |
+   = note: required because of the requirements on the impl of `UniquePtrTarget` for `CxxVector<here::Shared>`

--- a/tests/ui/alias_missing_unique_ptr_impl.rs
+++ b/tests/ui/alias_missing_unique_ptr_impl.rs
@@ -1,0 +1,27 @@
+#[cxx::bridge]
+mod here {
+    struct Shared {
+        z: usize,
+    }
+
+    extern "C" {
+        type C;
+    }
+}
+
+// Rustfmt mangles the extern type alias.
+// https://github.com/rust-lang/rustfmt/issues/4159
+#[rustfmt::skip]
+#[cxx::bridge]
+mod there {
+    type Shared = crate::here::Shared;
+
+    extern "C" {
+        type C = crate::here::C;
+
+        fn c_take_unique_ptr(s: UniquePtr<C>);
+        fn c_take_unique_ptr_shared(s: UniquePtr<Shared>);
+    }
+}
+
+fn main() {}

--- a/tests/ui/alias_missing_unique_ptr_impl.stderr
+++ b/tests/ui/alias_missing_unique_ptr_impl.stderr
@@ -1,0 +1,21 @@
+error[E0277]: the trait bound `here::C: UniquePtrTarget` is not satisfied
+  --> $DIR/alias_missing_unique_ptr_impl.rs:15:1
+   |
+15 | #[cxx::bridge]
+   | ^^^^^^^^^^^^^^ the trait `UniquePtrTarget` is not implemented for `here::C`
+   |
+  ::: $WORKSPACE/src/unique_ptr.rs
+   |
+   |     T: UniquePtrTarget,
+   |        --------------- required by this bound in `UniquePtr`
+
+error[E0277]: the trait bound `here::Shared: UniquePtrTarget` is not satisfied
+  --> $DIR/alias_missing_unique_ptr_impl.rs:15:1
+   |
+15 | #[cxx::bridge]
+   | ^^^^^^^^^^^^^^ the trait `UniquePtrTarget` is not implemented for `here::Shared`
+   |
+  ::: $WORKSPACE/src/unique_ptr.rs
+   |
+   |     T: UniquePtrTarget,
+   |        --------------- required by this bound in `UniquePtr`


### PR DESCRIPTION
Cherry-picked from #331 for a more comprehensible GitHub diff. We'll want to pick this up or something like it as part of closing #297.