### PR TITLE
Fix placement of commas in C++ member functions that call Rust methods

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -698,11 +698,13 @@ fn write_rust_function_shim_impl(
         write!(out, "::rust::repr::PtrLen error$ = ");
     }
     write!(out, "{}(", invoke);
+    let mut needs_comma = false;
     if sig.receiver.is_some() {
         write!(out, "*this");
+        needs_comma = true;
     }
-    for (i, arg) in sig.args.iter().enumerate() {
-        if i > 0 || sig.receiver.is_some() {
+    for arg in &sig.args {
+        if needs_comma {
             write!(out, ", ");
         }
         match &arg.ty {
@@ -725,15 +727,17 @@ fn write_rust_function_shim_impl(
             ty if ty != RustString && out.types.needs_indirect_abi(ty) => write!(out, "$.value"),
             _ => {}
         }
+        needs_comma = true;
     }
     if indirect_return {
-        if !sig.args.is_empty() {
+        if needs_comma {
             write!(out, ", ");
         }
         write!(out, "&return$.value");
+        needs_comma = true;
     }
     if indirect_call {
-        if !sig.args.is_empty() || indirect_return {
+        if needs_comma {
             write!(out, ", ");
         }
         write!(out, "extern$");

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -274,7 +274,7 @@ pub mod ffi {
         fn r_return_r2(n: usize) -> Box<R2>;
         fn get(self: &R2) -> usize;
         fn set(self: &mut R2, n: usize) -> usize;
-        fn r_method_on_shared(self: &Shared) -> usize;
+        fn r_method_on_shared(self: &Shared) -> String;
 
         #[cxx_name = "rAliasedFunction"]
         fn r_aliased_function(x: i32) -> String;
@@ -318,8 +318,8 @@ impl R2 {
 }
 
 impl ffi::Shared {
-    fn r_method_on_shared(&self) -> usize {
-        2020
+    fn r_method_on_shared(&self) -> String {
+        "2020".to_owned()
     }
 }
 

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -626,7 +626,7 @@ extern "C" const char *cxx_run_test() noexcept {
   ASSERT(r2->get() == 2021);
   ASSERT(r2->set(2020) == 2020);
   ASSERT(r2->get() == 2020);
-  ASSERT(Shared{0}.r_method_on_shared() == 2020);
+  ASSERT(std::string(Shared{0}.r_method_on_shared()) == "2020");
 
   ASSERT(std::string(rAliasedFunction(2020)) == "2020");
 


### PR DESCRIPTION
Fixes #442.