### PR TITLE
Skip ExternType::Kind check if type is known trivial

### DIFF
--- a/syntax/types.rs
+++ b/syntax/types.rs
@@ -170,7 +170,10 @@ impl<'a> Types<'a> {
         let mut required_trivial = Map::new();
         let mut insist_alias_types_are_trivial = |ty: &'a Type, reason| {
             if let Type::Ident(ident) = ty {
-                if cxx.contains(&ident.rust) {
+                if cxx.contains(&ident.rust)
+                    && !structs.contains_key(&ident.rust)
+                    && !enums.contains_key(&ident.rust)
+                {
                     required_trivial.entry(&ident.rust).or_insert(reason);
                 }
             }

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -113,6 +113,7 @@ pub mod ffi {
     #[namespace = "second"]
     struct Second {
         i: i32,
+        e: COwnedEnum,
     }
 
     unsafe extern "C++" {


### PR DESCRIPTION
This fixes an error when an extern struct or enum is used as a struct field or function argument. Previously that would fail:

```console
error[cxxbridge]: needs a cxx::ExternType impl in order to be used as a field of `Second`
    ┌─ lib.rs:222:9
    │
222 │         type COwnedEnum;
    │         ^^^^^^^^^^^^^^^ needs a cxx::ExternType impl in order to be used as a field of `Second`
```

which is wrong because the bridge should know it itself is producing a compatible ExternType impl for the struct/enum.