### PR TITLE
Fix Windows symlink test to give reproducible error messages

### DIFF
--- a/tools/cargo/build.rs
+++ b/tools/cargo/build.rs
@@ -61,6 +61,7 @@ fn main() {
         let from_dir = parent_dir.join("from");
         let to_dir = parent_dir.join("to");
         if fs::create_dir_all(&from_dir).is_ok()
+            && fs::remove_dir(&to_dir).is_ok()
             && windows::symlink_dir(&from_dir, &to_dir).is_err()
         {
             message = DENIED;


### PR DESCRIPTION
Hello! I have just seen a crazy amount of work has gone into this crate since my last symlink problem https://github.com/dtolnay/cxx/pull/227 🙂
I was eager to test it out on Windows, and found a little corner case:

After a `git clone -c core.symlinks=false` and `cargo test`, the script outputs a Git error as expected:
```
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  When building `cxx` from a git clone, git's symlink support needs
  to be enabled on platforms that have it off by default (Windows).
  Either use:

     $ git config --global core.symlinks true

  prior to cloning, or else use:

     $ git clone -c core.symlinks=true https://github.com/dtolnay/cxx

  for the clone.

  Symlinks are only required when compiling locally from a clone of
  the git repository---they are NOT required when building `cxx` as
  a Cargo-managed (possibly transitive) build dependency downloaded
  through crates.io.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

When running `cargo test` again, the error message changes to "symlink support needs to be enabled", even though Windows Developer mode is enabled:

```
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  When building `cxx` from a git clone on Windows we need Developer
  Mode enabled for symlink support.

  To enable Developer Mode: go under Settings to Update & Security,
  then 'For developers', and turn on the toggle for Developer Mode.

  For more explanation of symlinks in Windows, see these resources:
  > https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/
  > https://docs.microsoft.com/windows/uwp/get-started/enable-your-device-for-development

  Symlinks are only required when compiling locally from a clone of
  the git repository---they are NOT required when building `cxx` as
  a Cargo-managed (possibly transitive) build dependency downloaded
  through crates.io.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Reason: the symlink detection is done for an already existing directory, and the Windows `mklink` command _fails_ when the symlink exists already.
This PR deletes the link prior to the symlink creation.

By the way, **thanks a lot** for taking the time to document this problem so clearly. I'm sure many users can benefit from it, and I really appreciate the work, even if Windows may not be your main development platform. 👍 