### PR TITLE
Introduce UnorderedSet newtype

### DIFF
--- a/syntax/types.rs
+++ b/syntax/types.rs
@@ -1,14 +1,14 @@
 use crate::syntax::atom::Atom::{self, *};
 use crate::syntax::improper::ImproperCtype;
 use crate::syntax::report::Errors;
-use crate::syntax::set::OrderedSet as Set;
+use crate::syntax::set::{OrderedSet as Set, UnorderedSet};
 use crate::syntax::{
     toposort, Api, Derive, Enum, ExternFn, ExternType, Impl, Pair, ResolvableName, Struct, Type,
     TypeAlias,
 };
 use proc_macro2::Ident;
 use quote::ToTokens;
-use std::collections::{BTreeMap as Map, HashSet as UnorderedSet};
+use std::collections::BTreeMap as Map;
 
 pub struct Types<'a> {
     pub all: Set<&'a Type>,


### PR DESCRIPTION
Having a newtype here avoids introducing accidental iteration over sets what are not meant to be iterated over. See https://github.com/dtolnay/cxx/pull/368#discussion_r511539163.