### PR TITLE
Improve async fn error message with link to workaround

### DIFF
--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -373,6 +373,12 @@ fn parse_extern_fn(
             "variadic function is not supported yet",
         ));
     }
+    if foreign_fn.sig.asyncness.is_some() {
+        return Err(Error::new_spanned(
+            foreign_fn,
+            "async function is not directly supported yet, but see https://cxx.rs/async.html for a working approach",
+        ));
+    }
 
     let mut doc = Doc::new();
     let mut cxx_name = None;

--- a/tests/ui/async_fn.rs
+++ b/tests/ui/async_fn.rs
@@ -1,0 +1,10 @@
+#[cxx::bridge]
+mod ffi {
+    extern "Rust" {
+        async fn f();
+    }
+}
+
+async fn f() {}
+
+fn main() {}

--- a/tests/ui/async_fn.stderr
+++ b/tests/ui/async_fn.stderr
@@ -1,0 +1,22 @@
+error[E0308]: mismatched types
+ --> $DIR/async_fn.rs:4:18
+  |
+4 |         async fn f();
+  |                  ^
+  |                  |
+  |                  expected `()`, found opaque type
+  |                  possibly return type missing here?
+...
+8 | async fn f() {}
+  |              - the `Output` of this `async fn`'s found opaque type
+  |
+  = note: expected unit type `()`
+           found opaque type `impl Future`
+help: consider `await`ing on the `Future`
+  |
+4 |         async fn f.await();
+  |                   ^^^^^^
+help: try adding a semicolon
+  |
+4 |         async fn f;();
+  |                   ^

--- a/tests/ui/async_fn.stderr
+++ b/tests/ui/async_fn.stderr
@@ -1,22 +1,5 @@
-error[E0308]: mismatched types
- --> $DIR/async_fn.rs:4:18
+error: async function is not directly supported yet, but see https://cxx.rs/async.html for a working approach
+ --> $DIR/async_fn.rs:4:9
   |
 4 |         async fn f();
-  |                  ^
-  |                  |
-  |                  expected `()`, found opaque type
-  |                  possibly return type missing here?
-...
-8 | async fn f() {}
-  |              - the `Output` of this `async fn`'s found opaque type
-  |
-  = note: expected unit type `()`
-           found opaque type `impl Future`
-help: consider `await`ing on the `Future`
-  |
-4 |         async fn f.await();
-  |                   ^^^^^^
-help: try adding a semicolon
-  |
-4 |         async fn f;();
-  |                   ^
+  |         ^^^^^^^^^^^^^


### PR DESCRIPTION
Direct async fn support is tracked in https://github.com/dtolnay/cxx/issues/138. For now this just gives it a more useful error message than before.