### PR TITLE
Allow array inside shared struct definition

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -172,6 +172,9 @@ fn pick_includes_and_builtins(out: &mut OutFile, apis: &[Api]) {
                 out.include.cstdint = true;
                 out.builtin.rust_slice = true;
             }
+            Type::Array(_) => {
+                out.include.array = true;
+            }
             Type::Ref(_) | Type::Void(_) => {}
         }
     }
@@ -902,6 +905,11 @@ fn write_type(out: &mut OutFile, ty: &Type) {
             }
             write!(out, ")>");
         }
+        Type::Array(a) => {
+            write!(out, "::std::array<");
+            write_type(out, &a.inner);
+            write!(out, ", {}>", &a.len);
+        }
         Type::Void(_) => unreachable!(),
     }
 }
@@ -940,7 +948,8 @@ fn write_space_after_type(out: &mut OutFile, ty: &Type) {
         | Type::CxxVector(_)
         | Type::RustVec(_)
         | Type::SliceRefU8(_)
-        | Type::Fn(_) => write!(out, " "),
+        | Type::Fn(_)
+        | Type::Array(_) => write!(out, " "),
         Type::Ref(_) => {}
         Type::Void(_) | Type::Slice(_) => unreachable!(),
     }

--- a/syntax/impls.rs
+++ b/syntax/impls.rs
@@ -1,4 +1,4 @@
-use crate::syntax::{ExternFn, Impl, Include, Receiver, Ref, Signature, Slice, Ty1, Type};
+use crate::syntax::{Array, ExternFn, Impl, Include, Receiver, Ref, Signature, Slice, Ty1, Type};
 use std::borrow::Borrow;
 use std::hash::{Hash, Hasher};
 use std::mem;
@@ -50,6 +50,7 @@ impl Hash for Type {
             Type::Fn(t) => t.hash(state),
             Type::Slice(t) => t.hash(state),
             Type::SliceRefU8(t) => t.hash(state),
+            Type::Array(t) => t.hash(state),
             Type::Void(_) => {}
         }
     }
@@ -170,6 +171,37 @@ impl Hash for Slice {
     fn hash<H: Hasher>(&self, state: &mut H) {
         let Slice { bracket: _, inner } = self;
         inner.hash(state);
+    }
+}
+
+impl Eq for Array {}
+impl PartialEq for Array {
+    fn eq(&self, other: &Array) -> bool {
+        let Array {
+            bracket: _,
+            inner,
+            semi_token: _,
+            len,
+        } = self;
+        let Array {
+            bracket: _,
+            inner: inner2,
+            semi_token: _,
+            len: len2,
+        } = other;
+        inner == inner2 && len == len2
+    }
+}
+impl Hash for Array {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let Array {
+            bracket: _,
+            inner,
+            semi_token: _,
+            len,
+        } = self;
+        inner.hash(state);
+        len.to_string().hash(state);
     }
 }
 

--- a/syntax/improper.rs
+++ b/syntax/improper.rs
@@ -31,6 +31,7 @@ impl<'a> Types<'a> {
             | Type::SliceRefU8(_) => Definite(true),
             Type::UniquePtr(_) | Type::CxxVector(_) => Definite(false),
             Type::Ref(ty) => self.determine_improper_ctype(&ty.inner),
+            Type::Array(ty) => self.determine_improper_ctype(&ty.inner),
         }
     }
 }

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -165,6 +165,7 @@ pub enum Type {
     Void(Span),
     Slice(Box<Slice>),
     SliceRefU8(Box<Ref>),
+    Array(Box<Array>),
 }
 
 pub struct Ty1 {
@@ -187,6 +188,13 @@ pub struct Ref {
 pub struct Slice {
     pub bracket: Bracket,
     pub inner: Type,
+}
+
+pub struct Array {
+    pub bracket: Bracket,
+    pub inner: Type,
+    pub semi_token: Token![;],
+    pub len: usize,
 }
 
 #[derive(Copy, Clone, PartialEq)]

--- a/syntax/tokens.rs
+++ b/syntax/tokens.rs
@@ -1,7 +1,7 @@
 use crate::syntax::atom::Atom::*;
 use crate::syntax::{
-    Atom, Derive, Enum, ExternFn, ExternType, Impl, Receiver, Ref, ResolvableName, Signature,
-    Slice, Struct, Ty1, Type, TypeAlias, Var,
+    Array, Atom, Derive, Enum, ExternFn, ExternType, Impl, Receiver, Ref, ResolvableName,
+    Signature, Slice, Struct, Ty1, Type, TypeAlias, Var,
 };
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote_spanned, ToTokens};
@@ -22,6 +22,7 @@ impl ToTokens for Type {
             }
             Type::Ref(r) | Type::Str(r) | Type::SliceRefU8(r) => r.to_tokens(tokens),
             Type::Slice(s) => s.to_tokens(tokens),
+            Type::Array(a) => a.to_tokens(tokens),
             Type::Fn(f) => f.to_tokens(tokens),
             Type::Void(span) => tokens.extend(quote_spanned!(*span=> ())),
         }
