### PR TITLE
Parse trait bounded extern types

### DIFF
--- a/gen/src/nested.rs
+++ b/gen/src/nested.rs
@@ -131,6 +131,8 @@ mod tests {
             derives: Vec::new(),
             type_token: Token![type](Span::call_site()),
             name: Pair::new(ns, Ident::new(ident, Span::call_site())),
+            colon_token: None,
+            bounds: Vec::new(),
             semi_token: Token![;](Span::call_site()),
             trusted: false,
         })

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -72,6 +72,8 @@ pub struct ExternType {
     pub derives: Vec<Derive>,
     pub type_token: Token![type],
     pub name: Pair,
+    pub colon_token: Option<Token![:]>,
+    pub bounds: Vec<Derive>,
     pub semi_token: Token![;],
     pub trusted: bool,
 }
@@ -108,6 +110,7 @@ pub struct ExternFn {
 
 pub struct TypeAlias {
     pub doc: Doc,
+    pub derives: Vec<Derive>,
     pub type_token: Token![type],
     pub name: Pair,
     pub eq_token: Token![=],

--- a/tests/ui/extern_type_bound.rs
+++ b/tests/ui/extern_type_bound.rs
@@ -1,0 +1,15 @@
+#[cxx::bridge]
+mod ffi {
+    extern "C++" {
+        type Opaque: PartialEq + PartialOrd;
+    }
+}
+
+#[cxx::bridge]
+mod ffi {
+    extern "C++" {
+        type Opaque: for<'de> Deserialize<'de>;
+    }
+}
+
+fn main() {}

--- a/tests/ui/extern_type_bound.stderr
+++ b/tests/ui/extern_type_bound.stderr
@@ -1,0 +1,11 @@
+error: extern type bounds are not implemented yet
+ --> $DIR/extern_type_bound.rs:4:22
+  |
+4 |         type Opaque: PartialEq + PartialOrd;
+  |                      ^^^^^^^^^^^^^^^^^^^^^^
+
+error: unsupported trait
+  --> $DIR/extern_type_bound.rs:11:22
+   |
+11 |         type Opaque: for<'de> Deserialize<'de>;
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Relevant to the second and third bullet of #109. We'll be using these to connect C++ operators for opaque Rust types and Rust trait impls for opaque C++ types.