### PR TITLE
Add conditional DerefMut for UniquePtr

### DIFF
--- a/src/unique_ptr.rs
+++ b/src/unique_ptr.rs
@@ -6,7 +6,7 @@ use core::ffi::c_void;
 use core::fmt::{self, Debug, Display};
 use core::marker::PhantomData;
 use core::mem;
-use core::ops::Deref;
+use core::ops::{Deref, DerefMut};
 use core::pin::Pin;
 use core::ptr;
 
@@ -115,6 +115,18 @@ where
         match self.as_ref() {
             Some(target) => target,
             None => panic!("called deref on a null UniquePtr<{}>", T::__NAME),
+        }
+    }
+}
+
+impl<T> DerefMut for UniquePtr<T>
+where
+    T: UniquePtrTarget + Unpin,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self.as_mut() {
+            Some(target) => Pin::into_inner(target),
+            None => panic!("called deref_mut on a null UniquePtr<{}>", T::__NAME),
         }
     }
 }

--- a/tests/ui/unique_ptr_as_mut.stderr
+++ b/tests/ui/unique_ptr_as_mut.stderr
@@ -1,11 +1,3 @@
-error[E0596]: cannot borrow data in a dereference of `UniquePtr<Shared>` as mutable
-  --> $DIR/unique_ptr_as_mut.rs:19:31
-   |
-19 |     let _: &mut ffi::Shared = &mut shared;
-   |                               ^^^^^^^^^^^ cannot borrow as mutable
-   |
-   = help: trait `DerefMut` is required to modify through a dereference, but it is not implemented for `UniquePtr<Shared>`
-
 error[E0596]: cannot borrow data in a dereference of `UniquePtr<ffi::Opaque>` as mutable
   --> $DIR/unique_ptr_as_mut.rs:22:31
    |


### PR DESCRIPTION
This is sound because UniquePtr\<T\> follows the pinning invariants of Pin\<Box\<T\>\>, which provides DerefMut under the same condition. In practice for CXX this impl will apply to UniquePtr of shared structs, and will not apply to UniquePtr of opaque C++ types.