### PR TITLE
Pull in unreleased mdbook fixes

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -16,9 +16,9 @@ jobs:
 
       - name: Get mdBook
         run: |
-          export MDBOOK_VERSION="v0.4.4"
+          export MDBOOK_VERSION="dtolnay"
           export MDBOOK_TARBALL="mdbook-${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
-          export MDBOOK_URL="https://github.com/rust-lang/mdBook/releases/download/${MDBOOK_VERSION}/${MDBOOK_TARBALL}"
+          export MDBOOK_URL="https://github.com/dtolnay/mdBook/releases/download/cxx/${MDBOOK_TARBALL}"
           curl -Lf "${MDBOOK_URL}" | tar -xzC book
 
       - name: Build


### PR DESCRIPTION
This brings in the following PRs I made upstream which are not yet in an mdbook release:

- https://github.com/rust-lang/mdBook/pull/1375 ***Fix stray spacing after #playground code***
- https://github.com/rust-lang/mdBook/pull/1376 ***Escape \`<\` and \`>\` in rendered toc to match handlebars' escaping in \<title\>***
- https://github.com/rust-lang/mdBook/pull/1379 ***Add hidelines code class to enable hiding in non-Rust blocks***
- https://github.com/rust-lang/mdBook/pull/1381 ***Add page title override: {{#title My Title}}***

The package is built from https://github.com/dtolnay/mdBook/tree/cxx.