### PR TITLE
Provide rust::Fn call operator in generated header

### DIFF
--- a/gen/src/builtin.rs
+++ b/gen/src/builtin.rs
@@ -72,6 +72,10 @@ pub(super) fn write(out: &mut OutFile) {
         builtin.unsafe_bitcopy = true;
     }
 
+    if builtin.rust_fn {
+        include.utility = true;
+    }
+
     if builtin.rust_error {
         include.exception = true;
         builtin.friend_impl = true;

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -215,7 +215,6 @@ private:
 #endif // CXXBRIDGE05_RUST_VEC
 
 #ifndef CXXBRIDGE05_RUST_FN
-#define CXXBRIDGE05_RUST_FN
 template <typename Signature, bool Throws = false>
 class Fn;
 
@@ -316,6 +315,8 @@ template <typename Exception>
 void panic [[noreturn]] (const char *msg);
 #endif // CXXBRIDGE05_PANIC
 
+#ifndef CXXBRIDGE05_RUST_FN
+#define CXXBRIDGE05_RUST_FN
 template <typename Ret, typename... Args, bool Throws>
 Ret Fn<Ret(Args...), Throws>::operator()(Args... args) const noexcept(!Throws) {
   return (*this->trampoline)(std::move(args)..., this->fn);
@@ -325,6 +326,7 @@ template <typename Ret, typename... Args, bool Throws>
 Fn<Ret(Args...), Throws> Fn<Ret(Args...), Throws>::operator*() const noexcept {
   return *this;
 }
+#endif // CXXBRIDGE05_RUST_FN
 
 #ifndef CXXBRIDGE05_RUST_BITCOPY
 #define CXXBRIDGE05_RUST_BITCOPY


### PR DESCRIPTION
Even though the generated code does not use them, this avoids a situation where the user's code includes a generated header (but not rust/cxx.h) and thus gets the class definition of rust::Fn, but with the function call operator templates undefined. Previously they'd have gotten missing template errors until they also included rust/cxx.h.