### PR TITLE
Check for disallowed include strings in Cargo-based workflow

### DIFF
--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -271,7 +271,10 @@ fn make_include_dir(prj: &Project) -> Result<PathBuf> {
 }
 
 fn generate_bridge(prj: &Project, build: &mut Build, rust_source_file: &Path) -> Result<()> {
-    let opt = Opt::default();
+    let opt = Opt {
+        allow_dot_includes: false,
+        ..Opt::default()
+    };
     let generated = gen::generate_from_path(rust_source_file, &opt);
     let ref rel_path = paths::local_relative_path(rust_source_file);
 

--- a/gen/cmd/src/main.rs
+++ b/gen/cmd/src/main.rs
@@ -66,6 +66,7 @@ fn try_main() -> Result<()> {
         cxx_impl_annotations: opt.cxx_impl_annotations,
         gen_header,
         gen_implementation,
+        ..Default::default()
     };
 
     let generated_code = if let Some(input) = opt.input {

--- a/gen/src/check.rs
+++ b/gen/src/check.rs
@@ -1,0 +1,27 @@
+use crate::gen::Opt;
+use crate::syntax::report::Errors;
+use crate::syntax::{error, Api};
+use quote::{quote, quote_spanned};
+use std::path::{Component, Path};
+
+pub(super) use crate::syntax::check::typecheck;
+
+pub(super) fn precheck(cx: &mut Errors, apis: &[Api], opt: &Opt) {
+    if !opt.allow_dot_includes {
+        check_dot_includes(cx, apis);
+    }
+}
+
+fn check_dot_includes(cx: &mut Errors, apis: &[Api]) {
+    for api in apis {
+        if let Api::Include(include) = api {
+            let first_component = Path::new(&include.path).components().next();
+            if let Some(Component::CurDir) | Some(Component::ParentDir) = first_component {
+                let begin = quote_spanned!(include.begin_span=> .);
+                let end = quote_spanned!(include.end_span=> .);
+                let span = quote!(#begin #end);
+                cx.error(span, error::DOT_INCLUDE.msg);
+            }
+        }
+    }
+}

--- a/syntax/error.rs
+++ b/syntax/error.rs
@@ -19,6 +19,7 @@ pub static ERRORS: &[Error] = &[
     CXX_STRING_BY_VALUE,
     CXX_TYPE_BY_VALUE,
     DISCRIMINANT_OVERFLOW,
+    DOT_INCLUDE,
     DOUBLE_UNDERSCORE,
     RUST_TYPE_BY_VALUE,
     USE_NOT_ALLOWED,
@@ -52,6 +53,12 @@ pub static DISCRIMINANT_OVERFLOW: Error = Error {
     msg: "discriminant overflow on value after ",
     label: Some("discriminant overflow"),
     note: Some("note: explicitly set `= 0` if that is desired outcome"),
+};
+
+pub static DOT_INCLUDE: Error = Error {
+    msg: "#include relative to `.` or `..` is not supported in Cargo builds",
+    label: Some("#include relative to `.` or `..` is not supported in Cargo builds"),
+    note: Some("note: use a path starting with the crate name"),
 };
 
 pub static DOUBLE_UNDERSCORE: Error = Error {


### PR DESCRIPTION
```console
error[cxxbridge]: #include relative to `.` or `..` is not supported in Cargo builds
   ┌─ src/main.rs:10:18
   │
10 │         include!("../header.h");
   │                  ^^^^^^^^^^^^^ #include relative to `.` or `..` is not supported in Cargo builds
   │
   = note: use a path starting with the crate name
```

Closes #368.