### PR TITLE
No longer need rustfmt::skip when using extern type alias

### DIFF
--- a/tests/ffi/extra.rs
+++ b/tests/ffi/extra.rs
@@ -5,9 +5,6 @@
 // for testing aliasing between cxx::bridge mods, so we'll keep it that way and
 // start a new mod here.
 
-// Rustfmt mangles the extern type alias.
-// https://github.com/rust-lang/rustfmt/issues/4159
-#[rustfmt::skip]
 #[cxx::bridge(namespace = "tests")]
 pub mod ffi2 {
     impl UniquePtr<D> {}
@@ -43,7 +40,7 @@ pub mod ffi2 {
         fn c_return_trivial_ns_ptr() -> UniquePtr<G>;
         fn c_return_trivial_ns() -> G;
         fn c_return_opaque_ptr() -> UniquePtr<E>;
-        fn c_return_ns_opaque_ptr() -> UniquePtr<F>;  
+        fn c_return_ns_opaque_ptr() -> UniquePtr<F>;
         fn c_return_ns_unique_ptr() -> UniquePtr<H>;
         fn c_take_ref_ns_c(h: &H);
 

--- a/tests/ffi/module.rs
+++ b/tests/ffi/module.rs
@@ -1,6 +1,3 @@
-// Rustfmt mangles the extern type alias.
-// https://github.com/rust-lang/rustfmt/issues/4159
-#[rustfmt::skip]
 #[cxx::bridge(namespace = "tests")]
 pub mod ffi {
     unsafe extern "C++" {


### PR DESCRIPTION
The relevant rustfmt fixes:

- https://github.com/rust-lang/rustfmt/pull/4423
- https://github.com/rust-lang/rustfmt/pull/4433
- https://github.com/rust-lang/rustfmt/pull/4164

were backported to rustfmt 1.x in:

- https://github.com/rust-lang/rustfmt/pull/4434
- https://github.com/rust-lang/rustfmt/pull/4447

then that was brought into the Rust dist by:

- https://github.com/racer-rust/racer/pull/1132
- https://github.com/rust-lang/rls/pull/1701
- https://github.com/rust-lang/rust/pull/77590

and backported to beta:

- https://github.com/rust-lang/rust/pull/77705

in time for Rust 1.48, so rustfmt is able to handle this syntax now as of the most recent Rust release and I am comfortable removing the skips.