### PR TITLE
Parse namespace attribute on foreign mods

### DIFF
--- a/syntax/file.rs
+++ b/syntax/file.rs
@@ -94,7 +94,7 @@ impl Parse for Item {
             RustItem::Struct(item) => Ok(Item::Struct(ItemStruct { attrs, ..item })),
             RustItem::Enum(item) => Ok(Item::Enum(ItemEnum { attrs, ..item })),
             RustItem::ForeignMod(item) => Ok(Item::ForeignMod(ItemForeignMod {
-                attrs: item.attrs,
+                attrs,
                 unsafety,
                 abi: item.abi,
                 brace_token: item.brace_token,

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -214,16 +214,26 @@ fn parse_foreign_mod(
 
     let trusted = trusted || foreign_mod.unsafety.is_some();
 
+    let mut namespace = namespace.clone();
+    attrs::parse(
+        cx,
+        &foreign_mod.attrs,
+        attrs::Parser {
+            namespace: Some(&mut namespace),
+            ..Default::default()
+        },
+    );
+
     let mut items = Vec::new();
     for foreign in &foreign_mod.items {
         match foreign {
             ForeignItem::Type(foreign) => {
-                match parse_extern_type(cx, foreign, lang, trusted, namespace) {
+                match parse_extern_type(cx, foreign, lang, trusted, &namespace) {
                     Ok(ety) => items.push(ety),
                     Err(err) => cx.push(err),
                 }
             }
-            ForeignItem::Fn(foreign) => match parse_extern_fn(cx, foreign, lang, namespace) {
+            ForeignItem::Fn(foreign) => match parse_extern_fn(cx, foreign, lang, &namespace) {
                 Ok(efn) => items.push(efn),
                 Err(err) => cx.push(err),
             },
@@ -234,7 +244,7 @@ fn parse_foreign_mod(
                 }
             }
             ForeignItem::Verbatim(tokens) => {
-                match parse_extern_verbatim(cx, tokens, lang, namespace) {
+                match parse_extern_verbatim(cx, tokens, lang, &namespace) {
                     Ok(api) => items.push(api),
                     Err(err) => cx.push(err),
                 }


### PR DESCRIPTION
This is called out in #370 as not implemented yet.

> It should achieve points 1-3 on the plan in #353, and most of #​4 (it doesn't currently look for namespace attributes on `extern` blocks but the rest is done).

This PR implements `#[namespace = "..."]` attributes on extern blocks, such that an item will inherit the namespace specified on its surrounding extern block if any, otherwise the namespace specified with the top level cxx::bridge attribute.

```rust
#[cxx::bridge(namespace = "third_priority")]
mod ffi {
    #[namespace = "second_priority"]
    extern "Rust" {
        fn f();

        #[namespace = "first_priority"]
        fn g();
    }

    extern "Rust" {
        fn h();
    }
}
```

The above would result in functions `::second_priority::f`, `::first_priority::g`, `::third_priority::h`.