### PR TITLE
boost::scoped_ptr demo 2

### DIFF
--- a/scoped_ptr_demo/Cargo.toml
+++ b/scoped_ptr_demo/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "scoped-ptr-demo"
+version = "0.0.0"
+edition = "2018"
+links = "scoped-ptr-demo"
+publish = false
+
+[dependencies]
+cxx = "1.0"
+
+[build-dependencies]
+cxx-build = "1.0"
+
+[workspace]

--- a/scoped_ptr_demo/build.rs
+++ b/scoped_ptr_demo/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    cxx_build::bridge("src/main.rs")
+        .file("src/demo.cc")
+        .flag_if_supported("-std=c++17")
+        .compile("scoped-ptr-demo");
+}

--- a/scoped_ptr_demo/include/demo.h
+++ b/scoped_ptr_demo/include/demo.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <boost/scoped_ptr.hpp>
+#include <type_traits>
+
+template <typename T>
+class rust_scoped_ptr {
+public:
+  using IsRelocatable = std::true_type;
+  void drop_in_place() { this->~rust_scoped_ptr(); }
+  boost::scoped_ptr<T> ptr;
+  void *padding[2] = {};
+};
+
+struct Class {
+  ~Class();
+  void print() const;
+  int32_t x;
+};
+
+using ScopedClass = rust_scoped_ptr<Class>;
+
+rust_scoped_ptr<Class> getclass() noexcept;

--- a/scoped_ptr_demo/src/demo.cc
+++ b/scoped_ptr_demo/src/demo.cc
@@ -1,0 +1,10 @@
+#include "scoped-ptr-demo/include/demo.h"
+#include "scoped-ptr-demo/src/main.rs.h"
+#include <iostream>
+
+Class::~Class() { std::cout << x << "::~Class " << std::endl; }
+void Class::print() const { std::cout << x << "::print" << std::endl; }
+
+rust_scoped_ptr<Class> getclass() noexcept {
+  return {boost::scoped_ptr{new Class{9}}};
+}

--- a/scoped_ptr_demo/src/main.rs
+++ b/scoped_ptr_demo/src/main.rs
@@ -1,0 +1,55 @@
+use cxx::ExternType;
+use std::ops::Deref;
+
+#[repr(C)]
+pub struct ScopedPtr<T: ScopedPtrTarget> {
+    ptr: *mut T,
+    padding: [*const std::ffi::c_void; 2],
+}
+
+pub trait ScopedPtrTarget: Sized {
+    unsafe fn drop_in_place(ptr: &mut ScopedPtr<Self>);
+}
+
+impl<T: ScopedPtrTarget> Deref for ScopedPtr<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.ptr }
+    }
+}
+
+impl<T: ScopedPtrTarget> Drop for ScopedPtr<T> {
+    fn drop(&mut self) {
+        unsafe { T::drop_in_place(self) }
+    }
+}
+
+unsafe impl ExternType for ScopedPtr<ffi::Class> {
+    type Id = cxx::type_id!("ScopedClass");
+    type Kind = cxx::kind::Trivial;
+}
+
+impl ScopedPtrTarget for ffi::Class {
+    unsafe fn drop_in_place(ptr: &mut ScopedPtr<Self>) {
+        ptr.drop_in_place();
+    }
+}
+
+#[cxx::bridge]
+mod ffi {
+    unsafe extern "C++" {
+        include!("scoped-ptr-demo/include/demo.h");
+
+        type ScopedClass = crate::ScopedPtr<Class>;
+        unsafe fn drop_in_place(self: &mut ScopedClass);
+
+        fn getclass() -> ScopedClass;
+
+        type Class;
+        fn print(self: &Class);
+    }
+}
+
+fn main() {
+    ffi::getclass().print();
+}


### PR DESCRIPTION
Alternative to #524 which demonstrates a smart pointer for which item 1 in https://github.com/dtolnay/cxx/pull/524#issue-529004118 does not apply. This can be passed by value across the FFI.