### PR TITLE
Make cxx.h available to high level code generators.

### DIFF
--- a/gen/README.md
+++ b/gen/README.md
@@ -2,3 +2,6 @@ This directory contains CXX's C++ code generator. This code generator has two
 public frontends, one a command-line application (binary) in the *cmd* directory
 and the other a library intended to be used from a build.rs in the *build*
 directory.
+
+There's also a 'lib' frontend which is intended to allow higher level code generators
+to embed cxx. This is not yet recommended for general use.

--- a/gen/lib/src/lib.rs
+++ b/gen/lib/src/lib.rs
@@ -22,6 +22,7 @@ mod syntax;
 pub use crate::error::Error;
 pub use crate::gen::{GeneratedCode, Opt};
 use proc_macro2::TokenStream;
+use gen::include::HEADER;
 
 /// Generate C++ bindings code from a Rust token stream. This should be a Rust
 /// token stream which somewhere contains a `#[cxx::bridge] mod {}`.
@@ -30,4 +31,9 @@ pub fn generate_header_and_cc(rust_source: TokenStream, opt: &Opt) -> Result<Gen
         .map_err(crate::gen::Error::from)
         .map_err(Error::from)?;
     gen::generate(syntax, opt).map_err(Error::from)
+}
+
+/// Returns the complete contents of the cxx.h header.
+pub fn get_cxx_header_contents() -> &'static str {
+    HEADER
 }

--- a/gen/lib/src/lib.rs
+++ b/gen/lib/src/lib.rs
@@ -20,9 +20,9 @@ mod gen;
 mod syntax;
 
 pub use crate::error::Error;
+pub use crate::gen::include::HEADER;
 pub use crate::gen::{GeneratedCode, Opt};
 use proc_macro2::TokenStream;
-use gen::include::HEADER;
 
 /// Generate C++ bindings code from a Rust token stream. This should be a Rust
 /// token stream which somewhere contains a `#[cxx::bridge] mod {}`.
@@ -31,9 +31,4 @@ pub fn generate_header_and_cc(rust_source: TokenStream, opt: &Opt) -> Result<Gen
         .map_err(crate::gen::Error::from)
         .map_err(Error::from)?;
     gen::generate(syntax, opt).map_err(Error::from)
-}
-
-/// Returns the complete contents of the cxx.h header.
-pub fn get_cxx_header_contents() -> &'static str {
-    HEADER
 }

--- a/gen/src/include.rs
+++ b/gen/src/include.rs
@@ -1,6 +1,7 @@
 use crate::gen::out::OutFile;
 use std::fmt::{self, Display};
 
+/// The complete contents of the "rust/cxx.h" header.
 pub static HEADER: &str = include_str!("include/cxx.h");
 
 pub(super) fn write(out: &mut OutFile, needed: bool, guard: &str) {


### PR DESCRIPTION
At present, this file is available only from the git repository,
but higher level code generators may wish to ensure that they supply
a version of `cxx.h` corresponding precisely to the version of cxx
in use.

Specifically, such higher level code generators may wish to use
`rust::Str` and similar types in code which _they_ autogenerate,
and thus need a way to include definitions of such types. As
this code is autogenerated, it can't reasonably rummage around
the cxx git repository to find the correct `cxx.h` header.

To be even more specific, higher level code generators may wish
to pass `rust::Str` and/or `rust::String` types into C++, in order
to create `UniquePtr<CxxString>`s from Rust strings during function
calls.