### PR TITLE
Include filepath in no-bridge-found error

### DIFF
--- a/gen/src/error.rs
+++ b/gen/src/error.rs
@@ -68,6 +68,13 @@ pub(super) fn format_err(path: &Path, source: &str, error: Error) -> ! {
                 display_syn_error(stderr, path, source, error);
             }
         }
+        Error::NoBridgeMod => {
+            let _ = writeln!(
+                io::stderr(),
+                "cxxbridge: no #[cxx::bridge] module found in {}",
+                path.display(),
+            );
+        }
         _ => {
             let _ = writeln!(io::stderr(), "cxxbridge: {}", report(error));
         }


### PR DESCRIPTION
Improves the message in https://github.com/dtolnay/cxx/issues/119#issuecomment-733901382.

Before: `cxxbridge: no #[cxx::bridge] module found`
After: `cxxbridge: no #[cxx::bridge] module found in src/lib.rs`