### PR TITLE
Warn on unsupported rust toolchain version

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::path::Path;
+use std::process::Command;
 
 fn main() {
     cc::Build::new()
@@ -8,11 +9,40 @@ fn main() {
         .cpp_link_stdlib(None) // linked via link-cplusplus crate
         .flag_if_supported(cxxbridge_flags::STD)
         .compile("cxxbridge05");
+
     println!("cargo:rerun-if-changed=src/cxx.cc");
     println!("cargo:rerun-if-changed=include/cxx.h");
     println!("cargo:rustc-cfg=built_with_cargo");
+
     if let Some(manifest_dir) = env::var_os("CARGO_MANIFEST_DIR") {
         let cxx_h = Path::new(&manifest_dir).join("include").join("cxx.h");
         println!("cargo:HEADER={}", cxx_h.to_string_lossy());
     }
+
+    if let Some(rustc) = rustc_version() {
+        if rustc.minor < 43 {
+            println!("cargo:warning=The cxx crate requires a rustc version 1.43.0 or newer.");
+            println!(
+                "cargo:warning=You appear to be building with: {}",
+                rustc.version,
+            );
+        }
+    }
+}
+
+struct RustVersion {
+    version: String,
+    minor: u32,
+}
+
+fn rustc_version() -> Option<RustVersion> {
+    let rustc = env::var_os("RUSTC")?;
+    let output = Command::new(rustc).arg("--version").output().ok()?;
+    let version = String::from_utf8(output.stdout).ok()?;
+    let mut pieces = version.split('.');
+    if pieces.next() != Some("rustc 1") {
+        return None;
+    }
+    let minor = pieces.next()?.parse().ok()?;
+    Some(RustVersion { version, minor })
 }


### PR DESCRIPTION
This isn't so useful at the moment, but will be important after #456 since that change is going to require the most recent stable version of the compiler.

---
![Screenshot from 2020-11-11 12-04-30](https://user-images.githubusercontent.com/1940490/98858816-111e2200-2416-11eb-9362-63bba3ea5f20.png)

