### PR TITLE
Guarantee trivial copy constructor and destructor for Str and Slice

### DIFF
--- a/include/cxx.h
+++ b/include/cxx.h
@@ -56,8 +56,6 @@ private:
 class Str final {
 public:
   Str() noexcept;
-  Str(const Str &) noexcept;
-
   Str(const std::string &);
   Str(const char *);
   Str(const char *, size_t);
@@ -71,6 +69,10 @@ public:
   const char *data() const noexcept;
   size_t size() const noexcept;
   size_t length() const noexcept;
+
+  // Important in order for System V ABI to pass in registers.
+  Str(const Str &) noexcept = default;
+  ~Str() noexcept = default;
 
   // Repr is PRIVATE; must not be used other than by our generated code.
   //
@@ -93,7 +95,6 @@ template <typename T>
 class Slice final {
 public:
   Slice() noexcept;
-  Slice(const Slice<T> &) noexcept;
   Slice(const T *, size_t count) noexcept;
 
   Slice &operator=(Slice<T>) noexcept;
@@ -101,6 +102,10 @@ public:
   const T *data() const noexcept;
   size_t size() const noexcept;
   size_t length() const noexcept;
+
+  // Important in order for System V ABI to pass in registers.
+  Slice(const Slice<T> &) noexcept = default;
+  ~Slice() noexcept = default;
 
   // Repr is PRIVATE; must not be used other than by our generated code.
   //
@@ -316,9 +321,6 @@ constexpr unsafe_bitcopy_t unsafe_bitcopy{};
 #define CXXBRIDGE05_RUST_SLICE
 template <typename T>
 Slice<T>::Slice() noexcept : repr(Repr{reinterpret_cast<const T *>(this), 0}) {}
-
-template <typename T>
-Slice<T>::Slice(const Slice<T> &) noexcept = default;
 
 template <typename T>
 Slice<T>::Slice(const T *s, size_t count) noexcept : repr(Repr{s, count}) {}

--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -117,8 +117,6 @@ std::ostream &operator<<(std::ostream &os, const String &s) {
 
 Str::Str() noexcept : repr(Repr{reinterpret_cast<const char *>(1), 0}) {}
 
-Str::Str(const Str &) noexcept = default;
-
 static void initStr(Str::Repr repr) {
   if (!cxxbridge05$str$valid(repr.ptr, repr.len)) {
     panic<std::invalid_argument>("data for rust::Str is not utf-8");


### PR DESCRIPTION
This enables the System V ABI to pass them in registers. See page 20 of https://software.intel.com/sites/default/files/article/402129/mpx-linux64-abi.pdf.

> If a C++ object has either a non-trivial copy constructor or a non-trivial destructor<sup>11</sup>, it is passed by invisible reference (the object is replaced in the parameter list by a pointer that has class POINTER)<sup>12</sup>.
>
> An object with either a non-trivial copy constructor or a non-trivial destructor cannot be passed by value because such objects must have well defined addresses. Similar issues apply when returning an object from a function.

Repro:

```cpp
const char *ptr(rust::Str str) { return str.repr.ptr; }
size_t len(rust::Str str) { return str.repr.len; }
```

Before:

```asm
ptr(rust::Str):
        mov     rax, qword ptr [rdi]
        ret
len(rust::Str):
        mov     rax, qword ptr [rdi + 8]
        ret
```

After:

```asm
ptr(rust::Str):
        mov     rax, rdi
        ret
len(rust::Str):
        mov     rax, rsi
        ret
```

This change is also observable by `std::is_trivially_copy_constructible<rust::Str>()` (https://en.cppreference.com/w/cpp/types/is_copy_constructible) which lets us hit better fastpaths in libraries downstream.