### PR TITLE
Fix fn arg representation to eliminate warning on rust 1.46+

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -594,7 +594,7 @@ fn expand_rust_function_shim_impl(
                 quote!(#receiver_type::#ident)
             }
         },
-        None => quote!(__extern),
+        None => quote!(::std::mem::transmute::<*const (), #sig>(__extern)),
     };
     call.extend(quote! { (#(#vars),*) });
 
@@ -662,7 +662,7 @@ fn expand_rust_function_shim_impl(
     };
 
     let pointer = match invoke {
-        None => Some(quote!(__extern: #sig)),
+        None => Some(quote!(__extern: *const ())),
         Some(_) => None,
     };
 

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -169,10 +169,7 @@ pub mod ffi {
         fn c_take_ref_rust_vec_string(v: &Vec<String>);
         fn c_take_ref_rust_vec_index(v: &Vec<u8>);
         fn c_take_ref_rust_vec_copy(v: &Vec<u8>);
-        /*
-        // https://github.com/dtolnay/cxx/issues/232
         fn c_take_callback(callback: fn(String) -> usize);
-        */
         fn c_take_enum(e: Enum);
         fn c_take_ns_enum(e: AEnum);
         fn c_take_nested_ns_enum(e: ABEnum);

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -385,12 +385,9 @@ void c_take_ref_rust_vec_copy(const rust::Vec<uint8_t> &v) {
   }
 }
 
-/*
-// https://github.com/dtolnay/cxx/issues/232
 void c_take_callback(rust::Fn<size_t(rust::String)> callback) {
   callback("2020");
 }
-*/
 
 void c_take_enum(Enum e) {
   if (e == Enum::AVal) {

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -134,10 +134,7 @@ void c_take_ref_rust_vec(const rust::Vec<uint8_t> &v);
 void c_take_ref_rust_vec_string(const rust::Vec<rust::String> &v);
 void c_take_ref_rust_vec_index(const rust::Vec<uint8_t> &v);
 void c_take_ref_rust_vec_copy(const rust::Vec<uint8_t> &v);
-/*
-// https://github.com/dtolnay/cxx/issues/232
 void c_take_callback(rust::Fn<size_t(rust::String)> callback);
-*/
 void c_take_enum(Enum e);
 void c_take_ns_enum(::A::AEnum e);
 void c_take_nested_ns_enum(::A::B::ABEnum e);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -149,8 +149,6 @@ fn test_c_take() {
     check!(ffi::c_take_nested_ns_enum(ffi::ABEnum::ABAVal));
 }
 
-/*
-// https://github.com/dtolnay/cxx/issues/232
 #[test]
 fn test_c_callback() {
     fn callback(s: String) -> usize {
@@ -162,7 +160,6 @@ fn test_c_callback() {
 
     check!(ffi::c_take_callback(callback));
 }
-*/
 
 #[test]
 fn test_c_call_r() {


### PR DESCRIPTION
Fixes #232.