### PR TITLE
Support derive(PartialOrd, Ord)

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -187,6 +187,49 @@ fn expand_struct_operators(strct: &Struct) -> TokenStream {
                     });
                 }
             }
+            Trait::PartialOrd => {
+                let link_name = mangle::operator(&strct.name, "__operator_lt");
+                let local_name = format_ident!("__operator_lt_{}", strct.name.rust);
+                operators.extend(quote_spanned! {span=>
+                    #[doc(hidden)]
+                    #[export_name = #link_name]
+                    extern "C" fn #local_name(lhs: &#ident, rhs: &#ident) -> bool {
+                        *lhs < *rhs
+                    }
+                });
+
+                let link_name = mangle::operator(&strct.name, "__operator_le");
+                let local_name = format_ident!("__operator_le_{}", strct.name.rust);
+                operators.extend(quote_spanned! {span=>
+                    #[doc(hidden)]
+                    #[export_name = #link_name]
+                    extern "C" fn #local_name(lhs: &#ident, rhs: &#ident) -> bool {
+                        *lhs <= *rhs
+                    }
+                });
+
+                if !derive::contains(&strct.derives, Trait::Ord) {
+                    let link_name = mangle::operator(&strct.name, "__operator_gt");
+                    let local_name = format_ident!("__operator_gt_{}", strct.name.rust);
+                    operators.extend(quote_spanned! {span=>
+                        #[doc(hidden)]
+                        #[export_name = #link_name]
+                        extern "C" fn #local_name(lhs: &#ident, rhs: &#ident) -> bool {
+                            *lhs > *rhs
+                        }
+                    });
+
+                    let link_name = mangle::operator(&strct.name, "__operator_ge");
+                    let local_name = format_ident!("__operator_ge_{}", strct.name.rust);
+                    operators.extend(quote_spanned! {span=>
+                        #[doc(hidden)]
+                        #[export_name = #link_name]
+                        extern "C" fn #local_name(lhs: &#ident, rhs: &#ident) -> bool {
+                            *lhs >= *rhs
+                        }
+                    });
+                }
+            }
             _ => {}
         }
     }

--- a/syntax/derive.rs
+++ b/syntax/derive.rs
@@ -12,7 +12,9 @@ pub enum Trait {
     Copy,
     Debug,
     Eq,
+    Ord,
     PartialEq,
+    PartialOrd,
 }
 
 impl Derive {
@@ -22,7 +24,9 @@ impl Derive {
             "Copy" => Trait::Copy,
             "Debug" => Trait::Debug,
             "Eq" => Trait::Eq,
+            "Ord" => Trait::Ord,
             "PartialEq" => Trait::PartialEq,
+            "PartialOrd" => Trait::PartialOrd,
             _ => return None,
         };
         let span = ident.span();

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -15,12 +15,12 @@ use std::os::raw::c_char;
 
 #[cxx::bridge(namespace = "tests")]
 pub mod ffi {
-    #[derive(Clone, Debug, PartialEq, Eq)]
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
     struct Shared {
         z: usize,
     }
 
-    #[derive(PartialEq)]
+    #[derive(PartialEq, PartialOrd)]
     struct SharedString {
         msg: String,
     }


### PR DESCRIPTION
Part of #109. This adds `operator<`, `operator<=`, `operator>`, `operator>=` for shared structs that derive PartialOrd.