### PR TITLE
Allow un-pinned Trivial extern types to be passed by reference as arguments

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1,4 +1,3 @@
-use crate::gen::block::Block;
 use crate::gen::nested::NamespaceEntries;
 use crate::gen::out::OutFile;
 use crate::gen::{builtin, include, Opt};
@@ -8,6 +7,7 @@ use crate::syntax::{
     derive, mangle, Api, Enum, ExternFn, ExternType, Pair, RustName, Signature, Struct, Trait,
     Type, Types, Var,
 };
+use crate::{gen::block::Block, syntax::types::TrivialReason};
 use proc_macro2::Ident;
 use std::collections::{HashMap, HashSet};
 
@@ -117,8 +117,8 @@ fn write_data_structures<'a>(out: &mut OutFile<'a>, apis: &'a [Api]) {
     out.next_section();
     for api in apis {
         if let Api::TypeAlias(ety) = api {
-            if out.types.required_trivial.contains_key(&ety.name.rust) {
-                check_trivial_extern_type(out, &ety.name)
+            if let Some(reason) = out.types.required_trivial.get(&ety.name.rust) {
+                check_trivial_extern_type(out, &ety.name, reason)
             }
         }
     }
@@ -366,7 +366,7 @@ fn check_enum<'a>(out: &mut OutFile<'a>, enm: &'a Enum) {
     }
 }
 
