### PR TITLE
Allow simultaneous diagnostics on multiple fields of a struct

### DIFF
--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -89,16 +89,18 @@ fn parse_struct(cx: &mut Errors, item: ItemStruct, namespace: &Namespace) -> Res
         }
     };
 
-    let fields = named_fields
-        .named
-        .into_iter()
-        .map(|field| {
-            Ok(Var {
-                ident: field.ident.unwrap(),
-                ty: parse_type(&field.ty)?,
-            })
-        })
-        .collect::<Result<_>>()?;
+    let mut fields = Vec::new();
+    for field in named_fields.named {
+        let ident = field.ident.unwrap();
+        let ty = match parse_type(&field.ty) {
+            Ok(ty) => ty,
+            Err(err) => {
+                cx.push(err);
+                continue;
+            }
+        };
+        fields.push(Var { ident, ty });
+    }
 
     Ok(Api::Struct(Struct {
         doc,

--- a/tests/ui/array_len_expr.rs
+++ b/tests/ui/array_len_expr.rs
@@ -1,8 +1,8 @@
 #[cxx::bridge]
 mod ffi {
-    unsafe extern "C++" {
-        fn arraystr() -> [String; "13"];
-        fn arraysub() -> [String; 15 - 1];
+    struct Shared {
+        arraystr: [String; "13"],
+        arraysub: [String; 15 - 1],
     }
 }
 

--- a/tests/ui/array_len_expr.stderr
+++ b/tests/ui/array_len_expr.stderr
@@ -1,11 +1,5 @@
 error: array length must be an integer literal
- --> $DIR/array_len_expr.rs:4:35
+ --> $DIR/array_len_expr.rs:4:28
   |
-4 |         fn arraystr() -> [String; "13"];
-  |                                   ^^^^
-
-error: unsupported expression, array length must be an integer literal
- --> $DIR/array_len_expr.rs:5:35
-  |
-5 |         fn arraysub() -> [String; 15 - 1];
-  |                                   ^^^^^^
+4 |         arraystr: [String; "13"],
+  |                            ^^^^

--- a/tests/ui/array_len_expr.stderr
+++ b/tests/ui/array_len_expr.stderr
@@ -3,3 +3,9 @@ error: array length must be an integer literal
   |
 4 |         arraystr: [String; "13"],
   |                            ^^^^
+
+error: unsupported expression, array length must be an integer literal
+ --> $DIR/array_len_expr.rs:5:28
+  |
+5 |         arraysub: [String; 15 - 1],
+  |                            ^^^^^^


### PR DESCRIPTION
Previously only the first diagnostic among the fields would be emitted.