### PR TITLE
Implement CFG.exported_header_dirs

### DIFF
--- a/gen/build/src/error.rs
+++ b/gen/build/src/error.rs
@@ -2,6 +2,7 @@ use crate::gen::fs;
 use std::error::Error as StdError;
 use std::ffi::OsString;
 use std::fmt::{self, Display};
+use std::path::Path;
 
 pub(super) type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -9,6 +10,7 @@ pub(super) type Result<T, E = Error> = std::result::Result<T, E>;
 pub(super) enum Error {
     NoEnv(OsString),
     Fs(fs::Error),
+    ExportedDirNotAbsolute(&'static Path),
 }
 
 impl Display for Error {
@@ -18,6 +20,11 @@ impl Display for Error {
                 write!(f, "missing {} environment variable", var.to_string_lossy())
             }
             Error::Fs(err) => err.fmt(f),
+            Error::ExportedDirNotAbsolute(path) => write!(
+                f,
+                "element of CFG.exported_header_dirs must be absolute path, but was: {:?}",
+                path,
+            ),
         }
     }
 }

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -193,6 +193,9 @@ fn build(rust_source_files: &mut dyn Iterator<Item = impl AsRef<Path>>) -> Resul
     this_crate.exported_header_dirs.push(include_dir);
     this_crate.exported_header_dirs.extend(crate_dir);
     for exported_dir in &CFG.exported_header_dirs {
+        if !exported_dir.is_absolute() {
+            return Err(Error::ExportedDirNotAbsolute(exported_dir));
+        }
         this_crate
             .exported_header_dirs
             .push(PathBuf::from(exported_dir));

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -192,6 +192,11 @@ fn build(rust_source_files: &mut dyn Iterator<Item = impl AsRef<Path>>) -> Resul
     // source file.
     this_crate.exported_header_dirs.push(include_dir);
     this_crate.exported_header_dirs.extend(crate_dir);
+    for exported_dir in &CFG.exported_header_dirs {
+        this_crate
+            .exported_header_dirs
+            .push(PathBuf::from(exported_dir));
+    }
     this_crate.print_to_cargo();
 
     let mut build = Build::new();


### PR DESCRIPTION
Part of #417.

The field is still #\[doc(hidden)\] for now but documentation will follow after implementing the other two new fields of CFG in #417.