### PR TITLE
Include typename in diagnostic on unsupported type

### DIFF
--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -67,7 +67,7 @@ fn check_type_ident(cx: &mut Check, ident: &Ident) {
         && !cx.types.cxx.contains(ident)
         && !cx.types.rust.contains(ident)
     {
-        cx.error(ident, "unsupported type");
+        cx.error(ident, &format!("unsupported type: {}", ident));
     }
 }
 

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -67,7 +67,8 @@ fn check_type_ident(cx: &mut Check, ident: &Ident) {
         && !cx.types.cxx.contains(ident)
         && !cx.types.rust.contains(ident)
     {
-        cx.error(ident, &format!("unsupported type: {}", ident));
+        let msg = format!("unsupported type: {}", ident);
+        cx.error(ident, &msg);
     }
 }
 

--- a/syntax/error.rs
+++ b/syntax/error.rs
@@ -21,6 +21,7 @@ pub static ERRORS: &[Error] = &[
     DISCRIMINANT_OVERFLOW,
     DOUBLE_UNDERSCORE,
     RUST_TYPE_BY_VALUE,
+    UNSUPPORTED_TYPE,
     USE_NOT_ALLOWED,
 ];
 
@@ -64,6 +65,12 @@ pub static RUST_TYPE_BY_VALUE: Error = Error {
     msg: "opaque Rust type by value is not supported",
     label: None,
     note: Some("hint: wrap it in a Box<>"),
+};
+
+pub static UNSUPPORTED_TYPE: Error = Error {
+    msg: "unsupported type: ",
+    label: Some("unsupported type"),
+    note: None,
 };
 
 pub static USE_NOT_ALLOWED: Error = Error {


### PR DESCRIPTION
First commit is extracted from #370.

<pre>
<b>error[cxxbridge]: unsupported type: OsString</b>
   ┌─ src/main.rs:15:21
   │
15 │         fn huh(wtf: <b>OsString</b>);
   │                     <b>^^^^^^^^ unsupported type</b>
</pre>