### PR TITLE
Update CI to use stable 1.48.0 compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
         include:
           - rust: nightly
           - rust: beta
-          #- rust: stable
-          #- rust: 1.48.0
+          - rust: stable
+          - rust: 1.48.0
           - name: macOS
             rust: nightly
             os: macos
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: dtolnay/rust-toolchain@beta
+      - uses: dtolnay/rust-toolchain@stable
       - uses: actions/setup-java@v1
         with:
           java-version: 11

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,17 +25,15 @@ bazel_version(name = "bazel_version")
 load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repository_set")
 
 rust_repository_set(
-    name = "rust_1_48_beta_linux",
+    name = "rust_1_48_linux",
     exec_triple = "x86_64-unknown-linux-gnu",
-    iso_date = "2020-11-08",
-    version = "beta",
+    version = "1.48.0",
 )
 
 rust_repository_set(
-    name = "rust_1_48_beta_darwin",
+    name = "rust_1_48_darwin",
     exec_triple = "x86_64-apple-darwin",
-    iso_date = "2020-11-08",
-    version = "beta",
+    version = "1.48.0",
 )
 
 vendor(


### PR DESCRIPTION
#456 had pulled in beta temporarily for the `unsafe extern` block language feature, but that's now available in stable 1.48.0.