### PR TITLE
Issue 487 minimal repro

### DIFF
--- a/issue-487/Cargo.toml
+++ b/issue-487/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "repro"
+version = "0.0.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+cxx = "1.0.2"
+
+[build-dependencies]
+cxx-build = "1.0.2"
+
+[workspace]

--- a/issue-487/build.rs
+++ b/issue-487/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    cxx_build::bridge("src/lib.rs")
+        .file("src/repro.cpp")
+        .flag_if_supported("-std=c++14")
+        .compile("issue-487");
+}

--- a/issue-487/src/lib.rs
+++ b/issue-487/src/lib.rs
@@ -1,0 +1,13 @@
+pub struct RustType;
+
+#[cxx::bridge]
+mod ffi {
+    extern "Rust" {
+        type RustType;
+        fn new_client() -> Box<RustType>;
+    }
+}
+
+fn new_client() -> Box<RustType> {
+    Box::new(RustType)
+}

--- a/issue-487/src/repro.cpp
+++ b/issue-487/src/repro.cpp
@@ -1,0 +1,7 @@
+#include "repro/src/lib.rs.h"
+#include <memory>
+
+void repro() {
+  std::shared_ptr<RustType> client = std::make_shared<RustType>(*new_client());
+  (void)client;
+}


### PR DESCRIPTION
#487 -- @venslu here's an example of stripping out unrelated code, like the dependency on tikv-client, async stuff, CxxVector stuff, etc. It reproduces the same error message but is a lot easier for someone else to help with.