### PR TITLE
Improve error message on unique_ptr of incomplete forward declared type

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1242,6 +1242,26 @@ fn write_unique_ptr_common(out: &mut OutFile, ty: UniquePtr) {
         UniquePtr::CxxVector(_) => false,
     };
 
+    let conditional_delete = match ty {
+        UniquePtr::Ident(ident) => {
+            !out.types.structs.contains_key(&ident.rust)
+                && !out.types.enums.contains_key(&ident.rust)
+        }
+        UniquePtr::CxxVector(_) => false,
+    };
+
+    if conditional_delete {
+        out.builtin.is_complete = true;
+        let definition = match ty {
+            UniquePtr::Ident(ty) => &out.types.resolve(ty).cxx,
+            UniquePtr::CxxVector(_) => unreachable!(),
+        };
+        writeln!(
+            out,
+            "static_assert(::rust::is_complete<{}>::value, \"definition of {} is required\");",
+            inner, definition,
+        );
+    }
     writeln!(
         out,
         "static_assert(sizeof(::std::unique_ptr<{}>) == sizeof(void *), \"\");",
@@ -1298,7 +1318,16 @@ fn write_unique_ptr_common(out: &mut OutFile, ty: UniquePtr) {
         "void cxxbridge1$unique_ptr${}$drop(::std::unique_ptr<{}> *ptr) noexcept {{",
         instance, inner,
     );
-    writeln!(out, "  ptr->~unique_ptr();");
+    if conditional_delete {
+        out.builtin.deleter_if = true;
+        writeln!(
+            out,
+            "  ::rust::deleter_if<::rust::is_complete<{}>::value>{{}}(ptr);",
+            inner,
+        );
+    } else {
+        writeln!(out, "  ptr->~unique_ptr();");
+    }
     writeln!(out, "}}");
 }
 


### PR DESCRIPTION
We need a real definition for T, not just a forward declaration, when binding std::unique_ptr\<T\> because the Rust UniquePtr's Drop impl needs to be able to call ~unique_ptr which needs to call ~T. Among other things, the C++ compiler needs to be able to determine whether ~T is public, which needs a type definition available.

```rust
#[cxx::bridge]
mod ffi {
    unsafe extern "C++" {
        include!("test/include/test.h");
        type Opaque;
        fn f() -> UniquePtr<Opaque>;
    }
}
```

```cpp
#pragma once
#include <memory>

struct Opaque;
std::unique_ptr<Opaque> f() noexcept;
```

## Before:

```console
In file included from /usr/include/c++/9/memory:80,
                 from target/debug/build/example-8b477c085d2b5f88/out/cxxbridge/crate/test/include/test.h:2,
                 from target/debug/build/example-8b477c085d2b5f88/out/cxxbridge/sources/test/src/main.rs.cc:1:
/usr/include/c++/9/bits/unique_ptr.h: In instantiation of ‘void std::default_delete<_Tp>::operator()(_Tp*) const [with _Tp = Opaque]’:
/usr/include/c++/9/bits/unique_ptr.h:292:17:   required from ‘std::unique_ptr<_Tp, _Dp>::~unique_ptr() [with _Tp = Opaque; _Dp = std::default_delete<Opaque>]’
target/debug/build/example-8b477c085d2b5f88/out/cxxbridge/sources/test/src/main.rs.cc:11:13:   required from here
/usr/include/c++/9/bits/unique_ptr.h:79:16: error: invalid application of ‘sizeof’ to incomplete type ‘Opaque’
   79 |  static_assert(sizeof(_Tp)>0,
      |                ^~~~~~~~~~~
```

## After:

```console
out/cxxbridge/sources/test/src/main.rs.cc:41:54: error: static assertion failed: definition of Opaque is required
   41 | static_assert(::rust::is_complete<::Opaque>::value, "definition of Opaque is required");
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
```