### PR TITLE
Decouple Error from Str::Repr

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -322,25 +322,31 @@ fn write_include_cxxbridge(out: &mut OutFile, apis: &[Api]) {
         writeln!(out, "}};");
     }
 
+    out.begin_block("namespace");
+
+    if needs_trycatch || needs_rust_error {
+        out.begin_block("namespace repr");
+        writeln!(out, "struct PtrLen final {{");
+        writeln!(out, "  const char *ptr;");
+        writeln!(out, "  size_t len;");
+        writeln!(out, "}};");
+        out.end_block("namespace repr");
+    }
+
     if needs_rust_error {
-        out.begin_block("namespace");
         writeln!(out, "template <>");
         writeln!(out, "class impl<Error> final {{");
         writeln!(out, "public:");
-        writeln!(out, "  struct Repr final {{");
-        writeln!(out, "    const char *msg;");
-        writeln!(out, "    size_t len;");
-        writeln!(out, "  }};");
-        writeln!(out, "  static Error error(Repr repr) noexcept {{");
+        writeln!(out, "  static Error error(repr::PtrLen repr) noexcept {{");
         writeln!(out, "    Error error;");
-        writeln!(out, "    error.msg = repr.msg;");
+        writeln!(out, "    error.msg = repr.ptr;");
         writeln!(out, "    error.len = repr.len;");
         writeln!(out, "    return error;");
         writeln!(out, "  }}");
         writeln!(out, "}};");
-        out.end_block("namespace");
     }
 
+    out.end_block("namespace");
     out.end_block("namespace cxxbridge05");
 
     if needs_trycatch {
@@ -526,7 +532,7 @@ fn write_cxx_function_shim(out: &mut OutFile, efn: &ExternFn, impl_annotations: 
         write!(out, "{} ", annotation);
     }
     if efn.throws {
-        write!(out, "::rust::Str::Repr ");
+        write!(out, "::rust::repr::PtrLen ");
     } else {
         write_extern_return_type_space(out, &efn.ret);
     }
@@ -598,7 +604,7 @@ fn write_cxx_function_shim(out: &mut OutFile, efn: &ExternFn, impl_annotations: 
     writeln!(out, ";");
     write!(out, "  ");
     if efn.throws {
-        writeln!(out, "::rust::Str::Repr throw$;");
+        writeln!(out, "::rust::repr::PtrLen throw$;");
         writeln!(out, "  ::rust::behavior::trycatch(");
         writeln!(out, "      [&] {{");
         write!(out, "        ");
@@ -711,7 +717,7 @@ fn write_rust_function_decl_impl(
     indirect_call: bool,
 ) {
     if sig.throws {
-        write!(out, "::rust::impl<::rust::Error>::Repr ");
+        write!(out, "::rust::repr::PtrLen ");
     } else {
         write_extern_return_type_space(out, &sig.ret);
     }
@@ -849,7 +855,7 @@ fn write_rust_function_shim_impl(
         }
     }
     if sig.throws {
-        write!(out, "::rust::impl<::rust::Error>::Repr error$ = ");
+        write!(out, "::rust::repr::PtrLen error$ = ");
     }
     write!(out, "{}(", invoke);
     if sig.receiver.is_some() {
@@ -896,7 +902,7 @@ fn write_rust_function_shim_impl(
     }
     writeln!(out, ";");
     if sig.throws {
-        writeln!(out, "  if (error$.msg) {{");
+        writeln!(out, "  if (error$.ptr) {{");
         writeln!(out, "    throw ::rust::impl<::rust::Error>::error(error$);");
         writeln!(out, "  }}");
     }

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -251,12 +251,14 @@ class Error final : public std::exception {
 public:
   Error(const Error &);
   Error(Error &&) noexcept;
-  Error(Str::Repr) noexcept;
   ~Error() noexcept;
   const char *what() const noexcept override;
 
 private:
-  Str::Repr msg;
+  Error() noexcept = default;
+  friend class impl;
+  const char *msg;
+  size_t len;
 };
 #endif // CXXBRIDGE05_RUST_ERROR
 

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -19,6 +19,11 @@ inline namespace cxxbridge05 {
 
 struct unsafe_bitcopy_t;
 
+namespace {
+template <typename T>
+class impl;
+}
+
 #ifndef CXXBRIDGE05_RUST_STRING
 #define CXXBRIDGE05_RUST_STRING
 class String final {
@@ -256,7 +261,7 @@ public:
 
 private:
   Error() noexcept = default;
-  friend class impl;
+  friend impl<Error>;
   const char *msg;
   size_t len;
 };

--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -172,22 +172,21 @@ const char *cxxbridge05$error(const char *ptr, size_t len) {
 }
 } // extern "C"
 
-Error::Error(Str::Repr msg) noexcept : msg(msg) {}
-
 Error::Error(const Error &other) {
-  this->msg.ptr = cxxbridge05$error(other.msg.ptr, other.msg.len);
-  this->msg.len = other.msg.len;
+  this->msg = cxxbridge05$error(other.msg, other.len);
+  this->len = other.len;
 }
 
 Error::Error(Error &&other) noexcept {
   this->msg = other.msg;
-  other.msg.ptr = nullptr;
-  other.msg.len = 0;
+  this->len = other.len;
+  other.msg = nullptr;
+  other.len = 0;
 }
 
-Error::~Error() noexcept { delete[] this->msg.ptr; }
+Error::~Error() noexcept { delete[] this->msg; }
 
-const char *Error::what() const noexcept { return this->msg.ptr; }
+const char *Error::what() const noexcept { return this->msg; }
 
 } // namespace cxxbridge05
 } // namespace rust


### PR DESCRIPTION
It was misleading to use `Str` (which ordinarily represents borrowed strings) also for owned error messages.