### PR TITLE
Fill in Error base class constructor calls

### DIFF
--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -173,9 +173,11 @@ const char *cxxbridge05$error(const char *ptr, size_t len) {
 } // extern "C"
 
 Error::Error(const Error &other)
-    : msg(cxxbridge05$error(other.msg, other.len)), len(other.len) {}
+    : std::exception(other), msg(cxxbridge05$error(other.msg, other.len)),
+      len(other.len) {}
 
-Error::Error(Error &&other) noexcept : msg(other.msg), len(other.len) {
+Error::Error(Error &&other) noexcept
+    : std::exception(std::move(other)), msg(other.msg), len(other.len) {
   other.msg = nullptr;
   other.len = 0;
 }


### PR DESCRIPTION
Otherwise these would be default-constructing the base class. Unclear if this makes a difference for any real std::exception implementation but might as well.