### PR TITLE
Include <functional> when deriving Hash impl shim

### DIFF
--- a/gen/src/include.rs
+++ b/gen/src/include.rs
@@ -27,6 +27,7 @@ pub struct Includes<'a> {
     pub cstdint: bool,
     pub cstring: bool,
     pub exception: bool,
+    pub functional: bool,
     pub initializer_list: bool,
     pub iterator: bool,
     pub memory: bool,
@@ -77,6 +78,7 @@ pub(super) fn write(out: &mut OutFile) {
         cstdint,
         cstring,
         exception,
+        functional,
         initializer_list,
         iterator,
         memory,
@@ -106,6 +108,9 @@ pub(super) fn write(out: &mut OutFile) {
     }
     if exception {
         writeln!(out, "#include <exception>");
+    }
+    if functional {
+        writeln!(out, "#include <functional>");
     }
     if initializer_list {
         writeln!(out, "#include <initializer_list>");

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -158,6 +158,7 @@ fn write_std_specializations(out: &mut OutFile, apis: &[Api]) {
         if let Api::Struct(strct) = api {
             if derive::contains(&strct.derives, Trait::Hash) {
                 out.next_section();
+                out.include.functional = true;
                 let qualified = strct.name.to_fully_qualified();
                 writeln!(out, "template <> struct hash<{}> {{", qualified);
                 writeln!(


### PR DESCRIPTION
Otherwise:

```rust
#[cxx::bridge]
mod ffi {
    #[derive(Hash)]
    struct S { x: usize }
}
```

```console
example-2a7c49ac8bd0f12e/out/cxxbridge/sources/example/src/main.rs.cc:17:20: error: ‘hash’ is not a class template
   17 | template <> struct hash<::S> {
      |                    ^~~~
example-2a7c49ac8bd0f12e/out/cxxbridge/sources/example/src/main.rs.cc:17:30: error: explicit specialization of non-template ‘std::hash’
   17 | template <> struct hash<::S> {
      |                              ^
```