### PR TITLE
Limit instantiation of Vec and Box shims to local element type

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -961,6 +961,8 @@ fn expand_rust_box(ident: &RustName, types: &Types) -> TokenStream {
     let span = ident.span();
     quote_spanned! {span=>
         #[doc(hidden)]
+        unsafe impl ::cxx::private::ImplBox for #ident {}
+        #[doc(hidden)]
         #[export_name = #link_uninit]
         unsafe extern "C" fn #local_uninit(
             this: *mut ::std::boxed::Box<::std::mem::MaybeUninit<#ident>>,
@@ -999,6 +1001,8 @@ fn expand_rust_vec(elem: &RustName, types: &Types) -> TokenStream {
 
     let span = elem.span();
     quote_spanned! {span=>
+        #[doc(hidden)]
+        unsafe impl ::cxx::private::ImplVec for #elem {}
         #[doc(hidden)]
         #[export_name = #link_new]
         unsafe extern "C" fn #local_new(this: *mut ::cxx::private::RustVec<#elem>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,7 +448,7 @@ pub mod private {
     pub use crate::rust_slice::RustSlice;
     pub use crate::rust_str::RustStr;
     pub use crate::rust_string::RustString;
-    pub use crate::rust_type::RustType;
+    pub use crate::rust_type::{ImplBox, ImplVec, RustType};
     pub use crate::rust_vec::RustVec;
     pub use crate::shared_ptr::SharedPtrTarget;
     pub use crate::unique_ptr::UniquePtrTarget;

--- a/src/rust_type.rs
+++ b/src/rust_type.rs
@@ -1,1 +1,3 @@
 pub unsafe trait RustType {}
+pub unsafe trait ImplBox {}
+pub unsafe trait ImplVec {}


### PR DESCRIPTION
This fixes a hole in the combination of #541 + #542 (which is why I'd excluded those PRs from the most recent release).

Without this restriction, the following crates would have typechecked but caused duplicate symbols which is UB:

```rust
// crate A

#[cxx::bridge]
mod ffi {
    struct S { x: i32 }
}
```

```rust
// crate B which depends on A

#[cxx::bridge]
mod ffi {
    extern "C++" {
        type S = a::S;
    }
    impl Vec<S> {}
}
```

```rust
// crate C which depends on A

#[cxx::bridge]
mod ffi {
    extern "C++" {
        type S = a::S;
    }
    impl Vec<S> {}
}
```

The nonlocal types design described in https://github.com/dtolnay/cxx/issues/496#issuecomment-736253352 prohibits the code in crates B and C (`unsafe impl Vec<S>` would be required for a nonlocal type `S`) but is not implemented yet. For now this PR is a pretty blunt restriction and will get substantially relaxed as #496 gets implemented.