### PR TITLE
Add rust::Vec push_back and emplace_back

### DIFF
--- a/gen/src/builtin.rs
+++ b/gen/src/builtin.rs
@@ -69,6 +69,7 @@ pub(super) fn write(out: &mut OutFile) {
         include.array = true;
         include.new = true;
         include.type_traits = true;
+        include.utility = true;
         builtin.panic = true;
         builtin.unsafe_bitcopy = true;
     }

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1078,6 +1078,16 @@ fn write_rust_vec_extern(out: &mut OutFile, element: &ResolvableName) {
     );
     writeln!(
         out,
+        "void cxxbridge05$rust_vec${}$reserve_total(::rust::Vec<{}> *ptr, size_t cap) noexcept;",
+        instance, inner,
+    );
+    writeln!(
+        out,
+        "void cxxbridge05$rust_vec${}$set_len(::rust::Vec<{}> *ptr, size_t len) noexcept;",
+        instance, inner,
+    );
+    writeln!(
+        out,
         "size_t cxxbridge05$rust_vec${}$stride() noexcept;",
         instance,
     );
@@ -1128,6 +1138,28 @@ fn write_rust_vec_impl(out: &mut OutFile, element: &ResolvableName) {
     writeln!(
         out,
         "  return cxxbridge05$rust_vec${}$data(this);",
+        instance,
+    );
+    writeln!(out, "}}");
+
+    writeln!(out, "template <>");
+    writeln!(
+        out,
+        "void Vec<{}>::reserve_total(size_t cap) noexcept {{",
+        inner,
+    );
+    writeln!(
+        out,
+        "  return cxxbridge05$rust_vec${}$reserve_total(this, cap);",
+        instance,
+    );
+    writeln!(out, "}}");
+
+    writeln!(out, "template <>");
+    writeln!(out, "void Vec<{}>::set_len(size_t len) noexcept {{", inner);
+    writeln!(
+        out,
+        "  return cxxbridge05$rust_vec${}$set_len(this, len);",
         instance,
     );
     writeln!(out, "}}");

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -727,6 +727,8 @@ fn expand_rust_vec(elem: &ResolvableName, types: &Types) -> TokenStream {
     let link_drop = format!("{}drop", link_prefix);
     let link_len = format!("{}len", link_prefix);
     let link_data = format!("{}data", link_prefix);
+    let link_reserve_total = format!("{}reserve_total", link_prefix);
+    let link_set_len = format!("{}set_len", link_prefix);
     let link_stride = format!("{}stride", link_prefix);
 
     let local_prefix = format_ident!("{}__vec_", elem.rust);
@@ -734,6 +736,8 @@ fn expand_rust_vec(elem: &ResolvableName, types: &Types) -> TokenStream {
     let local_drop = format_ident!("{}drop", local_prefix);
     let local_len = format_ident!("{}len", local_prefix);
     let local_data = format_ident!("{}data", local_prefix);
+    let local_reserve_total = format_ident!("{}reserve_total", local_prefix);
+    let local_set_len = format_ident!("{}set_len", local_prefix);
     let local_stride = format_ident!("{}stride", local_prefix);
 
     let span = elem.span();
@@ -757,6 +761,16 @@ fn expand_rust_vec(elem: &ResolvableName, types: &Types) -> TokenStream {
         #[export_name = #link_data]
         unsafe extern "C" fn #local_data(this: *const ::cxx::private::RustVec<#elem>) -> *const #elem {
             (*this).as_ptr()
+        }
+        #[doc(hidden)]
+        #[export_name = #link_reserve_total]
+        unsafe extern "C" fn #local_reserve_total(this: *mut ::cxx::private::RustVec<#elem>, cap: usize) {
+            (*this).reserve_total(cap);
+        }
+        #[doc(hidden)]
+        #[export_name = #link_set_len]
+        unsafe extern "C" fn #local_set_len(this: *mut ::cxx::private::RustVec<#elem>, len: usize) {
+            (*this).set_len(len);
         }
         #[doc(hidden)]
         #[export_name = #link_stride]

--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -267,6 +267,10 @@ void cxxbridge05$unique_ptr$std$string$drop(
       const rust::Vec<CXX_TYPE> *ptr) noexcept;                                \
   const CXX_TYPE *cxxbridge05$rust_vec$##RUST_TYPE##$data(                     \
       const rust::Vec<CXX_TYPE> *ptr) noexcept;                                \
+  void cxxbridge05$rust_vec$##RUST_TYPE##$reserve_total(                       \
+      rust::Vec<CXX_TYPE> *ptr, size_t cap) noexcept;                          \
+  void cxxbridge05$rust_vec$##RUST_TYPE##$set_len(rust::Vec<CXX_TYPE> *ptr,    \
+                                                  size_t len) noexcept;        \
   size_t cxxbridge05$rust_vec$##RUST_TYPE##$stride() noexcept;
 
 #define RUST_VEC_OPS(RUST_TYPE, CXX_TYPE)                                      \
