### PR TITLE
Support rust_name/cxx_name on enum variants

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -247,7 +247,7 @@ fn write_enum<'a>(out: &mut OutFile<'a>, enm: &'a Enum) {
     write_atom(out, enm.repr);
     writeln!(out, " {{");
     for variant in &enm.variants {
-        writeln!(out, "  {} = {},", variant.ident, variant.discriminant);
+        writeln!(out, "  {} = {},", variant.ident.cxx, variant.discriminant);
     }
     writeln!(out, "}};");
     writeln!(out, "#endif // {}", guard);
@@ -264,7 +264,7 @@ fn check_enum<'a>(out: &mut OutFile<'a>, enm: &'a Enum) {
         writeln!(
             out,
             ">({}::{}) == {}, \"disagrees with the value in #[cxx::bridge]\");",
-            enm.name.cxx, variant.ident, variant.discriminant,
+            enm.name.cxx, variant.ident.cxx, variant.discriminant,
         );
     }
 }

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -155,7 +155,7 @@ fn expand_enum(enm: &Enum) -> TokenStream {
     let repr = enm.repr;
     let type_id = type_id(&enm.name);
     let variants = enm.variants.iter().map(|variant| {
-        let variant_ident = &variant.ident;
+        let variant_ident = &variant.ident.rust;
         let discriminant = &variant.discriminant;
         Some(quote! {
             pub const #variant_ident: Self = #ident { repr: #discriminant };

--- a/syntax/ident.rs
+++ b/syntax/ident.rs
@@ -32,7 +32,7 @@ pub(crate) fn check_all(cx: &mut Check, apis: &[Api]) {
             Api::Enum(enm) => {
                 check_ident(cx, &enm.name);
                 for variant in &enm.variants {
-                    check(cx, &variant.ident);
+                    check(cx, &variant.ident.cxx);
                 }
             }
             Api::CxxType(ety) | Api::RustType(ety) => {

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -142,7 +142,7 @@ pub struct Receiver {
 }
 
 pub struct Variant {
-    pub ident: Ident,
+    pub ident: Pair,
     pub discriminant: Discriminant,
     pub expr: Option<Expr>,
 }


### PR DESCRIPTION
/!\ Tests are missing, and I need some help to write them, I don't understand how they are structured

This is my first real contribution to cxx, I am not yet familiar with the structure of the repository, nor how contribution should be done. Any remarks are welcome.

---

Solve #379

This will allow to rename both the enum and the variants

``` rust
enum REnumRenamed {
        #[cxx_name = "RVARIANT"]
        RVariant,
            // Note: not renamed
            RVariant2,
}
```