-fn check_trivial_extern_type(out: &mut OutFile, id: &Pair) {
+fn check_trivial_extern_type(out: &mut OutFile, id: &Pair, reason: &TrivialReason) {
     // NOTE: The following static assertion is just nice-to-have and not
     // necessary for soundness. That's because triviality is always declared by
     // the user in the form of an unsafe impl of cxx::ExternType:
@@ -406,8 +406,9 @@ fn check_trivial_extern_type(out: &mut OutFile, id: &Pair) {
     writeln!(out, "    ::rust::IsRelocatable<{}>::value,", id);
     writeln!(
         out,
-        "    \"type {} marked as Trivial in Rust is not trivially move constructible and trivially destructible in C++\");",
+        "    \"type {} is not move constructible and trivially destructible in C++ yet is used as a trivial type in Rust ({})\");",
         id,
+        reason
     );
 }
 

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -324,13 +324,15 @@ fn check_api_type(cx: &mut Check, ety: &ExternType) {
         cx.error(span, "extern type bounds are not implemented yet");
     }
 
-    if let Some(reason) = cx.types.required_trivial.get(&ety.name.rust) {
-        let what = reason.describe_in_context(&ety);
-        let msg = format!(
-            "needs a cxx::ExternType impl in order to be used as {}",
-            what,
-        );
-        cx.error(ety, msg);
+    if let Some(reasons) = cx.types.required_trivial.get(&ety.name.rust) {
+        for reason in reasons {
+            let what = reason.describe_in_context(&ety);
+            let msg = format!(
+                "needs a cxx::ExternType impl in order to be used as {}",
+                what,
+            );
+            cx.error(ety, msg);
+        }
     }
 }
 

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -189,7 +189,7 @@ fn check_type_ref(cx: &mut Check, ty: &Ref) {
             cx.error(
                 ty,
                 format!(
-                    "mutable reference to C++ type requires a pin -- use Pin<&mut {}>",
+                    "mutable reference to C++ type requires a pin -- use Pin<&mut {}> or declare the type Trivial in a cxx::ExternType impl",
                     requires_pin,
                 ),
             );
@@ -332,6 +332,10 @@ fn check_api_type(cx: &mut Check, ety: &ExternType) {
             TrivialReason::FunctionReturn(efn) => format!("a return value of `{}`", efn.name.rust),
             TrivialReason::BoxTarget => format!("Box<{}>", ety.name.rust),
             TrivialReason::VecElement => format!("a vector element in Vec<{}>", ety.name.rust),
+            TrivialReason::UnpinnedMutableReferenceFunctionArgument(efn) => format!(
+                "a non-pinned mutable reference argument of {}",
+                efn.name.rust
+            ),
         };
         let msg = format!(
             "needs a cxx::ExternType impl in order to be used as {}",
@@ -385,7 +389,7 @@ fn check_api_fn(cx: &mut Check, efn: &ExternFn) {
             cx.error(
                 span,
                 format!(
-                    "mutable reference to C++ type requires a pin -- use `self: Pin<&mut {}>`",
+                    "mutable reference to opaque C++ type requires a pin -- use `self: Pin<&mut {}>` or declare the type Trivial in a cxx::ExternType impl",
                     receiver.ty.rust,
                 ),
             );

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -1,6 +1,5 @@
 use crate::syntax::atom::Atom::{self, *};
 use crate::syntax::report::Errors;
-use crate::syntax::types::TrivialReason;
 use crate::syntax::{
     error, ident, Api, Array, Enum, ExternFn, ExternType, Impl, Lang, Receiver, Ref, Signature,
     SliceRef, Struct, Trait, Ty1, Type, TypeAlias, Types,
@@ -326,17 +325,7 @@ fn check_api_type(cx: &mut Check, ety: &ExternType) {
     }
 
     if let Some(reason) = cx.types.required_trivial.get(&ety.name.rust) {
-        let what = match reason {
-            TrivialReason::StructField(strct) => format!("a field of `{}`", strct.name.rust),
-            TrivialReason::FunctionArgument(efn) => format!("an argument of `{}`", efn.name.rust),
-            TrivialReason::FunctionReturn(efn) => format!("a return value of `{}`", efn.name.rust),
-            TrivialReason::BoxTarget => format!("Box<{}>", ety.name.rust),
-            TrivialReason::VecElement => format!("a vector element in Vec<{}>", ety.name.rust),
-            TrivialReason::UnpinnedMutableReferenceFunctionArgument(efn) => format!(
-                "a non-pinned mutable reference argument of {}",
-                efn.name.rust
-            ),
-        };
+        let what = reason.describe_in_context(&ety);
         let msg = format!(
             "needs a cxx::ExternType impl in order to be used as {}",
             what,

--- a/tests/ffi/module.rs
+++ b/tests/ffi/module.rs
@@ -32,12 +32,16 @@ pub mod ffi2 {
 
         fn c_take_trivial_ptr(d: UniquePtr<D>);
         fn c_take_trivial_ref(d: &D);
+        fn c_take_trivial_ref_method(self: &D);
+        fn c_take_trivial_mut_ref_method(self: &mut D);
         fn c_take_trivial(d: D);
         fn c_take_trivial_ns_ptr(g: UniquePtr<G>);
         fn c_take_trivial_ns_ref(g: &G);
         fn c_take_trivial_ns(g: G);
         fn c_take_opaque_ptr(e: UniquePtr<E>);
         fn c_take_opaque_ref(e: &E);
+        fn c_take_opaque_ref_method(self: &E);
+        fn c_take_opaque_mut_ref_method(self: Pin<&mut E>);
         fn c_take_opaque_ns_ptr(e: UniquePtr<F>);
         fn c_take_opaque_ns_ref(e: &F);
         fn c_return_trivial_ptr() -> UniquePtr<D>;

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -529,6 +529,18 @@ void c_take_trivial_ref(const D &d) {
   }
 }
 
+void D::c_take_trivial_ref_method() const {
+  if (d == 30) {
+    cxx_test_suite_set_correct();
+  }
+}
+
+void D::c_take_trivial_mut_ref_method() {
+  if (d == 30) {
+    cxx_test_suite_set_correct();
+  }
+}
+
 void c_take_trivial(D d) {
   if (d.d == 30) {
     cxx_test_suite_set_correct();
@@ -567,6 +579,18 @@ void c_take_opaque_ns_ptr(std::unique_ptr<::F::F> f) {
 
 void c_take_opaque_ref(const E &e) {
   if (e.e == 40 && e.e_str == "hello") {
+    cxx_test_suite_set_correct();
+  }
+}
+
+void E::c_take_opaque_ref_method() const {
+  if (e == 40 && e_str == "hello") {
+    cxx_test_suite_set_correct();
+  }
+}
+
+void E::c_take_opaque_mut_ref_method() {
+  if (e == 40 && e_str == "hello") {
     cxx_test_suite_set_correct();
   }
 }

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -59,11 +59,15 @@ private:
 
 struct D {
   uint64_t d;
+  void c_take_trivial_ref_method() const;
+  void c_take_trivial_mut_ref_method();
 };
 
 struct E {
   uint64_t e;
   std::string e_str;
+  void c_take_opaque_ref_method() const;
+  void c_take_opaque_mut_ref_method();
 };
 
 enum COwnedEnum {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -263,10 +263,14 @@ fn test_rust_name_attribute() {
 
 #[test]
 fn test_extern_trivial() {
-    let d = ffi2::c_return_trivial();
+    let mut d = ffi2::c_return_trivial();
     check!(ffi2::c_take_trivial_ref(&d));
+    check!(d.c_take_trivial_ref_method());
+    check!(d.c_take_trivial_mut_ref_method());
     check!(ffi2::c_take_trivial(d));
-    let d = ffi2::c_return_trivial_ptr();
+    let mut d = ffi2::c_return_trivial_ptr();
+    check!(d.c_take_trivial_ref_method());
+    check!(d.c_take_trivial_mut_ref_method());
     check!(ffi2::c_take_trivial_ptr(d));
     cxx::UniquePtr::new(ffi2::D { d: 42 });
     let d = ffi2::ns_c_return_trivial();
@@ -282,8 +286,10 @@ fn test_extern_trivial() {
 
 #[test]
 fn test_extern_opaque() {
-    let e = ffi2::c_return_opaque_ptr();
+    let mut e = ffi2::c_return_opaque_ptr();
     check!(ffi2::c_take_opaque_ref(e.as_ref().unwrap()));
+    check!(e.c_take_opaque_ref_method());
+    check!(e.pin_mut().c_take_opaque_mut_ref_method());
     check!(ffi2::c_take_opaque_ptr(e));
 
     let f = ffi2::c_return_ns_opaque_ptr();

--- a/tests/ui/by_value_not_supported.stderr
+++ b/tests/ui/by_value_not_supported.stderr
@@ -22,6 +22,18 @@ error: needs a cxx::ExternType impl in order to be used as a field of `S`
 10 |         type C;
    |         ^^^^^^
 
+error: needs a cxx::ExternType impl in order to be used as an argument of `f`
+  --> $DIR/by_value_not_supported.rs:10:9
+   |
+10 |         type C;
+   |         ^^^^^^
+
+error: needs a cxx::ExternType impl in order to be used as a return value of `f`
+  --> $DIR/by_value_not_supported.rs:10:9
+   |
+10 |         type C;
+   |         ^^^^^^
+
 error: passing opaque C++ type by value is not supported
   --> $DIR/by_value_not_supported.rs:16:14
    |

--- a/tests/ui/pin_mut_opaque.stderr
+++ b/tests/ui/pin_mut_opaque.stderr
@@ -16,6 +16,12 @@ error: mutable reference to C++ type requires a pin -- use Pin<&mut CxxVector<..
 9 |         fn v(v: &mut CxxVector<u8>);
   |                 ^^^^^^^^^^^^^^^^^^
 
+error: needs a cxx::ExternType impl in order to be used as a non-pinned mutable reference argument of f
+ --> $DIR/pin_mut_opaque.rs:4:9
+  |
+4 |         type Opaque;
+  |         ^^^^^^^^^^^
+
 error: mutable reference to C++ type requires a pin -- use `self: Pin<&mut Opaque>`
  --> $DIR/pin_mut_opaque.rs:6:14
   |

--- a/tests/ui/pin_mut_opaque.stderr
+++ b/tests/ui/pin_mut_opaque.stderr
@@ -1,16 +1,16 @@
-error: mutable reference to C++ type requires a pin -- use Pin<&mut Opaque>
+error: mutable reference to C++ type requires a pin -- use Pin<&mut Opaque> or declare the type Trivial in a cxx::ExternType impl
  --> $DIR/pin_mut_opaque.rs:5:19
   |
 5 |         fn f(arg: &mut Opaque);
   |                   ^^^^^^^^^^^
 
-error: mutable reference to C++ type requires a pin -- use Pin<&mut CxxString>
+error: mutable reference to C++ type requires a pin -- use Pin<&mut CxxString> or declare the type Trivial in a cxx::ExternType impl
  --> $DIR/pin_mut_opaque.rs:8:17
   |
 8 |         fn s(s: &mut CxxString);
   |                 ^^^^^^^^^^^^^^
 
-error: mutable reference to C++ type requires a pin -- use Pin<&mut CxxVector<...>>
+error: mutable reference to C++ type requires a pin -- use Pin<&mut CxxVector<...>> or declare the type Trivial in a cxx::ExternType impl
  --> $DIR/pin_mut_opaque.rs:9:17
   |
 9 |         fn v(v: &mut CxxVector<u8>);
@@ -22,13 +22,25 @@ error: needs a cxx::ExternType impl in order to be used as a non-pinned mutable 
 4 |         type Opaque;
   |         ^^^^^^^^^^^
 
-error: mutable reference to C++ type requires a pin -- use `self: Pin<&mut Opaque>`
+error: needs a cxx::ExternType impl in order to be used as a non-pinned mutable reference argument of g
+ --> $DIR/pin_mut_opaque.rs:4:9
+  |
+4 |         type Opaque;
+  |         ^^^^^^^^^^^
+
+error: needs a cxx::ExternType impl in order to be used as a non-pinned mutable reference argument of h
+ --> $DIR/pin_mut_opaque.rs:4:9
+  |
+4 |         type Opaque;
+  |         ^^^^^^^^^^^
+
+error: mutable reference to opaque C++ type requires a pin -- use `self: Pin<&mut Opaque>` or declare the type Trivial in a cxx::ExternType impl
  --> $DIR/pin_mut_opaque.rs:6:14
   |
 6 |         fn g(&mut self);
   |              ^^^^^^^^^
 
-error: mutable reference to C++ type requires a pin -- use `self: Pin<&mut Opaque>`
+error: mutable reference to opaque C++ type requires a pin -- use `self: Pin<&mut Opaque>` or declare the type Trivial in a cxx::ExternType impl
  --> $DIR/pin_mut_opaque.rs:7:20
   |
 7 |         fn h(self: &mut Opaque);


### PR DESCRIPTION
Fixes #546. Fixes #549.