### PR TITLE
Expose way to bypass trivial destr/move on extern types passed by value

### DIFF
--- a/gen/src/builtin.rs
+++ b/gen/src/builtin.rs
@@ -23,6 +23,7 @@ pub struct Builtins<'a> {
     pub rust_slice_new: bool,
     pub rust_slice_repr: bool,
     pub exception: bool,
+    pub relocatable: bool,
     pub content: Content<'a>,
 }
 
@@ -73,6 +74,10 @@ pub(super) fn write(out: &mut OutFile) {
         include.basetsd = true;
     }
 
+    if builtin.relocatable {
+        include.type_traits = true;
+    }
+
     out.begin_block(Block::Namespace("rust"));
     out.begin_block(Block::InlineNamespace("cxxbridge05"));
     writeln!(out, "// #include \"rust/cxx.h\"");
@@ -100,6 +105,7 @@ pub(super) fn write(out: &mut OutFile) {
     ifndef::write(out, builtin.rust_fn, "CXXBRIDGE05_RUST_FN");
     ifndef::write(out, builtin.rust_error, "CXXBRIDGE05_RUST_ERROR");
     ifndef::write(out, builtin.rust_isize, "CXXBRIDGE05_RUST_ISIZE");
+    ifndef::write(out, builtin.relocatable, "CXXBRIDGE05_RELOCATABLE");
 
     if builtin.manually_drop {
         out.next_section();


### PR DESCRIPTION
```cpp
// IsRelocatable<T> is used in assertions that a C++ type passed by value
// between Rust and C++ is soundly relocatable by Rust.
//
// There may be legitimate reasons to opt out of the check for support of types
// that the programmer knows are soundly Rust-movable despite not being
// recognized as such by the C++ type system due to a move constructor or
// destructor. To opt out of the relocatability check, do either of the
// following things in any header used by `include!` in the bridge.
//
//      --- if you define the type:
//      struct MyType {
//        ...
//    +   using IsRelocatable = std::true_type;
//      };
//
//      --- otherwise:
//    + template <>
//    + struct rust::IsRelocatable<MyType> : std::true_type {};
template <typename T>
struct IsRelocatable;
```

Closes #359.