### PR TITLE
Ensure opaque types are !Unpin

### DIFF
--- a/src/cxx_string.rs
+++ b/src/cxx_string.rs
@@ -1,6 +1,7 @@
 use alloc::borrow::Cow;
 use alloc::string::String;
 use core::fmt::{self, Debug, Display};
+use core::marker::{PhantomData, PhantomPinned};
 use core::slice;
 use core::str::{self, Utf8Error};
 
@@ -26,6 +27,7 @@ extern "C" {
 #[repr(C)]
 pub struct CxxString {
     _private: [u8; 0],
+    _pinned: PhantomData<PhantomPinned>,
 }
 
 impl CxxString {

--- a/src/cxx_vector.rs
+++ b/src/cxx_vector.rs
@@ -1,7 +1,7 @@
 use crate::cxx_string::CxxString;
 use core::ffi::c_void;
 use core::fmt::{self, Display};
-use core::marker::PhantomData;
+use core::marker::{PhantomData, PhantomPinned};
 use core::mem;
 use core::ptr;
 use core::slice;
@@ -17,6 +17,7 @@ use core::slice;
 #[repr(C, packed)]
 pub struct CxxVector<T> {
     _private: [T; 0],
+    _pinned: PhantomData<PhantomPinned>,
 }
 
 impl<T> CxxVector<T>

--- a/src/opaque.rs
+++ b/src/opaque.rs
@@ -1,3 +1,4 @@
+use core::marker::{PhantomData, PhantomPinned};
 use core::mem;
 
 // . size = 0
@@ -5,9 +6,11 @@ use core::mem;
 // . ffi-safe
 // . !Send
 // . !Sync
+// . !Unpin
 #[repr(C, packed)]
 pub struct Opaque {
     _private: [*const u8; 0],
+    _pinned: PhantomData<PhantomPinned>,
 }
 
 const_assert_eq!(0, mem::size_of::<Opaque>());

--- a/tests/ui/opaque_autotraits.rs
+++ b/tests/ui/opaque_autotraits.rs
@@ -1,3 +1,5 @@
+use std::marker::Unpin;
+
 #[cxx::bridge]
 mod ffi {
     extern "C++" {
@@ -7,8 +9,10 @@ mod ffi {
 
 fn assert_send<T: Send>() {}
 fn assert_sync<T: Sync>() {}
+fn assert_unpin<T: Unpin>() {}
 
 fn main() {
     assert_send::<ffi::Opaque>();
     assert_sync::<ffi::Opaque>();
+    assert_unpin::<ffi::Opaque>();
 }

--- a/tests/ui/opaque_autotraits.stderr
+++ b/tests/ui/opaque_autotraits.stderr
@@ -25,3 +25,16 @@ error[E0277]: `*const u8` cannot be shared between threads safely
    = note: required because it appears within the type `[*const u8; 0]`
    = note: required because it appears within the type `cxx::private::Opaque`
    = note: required because it appears within the type `ffi::Opaque`
+
+error[E0277]: `PhantomPinned` cannot be unpinned
+  --> $DIR/opaque_autotraits.rs:17:5
+   |
+12 | fn assert_unpin<T: Unpin>() {}
+   |                    ----- required by this bound in `assert_unpin`
+...
+17 |     assert_unpin::<ffi::Opaque>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `ffi::Opaque`, the trait `Unpin` is not implemented for `PhantomPinned`
+   |
+   = note: required because it appears within the type `PhantomData<PhantomPinned>`
+   = note: required because it appears within the type `cxx::private::Opaque`
+   = note: required because it appears within the type `ffi::Opaque`

--- a/tests/ui/opaque_autotraits.stderr
+++ b/tests/ui/opaque_autotraits.stderr
@@ -1,10 +1,10 @@
 error[E0277]: `*const u8` cannot be sent between threads safely
-  --> $DIR/opaque_autotraits.rs:12:5
+  --> $DIR/opaque_autotraits.rs:15:5
    |
-8  | fn assert_send<T: Send>() {}
+10 | fn assert_send<T: Send>() {}
    |                   ---- required by this bound in `assert_send`
 ...
-12 |     assert_send::<ffi::Opaque>();
+15 |     assert_send::<ffi::Opaque>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const u8` cannot be sent between threads safely
    |
    = help: within `ffi::Opaque`, the trait `Send` is not implemented for `*const u8`
@@ -13,12 +13,12 @@ error[E0277]: `*const u8` cannot be sent between threads safely
    = note: required because it appears within the type `ffi::Opaque`
 
 error[E0277]: `*const u8` cannot be shared between threads safely
-  --> $DIR/opaque_autotraits.rs:13:5
+  --> $DIR/opaque_autotraits.rs:16:5
    |
-9  | fn assert_sync<T: Sync>() {}
+11 | fn assert_sync<T: Sync>() {}
    |                   ---- required by this bound in `assert_sync`
 ...
-13 |     assert_sync::<ffi::Opaque>();
+16 |     assert_sync::<ffi::Opaque>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const u8` cannot be shared between threads safely
    |
    = help: within `ffi::Opaque`, the trait `Sync` is not implemented for `*const u8`


### PR DESCRIPTION
This is necessary in order for `Pin<&mut Opaque>` to be meaningful. Otherwise it behaves just like `&mut Opaque` which may not be correct.