### PR TITLE
Update cxx::bridge modules to use extern "C++" as the ABI

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ items:
 - **Functions** &mdash; implemented in either language, callable from the other
   language.
 
-Within the `extern "C"` part of the CXX bridge we list the types and functions
+Within the `extern "C++"` part of the CXX bridge we list the types and functions
 for which C++ is the source of truth, as well as the header(s) that declare
 those APIs. In the future it's possible that this section could be generated
 bindgen-style from the headers but for now we need the signatures written out;

--- a/gen/lib/tests/test.rs
+++ b/gen/lib/tests/test.rs
@@ -6,7 +6,7 @@ fn test_positive() {
     let rs = quote! {
         #[cxx::bridge]
         mod ffi {
-            extern "C" {
+            extern "C++" {
                 fn in_C();
             }
             extern "Rust" {

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -27,7 +27,7 @@ use syn::parse_macro_input;
 /// is intended to be used.
 ///
 /// The only additional thing to note here is namespace support &mdash; if the
-/// types and functions on the `extern "C"` side of our bridge are in a
+/// types and functions on the `extern "C++"` side of our bridge are in a
 /// namespace, specify that namespace as an argument of the cxx::bridge
 /// attribute macro.
 ///

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -1,7 +1,7 @@
 use alloc::boxed::Box;
 use core::fmt::{self, Debug, Display};
 
-/// Exception thrown from an `extern "C"` function.
+/// Exception thrown from an `extern "C++"` function.
 #[derive(Debug)]
 pub struct Exception {
     pub(crate) what: Box<str>,

--- a/src/extern_type.rs
+++ b/src/extern_type.rs
@@ -30,7 +30,7 @@ use self::kind::{Kind, Opaque, Trivial};
 /// # mod file1 {
 /// #[cxx::bridge(namespace = "example")]
 /// pub mod ffi {
-///     extern "C" {
+///     extern "C++" {
 ///         type Demo;
 ///
 ///         fn create_demo() -> UniquePtr<Demo>;
@@ -41,7 +41,7 @@ use self::kind::{Kind, Opaque, Trivial};
 /// // file2.rs
 /// #[cxx::bridge(namespace = "example")]
 /// pub mod ffi {
-///     extern "C" {
+///     extern "C++" {
 ///         type Demo = crate::file1::ffi::Demo;
 ///
 ///         fn take_ref_demo(demo: &Demo);
@@ -80,7 +80,7 @@ use self::kind::{Kind, Opaque, Trivial};
 ///
 /// #[cxx::bridge(namespace = "folly")]
 /// pub mod ffi {
-///     extern "C" {
+///     extern "C++" {
 ///         include!("rust_cxx_bindings.h");
 ///
 ///         type StringPiece = crate::folly_sys::StringPiece;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@
 //! - **Functions** &mdash; implemented in either language, callable from the
 //!   other language.
 //!
-//! Within the `extern "C"` part of the CXX bridge we list the types and
+//! Within the `extern "C++"` part of the CXX bridge we list the types and
 //! functions for which C++ is the source of truth, as well as the header(s)
 //! that declare those APIs. In the future it's possible that this section could
 //! be generated bindgen-style from the headers but for now we need the

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -280,7 +280,7 @@ fn parse_lang(abi: &Abi) -> Result<Lang> {
         None => {
             return Err(Error::new_spanned(
                 abi,
-                "ABI name is required, extern \"C\" or extern \"Rust\"",
+                "ABI name is required, extern \"C++\" or extern \"Rust\"",
             ));
         }
     };

--- a/tests/cxx_gen.rs
+++ b/tests/cxx_gen.rs
@@ -6,7 +6,7 @@ use std::str;
 const BRIDGE0: &str = r#"
     #[cxx::bridge]
     mod ffi {
-        extern "C" {
+        extern "C++" {
             pub fn do_cpp_thing(foo: &str);
         }
     }

--- a/tests/ffi/extra.rs
+++ b/tests/ffi/extra.rs
@@ -15,7 +15,7 @@ pub mod ffi2 {
     impl UniquePtr<F> {}
     impl UniquePtr<G> {}
 
-    extern "C" {
+    extern "C++" {
         include!("tests/ffi/tests.h");
 
         type D = crate::other::D;

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -115,7 +115,7 @@ pub mod ffi {
         i: i32,
     }
 
-    extern "C" {
+    extern "C++" {
         include!("tests/ffi/tests.h");
 
         type C;
@@ -218,7 +218,7 @@ pub mod ffi {
         fn ns_c_take_ns_shared(shared: AShared);
     }
 
-    extern "C" {
+    extern "C++" {
         type COwnedEnum;
     }
 

--- a/tests/ffi/module.rs
+++ b/tests/ffi/module.rs
@@ -3,7 +3,7 @@
 #[rustfmt::skip]
 #[cxx::bridge(namespace = "tests")]
 pub mod ffi {
-    extern "C" {
+    extern "C++" {
         include!("tests/ffi/tests.h");
 
         type C = crate::ffi::C;

--- a/tests/ui/by_value_not_supported.rs
+++ b/tests/ui/by_value_not_supported.rs
@@ -6,7 +6,7 @@ mod ffi {
         s: CxxString,
     }
 
-    extern "C" {
+    extern "C++" {
         type C;
     }
 

--- a/tests/ui/disallow_lifetime.rs
+++ b/tests/ui/disallow_lifetime.rs
@@ -1,6 +1,6 @@
 #[cxx::bridge]
 mod ffi {
-    extern "C" {
+    extern "C++" {
         type C;
         fn f(&'static self);
     }

--- a/tests/ui/include.rs
+++ b/tests/ui/include.rs
@@ -1,6 +1,6 @@
 #[cxx::bridge]
 mod ffi {
-    extern "C" {
+    extern "C++" {
         include!("path/to" what);
         include!(<path/to> what);
         include!(<path/to);

--- a/tests/ui/reference_to_reference.rs
+++ b/tests/ui/reference_to_reference.rs
@@ -1,6 +1,6 @@
 #[cxx::bridge]
 mod ffi {
-    extern "C" {
+    extern "C++" {
         type ThingC;
         fn repro_c(t: &&ThingC);
     }

--- a/tests/ui/reserved_name.rs
+++ b/tests/ui/reserved_name.rs
@@ -4,7 +4,7 @@ mod ffi {
         val: usize,
     }
 
-    extern "C" {
+    extern "C++" {
         type Box;
     }
 

--- a/tests/ui/unique_ptr_to_opaque.rs
+++ b/tests/ui/unique_ptr_to_opaque.rs
@@ -11,7 +11,7 @@ mod outside {
 
 #[cxx::bridge]
 mod ffi {
-    extern "C" {
+    extern "C++" {
         type C = crate::outside::C;
     }
 

--- a/tests/ui/unique_ptr_twice.rs
+++ b/tests/ui/unique_ptr_twice.rs
@@ -1,6 +1,6 @@
 #[cxx::bridge]
 mod here {
-    extern "C" {
+    extern "C++" {
         type C;
     }
 
@@ -9,7 +9,7 @@ mod here {
 
 #[cxx::bridge]
 mod there {
-    extern "C" {
+    extern "C++" {
         type C = crate::here::C;
     }
 

--- a/tests/ui/unnamed_receiver.rs
+++ b/tests/ui/unnamed_receiver.rs
@@ -1,6 +1,6 @@
 #[cxx::bridge]
 mod ffi {
-    extern "C" {
+    extern "C++" {
         type One;
         type Two;
         fn f(&mut self);

--- a/tests/ui/unrecognized_receiver.rs
+++ b/tests/ui/unrecognized_receiver.rs
@@ -1,6 +1,6 @@
 #[cxx::bridge]
 mod ffi {
-    extern "C" {
+    extern "C++" {
         fn f(self: &Unrecognized);
     }
 }

--- a/tests/ui/wrong_type_id.rs
+++ b/tests/ui/wrong_type_id.rs
@@ -1,13 +1,13 @@
 #[cxx::bridge(namespace = "folly")]
 mod here {
-    extern "C" {
+    extern "C++" {
         type StringPiece;
     }
 }
 
 #[cxx::bridge(namespace = "folly")]
 mod there {
-    extern "C" {
+    extern "C++" {
         type ByteRange = crate::here::StringPiece;
     }
 }


### PR DESCRIPTION
This is the non-breaking part factored out of #454.