### PR TITLE
Enforce use of extern "C++" as the ABI string

### DIFF
--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -285,9 +285,9 @@ fn parse_lang(abi: &Abi) -> Result<Lang> {
         }
     };
     match name.value().as_str() {
-        "C" | "C++" => Ok(Lang::Cxx),
+        "C++" => Ok(Lang::Cxx),
         "Rust" => Ok(Lang::Rust),
-        _ => Err(Error::new_spanned(abi, "unrecognized ABI")),
+        _ => Err(Error::new_spanned(abi, "unrecognized ABI, requires either \"C++\" or \"Rust\"")),
     }
 }
 

--- a/tests/ui/multiple_parse_error.stderr
+++ b/tests/ui/multiple_parse_error.stderr
@@ -4,7 +4,7 @@ error: struct with generic parameters is not supported yet
 3 |     struct Monad<T>;
   |     ^^^^^^^^^^^^^^^
 
-error: unrecognized ABI
+error: unrecognized ABI, requires either "C++" or "Rust"
  --> $DIR/multiple_parse_error.rs:5:5
   |
 5 |     extern "Haskell" {}


### PR DESCRIPTION
We previously compromised in accepting `extern "C"` due to an unfortunate rustfmt bug that caused rustfmt to blindly replace any unrecognized ABI with `extern "Rust"` (https://github.com/rust-lang/rustfmt/issues/4086).

Closes #137.