### PR TITLE
Add error message for invalid include! paths

### DIFF
--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -311,8 +311,9 @@ fn verify_include_dir(include_dir: &PathBuf, include_prefix: &Path) {
         return;
     }
 
+    // Include prefix is stored with backslashes under Windows -> very basic slash conversion (use path-slash for more sophisticated one)
     panic!("include!(\"{}\") is invalid:\n   path must either start with include prefix '{}' or be an absolute path.\n\n",
-           include_dir.display(), include_prefix.display());
+           include_dir.display(), include_prefix.to_str().unwrap().to_string().replace("\\", "/"));
 }
 
 fn env_os(key: impl AsRef<OsStr>) -> Result<OsString> {

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -319,3 +319,43 @@ fn env_os(key: impl AsRef<OsStr>) -> Result<OsString> {
     let key = key.as_ref();
     env::var_os(key).ok_or_else(|| Error::NoEnv(key.to_owned()))
 }
+
+
+#[test]
+fn test_include_dir_correct0() {
+    verify_include_dir(&PathBuf::from("some_crate/path/to/dir"), Path::new("some_crate"));
+}
+
+#[test]
+fn test_include_dir_correct1() {
+    verify_include_dir(&PathBuf::from("some_crate/path/to/dir"), Path::new("some_crate/path"));
+}
+
+#[test]
+fn test_include_dir_correct2() {
+    verify_include_dir(&PathBuf::from("some_crate/path/to/dir"), Path::new("some_crate/path/"));
+}
+
+#[test]
+fn test_include_dir_correct_absolute() {
+    let root = if cfg!(windows) {
+        PathBuf::from("C:/")
+    } else {
+        PathBuf::from("/")
+    };
+
+    verify_include_dir(&root, Path::new("some_crate"));
+    verify_include_dir(&root.join("temp"), Path::new("some_crate"));
+}
+
+#[test]
+#[should_panic]
+fn test_include_dir_wrong_prefix() {
+    verify_include_dir(&PathBuf::from("other_dir/path/to/dir"), Path::new("some_crate"));
+}
+
+#[test]
+#[should_panic]
+fn test_include_dir_incomplete_prefix() {
+    verify_include_dir(&PathBuf::from("some_crate/path/to/dir"), Path::new("some"));
+}

--- a/gen/src/mod.rs
+++ b/gen/src/mod.rs
@@ -53,6 +53,9 @@ pub struct GeneratedCode {
     pub header: Vec<u8>,
     /// The bytes of a C++ implementation file (e.g. .cc, cpp etc.)
     pub implementation: Vec<u8>,
+
+    // All directory paths that were parsed inside a cxxbridge include!() macro
+    pub(crate) bridge_include_dirs: Vec<String>,
 }
 
 impl Default for Opt {
@@ -128,5 +131,6 @@ pub(super) fn generate(syntax: File, opt: &Opt) -> Result<GeneratedCode> {
         } else {
             Vec::new()
         },
+        bridge_include_dirs: types.include_dirs.iter().map(|&s| s.clone()).collect()
     })
 }

--- a/syntax/types.rs
+++ b/syntax/types.rs
@@ -16,6 +16,7 @@ pub struct Types<'a> {
     pub untrusted: Map<&'a Ident, &'a ExternType>,
     pub required_trivial: Map<&'a Ident, TrivialReason<'a>>,
     pub explicit_impls: Set<&'a Impl>,
+    pub include_dirs: UnorderedSet<&'a String>,
 }
 
 impl<'a> Types<'a> {
@@ -28,6 +29,7 @@ impl<'a> Types<'a> {
         let mut aliases = Map::new();
         let mut untrusted = Map::new();
         let mut explicit_impls = Set::new();
+        let mut include_dirs = UnorderedSet::new();
 
         fn visit<'a>(all: &mut Set<&'a Type>, ty: &'a Type) {
             all.insert(ty);
@@ -60,7 +62,9 @@ impl<'a> Types<'a> {
             //
             // All other cases of duplicate identifiers are reported as an error.
             match api {
-                Api::Include(_) => {}
+                Api::Include(include_dir) => {
+                    include_dirs.insert(include_dir);
+                }
                 Api::Struct(strct) => {
                     let ident = &strct.ident;
                     if !type_names.insert(ident)
@@ -187,6 +191,7 @@ impl<'a> Types<'a> {
             untrusted,
             required_trivial,
             explicit_impls,
+            include_dirs,
         }
     }
 


### PR DESCRIPTION
As promised in [#367](https://github.com/dtolnay/cxx/issues/367#issuecomment-714738184), here's the pull request for an error message when `include!` receives a path that it cannot handle. This is to avoid that such errors propagate further down and only fail at the C++ compile step (and was a reason I spend a lot of time debugging my cxx examples).

**The logic is:** path must begin with the configured include prefix (crate name by default) or must be an absolute path.

Remarks:
1. There were multiple places where I could have added the verification, but I thought the parser is not a good idea, because what `include!` means depends on the user of the parser (can be an external crate such as autocxx). So I implemented it close to the bridge generation.
1. In the parser, I now no longer skip `include!` statements, but integrate them with the `Types` struct and carry that information upward several levels.
1. There are unit tests for the `verify_include_dir()` function, but I'm not sure what's the best location for them. I cannot move them to another crate without making the function under test public.
1. For a similar reason I couldn't write any integration tests (testing the whole chain like in `tests/cxx_gen.rs`). I did some manual tests however. Probably you know much better how and where to add extra tests, if it's even necessary (this PR is primarily a quality-of-life/diagnostic improvement)