### PR TITLE
Add ui test of returning a non-displayable error

### DIFF
--- a/tests/ui/result_no_display.rs
+++ b/tests/ui/result_no_display.rs
@@ -1,0 +1,14 @@
+#[cxx::bridge]
+mod ffi {
+    extern "Rust" {
+        fn f() -> Result<()>;
+    }
+}
+
+pub struct NonError;
+
+fn f() -> Result<(), NonError> {
+    Ok(())
+}
+
+fn main() {}

--- a/tests/ui/result_no_display.stderr
+++ b/tests/ui/result_no_display.stderr
@@ -1,0 +1,14 @@
+error[E0277]: `NonError` doesn't implement `std::fmt::Display`
+  --> $DIR/result_no_display.rs:1:1
+   |
+1  | #[cxx::bridge]
+   | ^^^^^^^^^^^^^^ `NonError` cannot be formatted with the default formatter
+   |
+  ::: $WORKSPACE/src/result.rs
+   |
+   |     E: Display,
+   |        ------- required by this bound in `cxx::private::r#try`
+   |
+   = help: the trait `std::fmt::Display` is not implemented for `NonError`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
The placement of this error is not good. In an extern "Rust" block with a large number of signatures it's hard to tell which one is returning the problematic error type. Will follow up to fix this after a refactor.