@@ -65,6 +66,16 @@ impl ToTokens for Ref {
         if let Some((_pin, _langle, rangle)) = self.pin_tokens {
             rangle.to_tokens(tokens);
         }
+    }
+}
+
+impl ToTokens for Array {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.bracket.surround(tokens, |tokens| {
+            self.inner.to_tokens(tokens);
+            self.semi_token.to_tokens(tokens);
+            self.len.to_tokens(tokens);
+        });
     }
 }
 

--- a/syntax/types.rs
+++ b/syntax/types.rs
@@ -49,6 +49,7 @@ impl<'a> Types<'a> {
                 | Type::RustVec(ty) => visit(all, &ty.inner),
                 Type::Ref(r) => visit(all, &r.inner),
                 Type::Slice(s) => visit(all, &s.inner),
+                Type::Array(a) => visit(all, &a.inner),
                 Type::Fn(f) => {
                     if let Some(ret) = &f.ret {
                         visit(all, ret);

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -116,6 +116,10 @@ pub mod ffi {
         i: i32,
     }
 
+    pub struct Array {
+        a: [i32; 4],
+    }
+
     unsafe extern "C++" {
         include!("tests/ffi/tests.h");
 
@@ -204,6 +208,7 @@ pub mod ffi {
         fn set_succeed(self: Pin<&mut C>, n: usize) -> Result<usize>;
         fn get_fail(self: Pin<&mut C>) -> Result<usize>;
         fn c_method_on_shared(self: &Shared) -> usize;
+        fn c_set_array(self: &mut Array, value: i32);
 
         #[rust_name = "i32_overloaded_method"]
         fn cOverloadedMethod(&self, x: i32) -> String;
@@ -274,6 +279,7 @@ pub mod ffi {
         fn get(self: &R) -> usize;
         fn set(self: &mut R, n: usize) -> usize;
         fn r_method_on_shared(self: &Shared) -> String;
+        fn r_get_array_sum(self: &Array) -> i32;
 
         #[cxx_name = "rAliasedFunction"]
         fn r_aliased_function(x: i32) -> String;
@@ -318,6 +324,12 @@ impl R {
 impl ffi::Shared {
     fn r_method_on_shared(&self) -> String {
         "2020".to_owned()
+    }
+}
+
+impl ffi::Array {
+    pub fn r_get_array_sum(&self) -> i32 {
+        self.a.iter().sum()
     }
 }
 

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -32,6 +32,10 @@ size_t C::get_fail() { throw std::runtime_error("unimplemented"); }
 
 size_t Shared::c_method_on_shared() const noexcept { return 2021; }
 
+void Array::c_set_array(int32_t val) noexcept {
+  this->a = {val, val, val, val};
+}
+
 const std::vector<uint8_t> &C::get_v() const { return this->v; }
 
 std::vector<uint8_t> &C::get_v() { return this->v; }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -197,6 +197,11 @@ fn test_c_method_calls() {
     );
     assert!(unique_ptr.as_mut().unwrap().get_fail().is_err());
     assert_eq!(2021, ffi::Shared { z: 0 }.c_method_on_shared());
+
+    let val = 42;
+    let mut array = ffi::Array { a: [0, 0, 0, 0] };
+    array.c_set_array(val);
+    assert_eq!(array.a.len() as i32 * val, array.r_get_array_sum());
 }
 
 #[test]


### PR DESCRIPTION
Address #458 

It translates 
```rust
#[cxx::bridge]
mod ffi {
    struct Foo {
        a: [i32; 0xf],
        b: [Vec<usize>; 3_2],
    }
}
```
to
```cpp
struct Foo final {
  std::array<int32_t, 15> a;
  std::array<rust::Vec<size_t>, 32> b;
};
```
The current implementation requires:
1. The size field must be an integer literal
2. The literal should be able to parse to usize
3. The type needs to be one of primitive type, shared struct, RustBox, RustVec, CxxVector, UniquePtr

I'm not sure if we can simply replace `[usize; 16]` to `std::array<uint64_t, 16>`.
