### PR TITLE
Check std::is_enum on extern enum

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -269,6 +269,12 @@ fn write_enum<'a>(out: &mut OutFile<'a>, enm: &'a Enum) {
 
 fn check_enum<'a>(out: &mut OutFile<'a>, enm: &'a Enum) {
     out.set_namespace(&enm.name.namespace);
+    out.include.type_traits = true;
+    writeln!(
+        out,
+        "static_assert(::std::is_enum<{}>::value, \"expected enum\");",
+        enm.name.cxx,
+    );
     write!(out, "static_assert(sizeof({}) == sizeof(", enm.name.cxx);
     write_atom(out, enm.repr);
     writeln!(out, "), \"incorrect size\");");


### PR DESCRIPTION
Without this, something that is not an enum could have been able to pass our assertions, resulting in unpredictable behavior.

```rust
// rust
enum FakeEnum { K = 1usize }
extern "C++" { type FakeEnum; }
```

```cpp
// c++
struct FakeEnum {
  static const int K = 1;
  const char *x;
};
```

There may be valid reasons to want something of this nature to work, but forbid for now and someone will need to bring forward a concrete use case for consideration.