### PR TITLE
boost::scoped_ptr demo

### DIFF
--- a/scoped_ptr_demo/Cargo.toml
+++ b/scoped_ptr_demo/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "scoped-ptr-demo"
+version = "0.0.0"
+edition = "2018"
+links = "scoped-ptr-demo"
+publish = false
+
+[dependencies]
+cxx = "1.0"
+
+[build-dependencies]
+cxx-build = "1.0"
+
+[workspace]

--- a/scoped_ptr_demo/build.rs
+++ b/scoped_ptr_demo/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    cxx_build::bridge("src/main.rs")
+        .file("src/demo.cc")
+        .flag_if_supported("-std=c++17")
+        .compile("scoped-ptr-demo");
+}

--- a/scoped_ptr_demo/include/demo.h
+++ b/scoped_ptr_demo/include/demo.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <boost/scoped_ptr.hpp>
+
+struct Class {
+  ~Class();
+  void print() const;
+  int32_t x;
+};
+
+using ScopedClass = boost::scoped_ptr<Class>;
+
+void run();

--- a/scoped_ptr_demo/src/demo.cc
+++ b/scoped_ptr_demo/src/demo.cc
@@ -1,0 +1,10 @@
+#include "scoped-ptr-demo/include/demo.h"
+#include "scoped-ptr-demo/src/main.rs.h"
+#include <iostream>
+
+Class::~Class() { std::cout << x << "::~Class " << std::endl; }
+void Class::print() const { std::cout << x << "::print" << std::endl; }
+
+void run() {
+  recv(boost::scoped_ptr{new Class{9}}, boost::scoped_ptr{new Class{1}});
+}

--- a/scoped_ptr_demo/src/main.rs
+++ b/scoped_ptr_demo/src/main.rs
@@ -1,0 +1,44 @@
+use cxx::ExternType;
+use std::ops::Deref;
+
+#[repr(transparent)]
+pub struct ScopedPtr<T>(*mut T);
+
+impl<T> Deref for ScopedPtr<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
+}
+
+unsafe impl ExternType for ScopedPtr<ffi::Class> {
+    type Id = cxx::type_id!("ScopedClass");
+    type Kind = cxx::kind::Opaque;
+}
+
+#[cxx::bridge]
+mod ffi {
+    unsafe extern "C++" {
+        include!("scoped-ptr-demo/include/demo.h");
+
+        type ScopedClass = crate::ScopedPtr<Class>;
+
+        fn run();
+
+        type Class;
+        fn print(self: &Class);
+    }
+
+    extern "Rust" {
+        fn recv(a: &ScopedClass, b: &ScopedClass);
+    }
+}
+
+fn recv(a: &ffi::ScopedClass, b: &ffi::ScopedClass) {
+    a.print();
+    b.print();
+}
+
+fn main() {
+    ffi::run();
+}


### PR DESCRIPTION
Example code in response to https://github.com/dtolnay/cxx/issues/251#issuecomment-735275024.

Note this line is using `cxx::kind::Opaque`:

https://github.com/dtolnay/cxx/blob/bb4fda0682611b11c494abee2ad752114e88058b/scoped_ptr_demo/src/main.rs#L16

because passing a boost::scoped_ptr by value across the FFI is not possible due to both of the following being true:

1. It uses the "small class" ABI in C++ which Rust has no representation for. Any Rust data structure will always either look like "small POD" or "big classes" as far as the ABI in C++.

2. It exposes no way to exit out of "small class" state (analogous to `unique_ptr<T>::release` which is what we use for making UniquePtr work by value on the language boundary).

For a different smart pointer for which one or both of these doesn't apply you'd probably use `cxx::kind::Trivial` because Rust's move semantics are non-problematic for anything pointer-like.