### PR TITLE
Allow instance methods with same name on different types in same bridge

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -665,8 +665,14 @@ fn expand_rust_type_assert_sized(ety: &ExternType) -> TokenStream {
 
 fn expand_rust_function_shim(efn: &ExternFn, types: &Types) -> TokenStream {
     let link_name = mangle::extern_fn(efn, types);
-    let local_name = format_ident!("__{}", efn.name.rust);
-    let catch_unwind_label = format!("::{}", efn.name.rust);
+    let local_name = match &efn.receiver {
+        None => format_ident!("__{}", efn.name.rust),
+        Some(receiver) => format_ident!("__{}__{}", receiver.ty.rust, efn.name.rust),
+    };
+    let catch_unwind_label = match &efn.receiver {
+        None => format!("::{}", efn.name.rust),
+        Some(receiver) => format!("::{}::{}", receiver.ty.rust, efn.name.rust),
+    };
     let invoke = Some(&efn.name.rust);
     expand_rust_function_shim_impl(
         efn,


### PR DESCRIPTION
Fixes #471.