### PR TITLE
Emit fully qualified namespaces

### DIFF
--- a/gen/src/mod.rs
+++ b/gen/src/mod.rs
@@ -5,6 +5,7 @@ pub(super) mod error;
 mod file;
 pub(super) mod fs;
 pub(super) mod include;
+mod namespace_organizer;
 pub(super) mod out;
 mod write;
 
@@ -119,12 +120,12 @@ pub(super) fn generate(syntax: File, opt: &Opt) -> Result<GeneratedCode> {
     // only need to generate one or the other.
     Ok(GeneratedCode {
         header: if opt.gen_header {
-            write::gen(namespace, apis, types, opt, true).content()
+            write::gen(apis, types, opt, true).content()
         } else {
             Vec::new()
         },
         implementation: if opt.gen_implementation {
-            write::gen(namespace, apis, types, opt, false).content()
+            write::gen(apis, types, opt, false).content()
         } else {
             Vec::new()
         },

--- a/gen/src/mod.rs
+++ b/gen/src/mod.rs
@@ -109,10 +109,10 @@ pub(super) fn generate(syntax: File, opt: &Opt) -> Result<GeneratedCode> {
         .ok_or(Error::NoBridgeMod)?;
     let ref namespace = bridge.namespace;
     let trusted = bridge.unsafety.is_some();
-    let ref apis = syntax::parse_items(errors, bridge.content, trusted);
+    let ref apis = syntax::parse_items(errors, bridge.content, trusted, namespace);
     let ref types = Types::collect(errors, apis);
     errors.propagate()?;
-    check::typecheck(errors, namespace, apis, types);
+    check::typecheck(errors, apis, types);
     errors.propagate()?;
     // Some callers may wish to generate both header and C++
     // from the same token stream to avoid parsing twice. But others

--- a/gen/src/namespace_organizer.rs
+++ b/gen/src/namespace_organizer.rs
@@ -21,7 +21,7 @@ fn sort_by_inner_namespace(apis: Vec<&Api>, depth: usize) -> NamespaceEntries {
     let mut kids_by_child_ns = HashMap::new();
     for api in apis {
         if let Some(ns) = api.get_namespace() {
-            let first_ns_elem = ns.iter().skip(depth).next();
+            let first_ns_elem = ns.iter().nth(depth);
             if let Some(first_ns_elem) = first_ns_elem {
                 let list = kids_by_child_ns.entry(first_ns_elem).or_insert(Vec::new());
                 list.push(api);

--- a/gen/src/namespace_organizer.rs
+++ b/gen/src/namespace_organizer.rs
@@ -1,0 +1,40 @@
+use crate::syntax::Api;
+use proc_macro2::Ident;
+use std::collections::HashMap;
+
+pub(crate) struct NamespaceEntries<'a> {
+    pub(crate) entries: Vec<&'a Api>,
+    pub(crate) children: HashMap<&'a Ident, NamespaceEntries<'a>>,
+}
+
+pub(crate) fn sort_by_namespace(apis: &[Api]) -> NamespaceEntries {
+    let api_refs = apis.iter().collect::<Vec<_>>();
+    sort_by_inner_namespace(api_refs, 0)
+}
+
+fn sort_by_inner_namespace(apis: Vec<&Api>, depth: usize) -> NamespaceEntries {
+    let mut root = NamespaceEntries {
+        entries: Vec::new(),
+        children: HashMap::new(),
+    };
+
+    let mut kids_by_child_ns = HashMap::new();
+    for api in apis {
+        if let Some(ns) = api.get_namespace() {
+            let first_ns_elem = ns.iter().skip(depth).next();
+            if let Some(first_ns_elem) = first_ns_elem {
+                let list = kids_by_child_ns.entry(first_ns_elem).or_insert(Vec::new());
+                list.push(api);
+                continue;
+            }
+        }
+        root.entries.push(api);
+    }
+
+    for (k, v) in kids_by_child_ns.into_iter() {
+        root.children
+            .insert(k, sort_by_inner_namespace(v, depth + 1));
+    }
+
+    root
+}

--- a/gen/src/out.rs
+++ b/gen/src/out.rs
@@ -1,10 +1,8 @@
 use crate::gen::include::Includes;
-use crate::syntax::namespace::Namespace;
 use std::cell::RefCell;
 use std::fmt::{self, Arguments, Write};
 
 pub(crate) struct OutFile {
-    pub namespace: Namespace,
     pub header: bool,
     pub include: Includes,
     pub front: Content,
@@ -18,9 +16,8 @@ pub struct Content {
 }
 
 impl OutFile {
-    pub fn new(namespace: Namespace, header: bool) -> Self {
+    pub fn new(header: bool) -> Self {
         OutFile {
-            namespace,
             header,
             include: Includes::new(),
             front: Content::new(),

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -343,7 +343,7 @@ fn write_include_cxxbridge(out: &mut OutFile, apis: &[Api], types: &Types) {
 }
 
 fn write_struct(out: &mut OutFile, strct: &Struct) {
-    let guard = format!("CXXBRIDGE05_STRUCT_{}", strct.ident.to_include_guard());
+    let guard = format!("CXXBRIDGE05_STRUCT_{}", strct.ident.to_symbol());
     writeln!(out, "#ifndef {}", guard);
     writeln!(out, "#define {}", guard);
     for line in strct.doc.to_string().lines() {
@@ -373,7 +373,7 @@ fn write_struct_using(out: &mut OutFile, ident: &QualifiedIdent) {
 }
 
 fn write_struct_with_methods(out: &mut OutFile, ety: &ExternType, methods: &[&ExternFn]) {
-    let guard = format!("CXXBRIDGE05_STRUCT_{}", ety.ident.to_include_guard());
+    let guard = format!("CXXBRIDGE05_STRUCT_{}", ety.ident.to_symbol());
     writeln!(out, "#ifndef {}", guard);
     writeln!(out, "#define {}", guard);
     for line in ety.doc.to_string().lines() {
@@ -398,7 +398,7 @@ fn write_struct_with_methods(out: &mut OutFile, ety: &ExternType, methods: &[&Ex
 }
 
 fn write_enum(out: &mut OutFile, enm: &Enum) {
-    let guard = format!("CXXBRIDGE05_ENUM_{}", enm.ident.to_include_guard());
+    let guard = format!("CXXBRIDGE05_ENUM_{}", enm.ident.to_symbol());
     writeln!(out, "#ifndef {}", guard);
     writeln!(out, "#define {}", guard);
     for line in enm.doc.to_string().lines() {
@@ -1065,10 +1065,10 @@ fn to_typename(ty: &Type) -> String {
 
 // Only called for legal referent types of unique_ptr and element types of
 // std::vector and Vec.
-fn to_mangled(ty: &Type) -> String {
+fn to_mangled(ty: &Type) -> Symbol {
     match ty {
-        Type::Ident(ident) => ident.to_bridge_name(),
-        Type::CxxVector(ptr) => format!("std$vector${}", to_mangled(&ptr.inner)),
+        Type::Ident(ident) => ident.to_symbol(),
+        Type::CxxVector(ptr) => to_mangled(&ptr.inner).prefix_with("std$vector$"),
         _ => unreachable!(),
     }
 }
@@ -1131,7 +1131,7 @@ fn write_generic_instantiations(out: &mut OutFile, types: &Types) {
 
 fn write_rust_box_extern(out: &mut OutFile, ident: &QualifiedIdent) {
     let inner = ident.to_fully_qualified();
-    let instance = ident.to_bridge_name();
+    let instance = ident.to_symbol();
 
     writeln!(out, "#ifndef CXXBRIDGE05_RUST_BOX_{}", instance);
     writeln!(out, "#define CXXBRIDGE05_RUST_BOX_{}", instance);
@@ -1185,7 +1185,7 @@ fn write_rust_vec_extern(out: &mut OutFile, element: &QualifiedIdent) {
 
 fn write_rust_box_impl(out: &mut OutFile, ident: &QualifiedIdent) {
     let inner = ident.to_fully_qualified();
-    let instance = ident.to_bridge_name();
+    let instance = ident.to_symbol();
 
     writeln!(out, "template <>");
     writeln!(out, "void Box<{}>::uninit() noexcept {{", inner);

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -710,7 +710,7 @@ fn type_id(ident: &QualifiedIdent) -> TokenStream {
 }
 
 fn expand_rust_box(ident: &QualifiedIdent) -> TokenStream {
-    let link_prefix = format!("cxxbridge05$box${}$", ident.to_bridge_name());
+    let link_prefix = format!("cxxbridge05$box${}$", ident.to_symbol());
     let link_uninit = format!("{}uninit", link_prefix);
     let link_drop = format!("{}drop", link_prefix);
 
@@ -739,7 +739,7 @@ fn expand_rust_box(ident: &QualifiedIdent) -> TokenStream {
 }
 
 fn expand_rust_vec(elem: &QualifiedIdent) -> TokenStream {
-    let link_prefix = format!("cxxbridge05$rust_vec${}$", elem.to_bridge_name());
+    let link_prefix = format!("cxxbridge05$rust_vec${}$", elem.to_symbol());
     let link_new = format!("{}new", link_prefix);
     let link_drop = format!("{}drop", link_prefix);
     let link_len = format!("{}len", link_prefix);
@@ -789,7 +789,7 @@ fn expand_unique_ptr(
     explicit_impl: Option<&Impl>,
 ) -> TokenStream {
     let name = ident.to_fully_qualified();
-    let prefix = format!("cxxbridge05$unique_ptr${}$", ident.to_bridge_name());
+    let prefix = format!("cxxbridge05$unique_ptr${}$", ident.to_symbol());
     let link_null = format!("{}null", prefix);
     let link_new = format!("{}new", prefix);
     let link_raw = format!("{}raw", prefix);
@@ -868,13 +868,10 @@ fn expand_unique_ptr(
 fn expand_cxx_vector(elem: &QualifiedIdent, explicit_impl: Option<&Impl>) -> TokenStream {
     let _ = explicit_impl;
     let name = elem.to_fully_qualified();
-    let prefix = format!("cxxbridge05$std$vector${}$", elem.to_bridge_name());
+    let prefix = format!("cxxbridge05$std$vector${}$", elem.to_symbol());
     let link_size = format!("{}size", prefix);
     let link_get_unchecked = format!("{}get_unchecked", prefix);
-    let unique_ptr_prefix = format!(
-        "cxxbridge05$unique_ptr$std$vector${}$",
-        elem.to_bridge_name()
-    );
+    let unique_ptr_prefix = format!("cxxbridge05$unique_ptr$std$vector${}$", elem.to_symbol());
     let link_unique_ptr_null = format!("{}null", unique_ptr_prefix);
     let link_unique_ptr_raw = format!("{}raw", unique_ptr_prefix);
     let link_unique_ptr_get = format!("{}get", unique_ptr_prefix);

--- a/syntax/atom.rs
+++ b/syntax/atom.rs
@@ -1,3 +1,4 @@
+use crate::syntax::QualifiedIdent;
 use crate::syntax::Type;
 use proc_macro2::Ident;
 use std::fmt::{self, Display};
@@ -22,6 +23,14 @@ pub enum Atom {
 }
 
 impl Atom {
+    pub fn from_qualified_ident(ident: &QualifiedIdent) -> Option<Self> {
+        if !ident.ns.is_empty() {
+            None
+        } else {
+            Self::from(&ident.ident)
+        }
+    }
+
     pub fn from(ident: &Ident) -> Option<Self> {
         Self::from_str(ident.to_string().as_str())
     }
@@ -90,6 +99,18 @@ impl PartialEq<Atom> for Type {
 impl PartialEq<Atom> for &Ident {
     fn eq(&self, atom: &Atom) -> bool {
         *self == atom
+    }
+}
+
+impl PartialEq<Atom> for &QualifiedIdent {
+    fn eq(&self, atom: &Atom) -> bool {
+        self.ns.is_empty() && self.ident == atom
+    }
+}
+
+impl PartialEq<Atom> for QualifiedIdent {
+    fn eq(&self, atom: &Atom) -> bool {
+        self.ns.is_empty() && self.ident == atom
     }
 }
 

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -67,7 +67,7 @@ fn check_type_ident(cx: &mut Check, ident: &Ident) {
         && !cx.types.cxx.contains(ident)
         && !cx.types.rust.contains(ident)
     {
-        cx.error(ident, "unsupported type");
+        cx.error(ident, &format!("unsupported type: {}", ident));
     }
 }
 

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -64,7 +64,10 @@ fn check_type_ident(cx: &mut Check, ident: &QualifiedIdent) {
         && !cx.types.cxx.contains(ident)
         && !cx.types.rust.contains(ident)
     {
-        cx.error(ident, &format!("unsupported type: {}", ident));
+        cx.error(
+            ident,
+            &format!("unsupported type: {}", ident.to_fully_qualified()),
+        );
     }
 }
 
@@ -210,7 +213,9 @@ fn check_api_type(cx: &mut Check, ety: &ExternType) {
 
     if let Some(reason) = cx.types.required_trivial.get(&ety.ident) {
         let what = match reason {
-            TrivialReason::StructField(strct) => format!("a field of `{}`", strct.ident),
+            TrivialReason::StructField(strct) => {
+                format!("a field of `{}`", strct.ident.to_fully_qualified())
+            }
             TrivialReason::FunctionArgument(efn) => format!("an argument of `{}`", efn.ident.rust),
             TrivialReason::FunctionReturn(efn) => format!("a return value of `{}`", efn.ident.rust),
         };
@@ -410,7 +415,7 @@ fn describe(cx: &mut Check, ty: &Type) -> String {
             } else if Atom::from_qualified_ident(ident) == Some(CxxString) {
                 "C++ string".to_owned()
             } else {
-                ident.to_string()
+                ident.to_fully_qualified()
             }
         }
         Type::RustBox(_) => "Box".to_owned(),

--- a/syntax/mangle.rs
+++ b/syntax/mangle.rs
@@ -1,4 +1,3 @@
-use crate::syntax::namespace::Namespace;
 use crate::syntax::symbol::{self, Symbol};
 use crate::syntax::ExternFn;
 use proc_macro2::Ident;
@@ -11,19 +10,19 @@ macro_rules! join {
     };
 }
 
-pub fn extern_fn(namespace: &Namespace, efn: &ExternFn) -> Symbol {
+pub fn extern_fn(efn: &ExternFn) -> Symbol {
     match &efn.receiver {
-        Some(receiver) => join!(namespace, CXXBRIDGE, receiver.ty, efn.ident.rust),
-        None => join!(namespace, CXXBRIDGE, efn.ident.rust),
+        Some(receiver) => join!(efn.ident.cxx.ns, CXXBRIDGE, receiver.ty, efn.ident.rust),
+        None => join!(efn.ident.cxx.ns, CXXBRIDGE, efn.ident.rust),
     }
 }
 
 // The C half of a function pointer trampoline.
-pub fn c_trampoline(namespace: &Namespace, efn: &ExternFn, var: &Ident) -> Symbol {
-    join!(extern_fn(namespace, efn), var, 0)
+pub fn c_trampoline(efn: &ExternFn, var: &Ident) -> Symbol {
+    join!(extern_fn(efn), var, 0)
 }
 
 // The Rust half of a function pointer trampoline.
-pub fn r_trampoline(namespace: &Namespace, efn: &ExternFn, var: &Ident) -> Symbol {
-    join!(extern_fn(namespace, efn), var, 1)
+pub fn r_trampoline(efn: &ExternFn, var: &Ident) -> Symbol {
+    join!(extern_fn(efn), var, 1)
 }

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -25,7 +25,7 @@ use self::namespace::Namespace;
 use self::parse::kw;
 use core::fmt::{Formatter, Result};
 use proc_macro2::{Ident, Span, TokenStream};
-use quote::{quote, IdentFragment, ToTokens};
+use quote::{IdentFragment, ToTokens};
 use syn::punctuated::Punctuated;
 use syn::token::{Brace, Bracket, Paren};
 use syn::{Expr, Lifetime, Token, Type as RustType};
@@ -37,6 +37,10 @@ pub use self::parse::parse_items;
 pub use self::types::Types;
 
 #[derive(Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+/// A C++ identifier in a particular namespace.
+/// It is intentional that this does not impl Display,
+/// because we want to force users actively to decide whether to output
+/// it as a qualified name or as an unqualfiied name.
 pub struct QualifiedIdent {
     pub ns: Namespace,
     pub ident: Ident,
@@ -179,6 +183,21 @@ pub enum Lang {
     Rust,
 }
 
+impl Api {
+    pub fn get_namespace(&self) -> Option<&Namespace> {
+        match self {
+            Api::CxxFunction(cfn) => Some(&cfn.ident.cxx.ns),
+            Api::CxxType(cty) => Some(&cty.ident.ns),
+            Api::Enum(enm) => Some(&enm.ident.ns),
+            Api::Struct(strct) => Some(&strct.ident.ns),
+            Api::TypeAlias(ta) => Some(&ta.ident.ns),
+            Api::RustType(rty) => Some(&rty.ident.ns),
+            Api::RustFunction(rfn) => Some(&rfn.ident.cxx.ns),
+            Api::Impl(_) | Api::Include(_) => None,
+        }
+    }
+}
+
 impl QualifiedIdent {
     /// Use this constructor if the name is always qualified according to
     /// the namespace.
@@ -230,37 +249,30 @@ impl QualifiedIdent {
     ) -> std::iter::Chain<std::slice::Iter<Ident>, std::iter::Once<&Ident>> {
         self.ns.iter().chain(std::iter::once(&self.ident))
     }
-}
 
-// TODO - we need to change this to the following
-// to output fully-qualified names in Rust and C++. It breaks everything :)
-const USE_FULLY_QUALIFIED_NAMES: bool = false;
+    fn join(&self, sep: &str) -> String {
+        self.iter_all_segments()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>()
+            .join(sep)
+    }
 
-impl std::fmt::Display for QualifiedIdent {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        if USE_FULLY_QUALIFIED_NAMES {
-            let fully_qualified = self
-                .iter_all_segments()
-                .map(|s| s.to_string())
-                .collect::<Vec<_>>()
-                .join("::");
-            write!(f, "{}", fully_qualified)
-        } else {
-            write!(f, "{}", self.ident.to_string())
-        }
+    pub fn to_include_guard(&self) -> String {
+        self.to_bridge_name()
+    }
+
+    pub fn to_bridge_name(&self) -> String {
+        self.join("$")
+    }
+
+    pub fn to_fully_qualified(&self) -> String {
+        format!("::{}", self.join("::"))
     }
 }
 
 impl ToTokens for QualifiedIdent {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        if USE_FULLY_QUALIFIED_NAMES {
-            let segments = self.iter_all_segments();
-            tokens.extend(quote! {
-                #(#segments)::*
-            })
-        } else {
-            self.ident.to_tokens(tokens);
-        }
+        self.ident.to_tokens(tokens);
     }
 }
 

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -23,6 +23,7 @@ pub mod types;
 use self::discriminant::Discriminant;
 use self::namespace::Namespace;
 use self::parse::kw;
+use self::symbol::Symbol;
 use core::fmt::{Formatter, Result};
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{IdentFragment, ToTokens};
@@ -257,12 +258,8 @@ impl QualifiedIdent {
             .join(sep)
     }
 
-    pub fn to_include_guard(&self) -> String {
-        self.to_bridge_name()
-    }
-
-    pub fn to_bridge_name(&self) -> String {
-        self.join("$")
+    pub fn to_symbol(&self) -> Symbol {
+        Symbol::from_idents(self.iter_all_segments())
     }
 
     pub fn to_fully_qualified(&self) -> String {

--- a/syntax/namespace.rs
+++ b/syntax/namespace.rs
@@ -8,8 +8,7 @@ use syn::{Ident, Token};
 mod kw {
     syn::custom_keyword!(namespace);
 }
-
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Namespace {
     segments: Vec<Ident>,
 }
@@ -23,6 +22,10 @@ impl Namespace {
 
     pub fn iter(&self) -> Iter<Ident> {
         self.segments.iter()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.segments.is_empty()
     }
 }
 

--- a/syntax/qualified.rs
+++ b/syntax/qualified.rs
@@ -10,6 +10,7 @@ impl QualifiedName {
     pub fn parse_unquoted(input: ParseStream) -> Result<Self> {
         let mut segments = Vec::new();
         let mut trailing_punct = true;
+        input.parse::<Option<Token![::]>>()?;
         while trailing_punct && input.peek(Ident::peek_any) {
             let ident = Ident::parse_any(input)?;
             segments.push(ident);

--- a/syntax/symbol.rs
+++ b/syntax/symbol.rs
@@ -1,4 +1,5 @@
 use crate::syntax::namespace::Namespace;
+use crate::syntax::QualifiedIdent;
 use proc_macro2::{Ident, TokenStream};
 use quote::ToTokens;
 use std::fmt::{self, Display, Write};
@@ -52,6 +53,13 @@ impl Segment for Namespace {
         for segment in self {
             symbol.push(segment);
         }
+    }
+}
+
+impl Segment for QualifiedIdent {
+    fn write(&self, symbol: &mut Symbol) {
+        self.ns.write(symbol);
+        self.ident.write(symbol);
     }
 }
 

--- a/syntax/symbol.rs
+++ b/syntax/symbol.rs
@@ -37,16 +37,30 @@ impl Symbol {
     }
 }
 
-pub trait Segment: Display {
+pub trait Segment {
+    fn write(&self, symbol: &mut Symbol);
+}
+
+impl Segment for str {
     fn write(&self, symbol: &mut Symbol) {
         symbol.push(&self);
     }
 }
-
-impl Segment for str {}
-impl Segment for usize {}
-impl Segment for Ident {}
-impl Segment for Symbol {}
+impl Segment for usize {
+    fn write(&self, symbol: &mut Symbol) {
+        symbol.push(&self);
+    }
+}
+impl Segment for Ident {
+    fn write(&self, symbol: &mut Symbol) {
+        symbol.push(&self);
+    }
+}
+impl Segment for Symbol {
+    fn write(&self, symbol: &mut Symbol) {
+        symbol.push(&self);
+    }
+}
 
 impl Segment for Namespace {
     fn write(&self, symbol: &mut Symbol) {
@@ -65,7 +79,7 @@ impl Segment for QualifiedIdent {
 
 impl<T> Segment for &'_ T
 where
-    T: ?Sized + Segment,
+    T: ?Sized + Segment + Display,
 {
     fn write(&self, symbol: &mut Symbol) {
         (**self).write(symbol);

--- a/syntax/symbol.rs
+++ b/syntax/symbol.rs
@@ -20,12 +20,6 @@ impl ToTokens for Symbol {
     }
 }
 
-impl From<&Ident> for Symbol {
-    fn from(ident: &Ident) -> Self {
-        Symbol(ident.to_string())
-    }
-}
-
 impl Symbol {
     fn push(&mut self, segment: &dyn Display) {
         let len_before = self.0.len();
@@ -34,6 +28,21 @@ impl Symbol {
         }
         self.0.write_fmt(format_args!("{}", segment)).unwrap();
         assert!(self.0.len() > len_before);
+    }
+
+    pub fn from_idents<'a, T: Iterator<Item = &'a Ident>>(it: T) -> Self {
+        let mut symbol = Symbol(String::new());
+        for segment in it {
+            segment.write(&mut symbol);
+        }
+        assert!(!symbol.0.is_empty());
+        symbol
+    }
+
+    /// For example, for taking a symbol and then making a new symbol
+    /// for a vec of that symbol.
+    pub fn prefix_with(&self, prefix: &str) -> Symbol {
+        Symbol(format!("{}{}", prefix, self.to_string()))
     }
 }
 

--- a/syntax/tokens.rs
+++ b/syntax/tokens.rs
@@ -39,7 +39,7 @@ impl ToTokens for Var {
 impl ToTokens for Ty1 {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let span = self.name.span();
-        let name = self.name.to_string();
+        let name = self.name.ident.to_string();
         if let "UniquePtr" | "CxxVector" = name.as_str() {
             tokens.extend(quote_spanned!(span=> ::cxx::));
         } else if name == "Vec" {

--- a/syntax/types.rs
+++ b/syntax/types.rs
@@ -232,7 +232,10 @@ pub enum TrivialReason<'a> {
 }
 
 fn duplicate_cxx_name(cx: &mut Errors, sp: impl ToTokens, ident: &QualifiedIdent) {
-    let msg = format!("the C++ name `{}` is defined multiple times", ident);
+    let msg = format!(
+        "the C++ name `{}` is defined multiple times",
+        ident.to_fully_qualified()
+    );
     cx.error(sp, msg);
 }
 

--- a/tests/ui/by_value_not_supported.stderr
+++ b/tests/ui/by_value_not_supported.stderr
@@ -16,7 +16,7 @@ error: using C++ string by value is not supported
 6 |         s: CxxString,
   |         ^^^^^^^^^^^^
 
-error: needs a cxx::ExternType impl in order to be used as a field of `S`
+error: needs a cxx::ExternType impl in order to be used as a field of `::S`
   --> $DIR/by_value_not_supported.rs:10:9
    |
 10 |         type C;


### PR DESCRIPTION
This is some work towards #353.

It's not complete. I think it does the hard bits:
* We associate namespaces with each C++ identifier
* We output C++ fully qualified names, possibly in the right places

But we do not currently have any way to _set_ different namespaces, and there are therefore no extra tests yet.

So it feels like it's about half the job (if we exclude the later need to resolve `use` statements).

I'm raising this PR now because it's already pretty complicated, and there are (at least) the following areas where I think rework may be required and I would like your comments.

* I assume and hope that storing `QualifiedIdent`s instead of `Ident`s all over the `Api` was what you had in mind. But per the 75f435e commit comment, it would be great to understand that I've qualified the names for _roughly_ the right set of things. (I do expect to find some anomalies when we come to add tests).
* I'm somewhat unhappy with the way the code in `parse.rs` recognizes primitives and built-ins, which should therefore not have the current namespace prepended. This is an interim step until we support `use`, but I'd be interested in your views about whether it's about right meanwhile (I do think the list of built-ins should probably be abstracted somewhere, at least.)
* I am unhappy about `Symbol` and its relationship to `QualifiedIdent`. I think it's OK to have a distinct type (`QualifiedIdent` = C++ name with namespace; `Symbol` = mangled version of same) but I feel as though I should now be able to rip out a ton of `Symbol` code and I can't.
* Possibly all the `QualifiedIdent` code should go into a `qualified_ident.rs` file.

As ever, feel free to tinker with these things directly or give me your wisdom so I can do follow-up work!