### PR TITLE
Emit operator== for shared structs with derive(PartialEq)

### DIFF
--- a/macro/src/derive.rs
+++ b/macro/src/derive.rs
@@ -17,7 +17,7 @@ pub fn expand_struct(strct: &Struct) -> TokenStream {
     expanded
 }
 
-pub fn expand_enum(enm: &Enum) -> TokenStream {
+pub fn expand_enum(enm: &Enum, actual_derives: &mut Option<TokenStream>) -> TokenStream {
     let mut expanded = TokenStream::new();
     let mut has_copy = false;
     let mut has_clone = false;
@@ -44,6 +44,12 @@ pub fn expand_enum(enm: &Enum) -> TokenStream {
     if !has_clone {
         expanded.extend(enum_clone(enm, span));
     }
+
+    *actual_derives = Some(quote! {
+        // Required to be derived in order for the enum's "variants" to be
+        // usable in patterns.
+        #[derive(::std::cmp::PartialEq, ::std::cmp::Eq)]
+    });
 
     expanded
 }

--- a/macro/src/derive.rs
+++ b/macro/src/derive.rs
@@ -2,6 +2,8 @@ use crate::syntax::{derive, Enum, Struct, Trait};
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, quote_spanned, ToTokens};
 
+pub use crate::syntax::derive::*;
+
 pub fn expand_struct(strct: &Struct, actual_derives: &mut Option<TokenStream>) -> TokenStream {
     let mut expanded = TokenStream::new();
     let mut traits = Vec::new();

--- a/macro/src/derive.rs
+++ b/macro/src/derive.rs
@@ -2,7 +2,7 @@ use crate::syntax::{derive, Enum, Struct, Trait};
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, quote_spanned, ToTokens};
 
-pub fn expand_struct(strct: &Struct) -> TokenStream {
+pub fn expand_struct(strct: &Struct, actual_derives: &mut Option<TokenStream>) -> TokenStream {
     let mut expanded = TokenStream::new();
 
     for derive in &strct.derives {
@@ -13,6 +13,8 @@ pub fn expand_struct(strct: &Struct) -> TokenStream {
             Trait::Debug => expanded.extend(struct_debug(strct, span)),
         }
     }
+
+    *actual_derives = None;
 
     expanded
 }

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -164,12 +164,8 @@ fn expand_enum(enm: &Enum) -> TokenStream {
             pub const #variant_ident: Self = #ident { repr: #discriminant };
         })
     });
-    let derives = quote! {
-        // Required to be derived in order for the enum's "variants" to be
-        // usable in patterns.
-        #[derive(::std::cmp::PartialEq, ::std::cmp::Eq)]
-    };
-    let derived_traits = derive::expand_enum(enm);
+    let mut derives = None;
+    let derived_traits = derive::expand_enum(enm, &mut derives);
 
     quote! {
         #doc

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -134,10 +134,12 @@ fn expand_struct(strct: &Struct) -> TokenStream {
         let vis = Token![pub](field.ident.span());
         quote!(#vis #field)
     });
-    let derived_traits = derive::expand_struct(strct);
+    let mut derives = None;
+    let derived_traits = derive::expand_struct(strct, &mut derives);
 
     quote! {
         #doc
+        #derives
         #[repr(C)]
         pub struct #ident {
             #(#fields,)*

--- a/syntax/derive.rs
+++ b/syntax/derive.rs
@@ -11,6 +11,8 @@ pub enum Trait {
     Clone,
     Copy,
     Debug,
+    Eq,
+    PartialEq,
 }
 
 impl Derive {
@@ -19,6 +21,8 @@ impl Derive {
             "Clone" => Trait::Clone,
             "Copy" => Trait::Copy,
             "Debug" => Trait::Debug,
+            "Eq" => Trait::Eq,
+            "PartialEq" => Trait::PartialEq,
             _ => return None,
         };
         let span = ident.span();

--- a/syntax/mangle.rs
+++ b/syntax/mangle.rs
@@ -1,5 +1,5 @@
 use crate::syntax::symbol::{self, Symbol};
-use crate::syntax::{ExternFn, Types};
+use crate::syntax::{ExternFn, Pair, Types};
 use proc_macro2::Ident;
 
 const CXXBRIDGE: &str = "cxxbridge1";
@@ -23,6 +23,10 @@ pub fn extern_fn(efn: &ExternFn, types: &Types) -> Symbol {
         }
         None => join!(efn.name.namespace, CXXBRIDGE, efn.name.rust),
     }
+}
+
+pub fn operator(receiver: &Pair, operator: &'static str) -> Symbol {
+    join!(receiver.namespace, CXXBRIDGE, receiver.cxx, operator)
 }
 
 // The C half of a function pointer trampoline.

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -15,7 +15,7 @@ use std::os::raw::c_char;
 
 #[cxx::bridge(namespace = "tests")]
 pub mod ffi {
-    #[derive(Clone, Debug)]
+    #[derive(Clone, Debug, PartialEq, Eq)]
     struct Shared {
         z: usize,
     }

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -653,6 +653,9 @@ extern "C" const char *cxx_run_test() noexcept {
 
   ASSERT(std::string(rAliasedFunction(2020)) == "2020");
 
+  ASSERT(Shared{1} == Shared{1});
+  ASSERT(Shared{1} != Shared{2});
+
   cxx_test_suite_set_correct();
   return nullptr;
 }


### PR DESCRIPTION
Part of #109.

```rust
#[cxx::bridge]
mod ffi {
    #[derive(PartialEq)]
    struct Struct {
        x: i32,
    }
}
```

```cpp
// generated

struct Struct final {
  int32_t x;

  bool operator==(const Struct &) const noexcept;
  bool operator!=(const Struct &) const noexcept;
};
```