@@ -285,6 +289,14 @@ void cxxbridge05$unique_ptr$std$string$drop(
   template <>                                                                  \
   const CXX_TYPE *Vec<CXX_TYPE>::data() const noexcept {                       \
     return cxxbridge05$rust_vec$##RUST_TYPE##$data(this);                      \
+  }                                                                            \
+  template <>                                                                  \
+  void Vec<CXX_TYPE>::reserve_total(size_t cap) noexcept {                     \
+    cxxbridge05$rust_vec$##RUST_TYPE##$reserve_total(this, cap);               \
+  }                                                                            \
+  template <>                                                                  \
+  void Vec<CXX_TYPE>::set_len(size_t len) noexcept {                           \
+    cxxbridge05$rust_vec$##RUST_TYPE##$set_len(this, len);                     \
   }                                                                            \
   template <>                                                                  \
   size_t Vec<CXX_TYPE>::stride() noexcept {                                    \

--- a/src/rust_vec.rs
+++ b/src/rust_vec.rs
@@ -44,6 +44,17 @@ impl<T> RustVec<T> {
     pub fn as_ptr(&self) -> *const T {
         self.repr.as_ptr()
     }
+
+    pub fn reserve_total(&mut self, cap: usize) {
+        let len = self.repr.len();
+        if cap > len {
+            self.repr.reserve(cap - len);
+        }
+    }
+
+    pub unsafe fn set_len(&mut self, len: usize) {
+        self.repr.set_len(len);
+    }
 }
 
 impl RustVec<RustString> {

--- a/src/symbols/rust_vec.rs
+++ b/src/symbols/rust_vec.rs
@@ -35,6 +35,18 @@ macro_rules! rust_vec_shims {
                 }
             }
             attr! {
+                #[export_name = concat!("cxxbridge05$rust_vec$", $segment, "$reserve_total")]
+                unsafe extern "C" fn __reserve_total(this: *mut RustVec<$ty>, cap: usize) {
+                    (*this).reserve_total(cap);
+                }
+            }
+            attr! {
+                #[export_name = concat!("cxxbridge05$rust_vec$", $segment, "$set_len")]
+                unsafe extern "C" fn __set_len(this: *mut RustVec<$ty>, len: usize) {
+                    (*this).repr.set_len(len);
+                }
+            }
+            attr! {
                 #[export_name = concat!("cxxbridge05$rust_vec$", $segment, "$stride")]
                 unsafe extern "C" fn __stride() -> usize {
                     mem::size_of::<$ty>()

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -168,6 +168,7 @@ pub mod ffi {
         fn c_take_rust_vec_string(v: Vec<String>);
         fn c_take_rust_vec_index(v: Vec<u8>);
         fn c_take_rust_vec_shared_index(v: Vec<Shared>);
+        fn c_take_rust_vec_shared_push(v: Vec<Shared>);
         fn c_take_rust_vec_shared_forward_iterator(v: Vec<Shared>);
         fn c_take_ref_rust_vec(v: &Vec<u8>);
         fn c_take_ref_rust_vec_string(v: &Vec<String>);

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -356,6 +356,14 @@ void c_take_rust_vec_shared_index(rust::Vec<Shared> v) {
   }
 }
 
+void c_take_rust_vec_shared_push(rust::Vec<Shared> v) {
+  v.push_back(Shared{3});
+  v.emplace_back(Shared{2});
+  if (v[v.size() - 2].z == 3 && v.back().z == 2) {
+    cxx_test_suite_set_correct();
+  }
+}
+
 void c_take_ref_rust_vec(const rust::Vec<uint8_t> &v) {
   uint8_t sum = std::accumulate(v.begin(), v.end(), 0);
   if (sum == 200) {

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -130,6 +130,7 @@ void c_take_rust_vec_ns_shared(rust::Vec<::A::AShared> v);
 void c_take_rust_vec_nested_ns_shared(rust::Vec<::A::B::ABShared> v);
 void c_take_rust_vec_string(rust::Vec<rust::String> v);
 void c_take_rust_vec_shared_index(rust::Vec<Shared> v);
+void c_take_rust_vec_shared_push(rust::Vec<Shared> v);
 void c_take_rust_vec_shared_forward_iterator(rust::Vec<Shared> v);
 void c_take_ref_rust_vec(const rust::Vec<uint8_t> &v);
 void c_take_ref_rust_vec_string(const rust::Vec<rust::String> &v);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -133,6 +133,7 @@ fn test_c_take() {
     let shared_test_vec = vec![ffi::Shared { z: 1010 }, ffi::Shared { z: 1011 }];
     check!(ffi::c_take_rust_vec_shared(shared_test_vec.clone()));
     check!(ffi::c_take_rust_vec_shared_index(shared_test_vec.clone()));
+    check!(ffi::c_take_rust_vec_shared_push(shared_test_vec.clone()));
     check!(ffi::c_take_rust_vec_shared_forward_iterator(
         shared_test_vec,
     ));


### PR DESCRIPTION
These APIs match std::vector.

```diff
  template <typename T>
  class Vec final {
  public:
    ...
+   void reserve(size_t new_cap);
+   void push_back(const T &value);
+   void push_back(T &&value);

+   template <class... Args>
+   void emplace_back(Args &&... args);
  };
```

Part of #149.