### PR TITLE
Enforce accurate unsafety declaration on extern Rust sigs

### DIFF
--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -1,5 +1,6 @@
 #![allow(
     clippy::boxed_local,
+    clippy::just_underscores_and_digits,
     clippy::ptr_arg,
     clippy::trivially_copy_pass_by_ref
 )]

--- a/tests/ui/missing_unsafe.rs
+++ b/tests/ui/missing_unsafe.rs
@@ -1,0 +1,10 @@
+#[cxx::bridge]
+mod ffi {
+    extern "Rust" {
+        fn f(x: i32);
+    }
+}
+
+unsafe fn f(_x: i32) {}
+
+fn main() {}

--- a/tests/ui/missing_unsafe.stderr
+++ b/tests/ui/missing_unsafe.stderr
@@ -1,0 +1,7 @@
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+ --> $DIR/missing_unsafe.rs:4:12
+  |
+4 |         fn f(x: i32);
+  |            ^ call to unsafe function
+  |
+  = note: consult the function's documentation for information on how to avoid undefined behavior

--- a/tests/ui/result_no_display.stderr
+++ b/tests/ui/result_no_display.stderr
@@ -1,14 +1,8 @@
 error[E0277]: `NonError` doesn't implement `std::fmt::Display`
-  --> $DIR/result_no_display.rs:1:1
-   |
-1  | #[cxx::bridge]
-   | ^^^^^^^^^^^^^^ `NonError` cannot be formatted with the default formatter
-   |
-  ::: $WORKSPACE/src/result.rs
-   |
-   |     E: Display,
-   |        ------- required by this bound in `cxx::private::r#try`
-   |
-   = help: the trait `std::fmt::Display` is not implemented for `NonError`
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+ --> $DIR/result_no_display.rs:1:1
+  |
+1 | #[cxx::bridge]
+  | ^^^^^^^^^^^^^^ `NonError` cannot be formatted with the default formatter
+  |
+  = help: the trait `std::fmt::Display` is not implemented for `NonError`
+  = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead

--- a/tests/ui/unsupported_elided.rs
+++ b/tests/ui/unsupported_elided.rs
@@ -1,0 +1,20 @@
+use std::marker::PhantomData;
+
+#[cxx::bridge]
+mod ffi {
+    extern "Rust" {
+        type T;
+
+        fn f(t: &T) -> &str;
+    }
+}
+
+pub struct T<'a> {
+    _lifetime: PhantomData<&'a ()>,
+}
+
+fn f<'a>(_t: &T<'a>) -> &'a str {
+    ""
+}
+
+fn main() {}

--- a/tests/ui/unsupported_elided.stderr
+++ b/tests/ui/unsupported_elided.stderr
@@ -1,0 +1,11 @@
+error[E0106]: missing lifetime specifier
+ --> $DIR/unsupported_elided.rs:8:24
+  |
+8 |         fn f(t: &T) -> &str;
+  |                 --     ^ expected named lifetime parameter
+  |
+  = help: this function's return type contains a borrowed value, but the signature does not say which one of `t`'s 2 lifetimes it is borrowed from
+help: consider introducing a named lifetime parameter
+  |
+8 |         fn f<'a>(t: &'a T) -> &'a str;
+  |             ^^^^    ^^^^^     ^^^


### PR DESCRIPTION
Previously we were accepting extern Rust declarations like the following, which is problematic because it makes it hard for a caller in C++ to see clearly when they hold responsibility for additional invariants.

```rust
    extern "Rust" {
        fn f();
    }
...

unsafe fn f() {...}
```