### PR TITLE
Implement operator!= using a distinct symbol from operator==

### DIFF
--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -20,6 +20,7 @@ pub mod ffi {
         z: usize,
     }
 
+    #[derive(PartialEq)]
     struct SharedString {
         msg: String,
     }


### PR DESCRIPTION
The previous implementation from #518 wrongly assumed `operator!=` can be implemented as `!(*this == other)`. That's only the case if an `Eq` impl is present (in addition to the `PartialEq`). For example it is not true in the case of floats, which are PartialEq-only.

This PR adds a separate symbol for `operator!=` for types that may have no `Eq` impl.