### PR TITLE
Disallow array with zero size

### DIFF
--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -767,9 +767,14 @@ fn parse_type_array(ty: &TypeArray) -> Result<Type> {
         return Err(Error::new_spanned(len_expr, msg));
     };
 
+    let len = len_token.base10_parse::<usize>()?;
+    if len == 0 {
+        let msg = "array with zero size is not supported";
+        return Err(Error::new_spanned(ty, msg));
+    }
+
     let bracket = ty.bracket_token;
     let semi_token = ty.semi_token;
-    let len = len_token.base10_parse::<usize>()?;
 
     Ok(Type::Array(Box::new(Array {
         bracket,

--- a/tests/ui/array_len_expr.rs
+++ b/tests/ui/array_len_expr.rs
@@ -3,6 +3,7 @@ mod ffi {
     struct Shared {
         arraystr: [String; "13"],
         arraysub: [String; 15 - 1],
+        arrayzero: [String; 0],
     }
 }
 

--- a/tests/ui/array_len_expr.stderr
+++ b/tests/ui/array_len_expr.stderr
@@ -9,3 +9,9 @@ error: unsupported expression, array length must be an integer literal
   |
 5 |         arraysub: [String; 15 - 1],
   |                            ^^^^^^
+
+error: array with zero size is not supported
+ --> $DIR/array_len_expr.rs:6:20
+  |
+6 |         arrayzero: [String; 0],
+  |                    ^^^^^^^^^^^


### PR DESCRIPTION
C++ interprets these differently than Rust, causing potentially mismatching field offsets.