### PR TITLE
Delete private Box default constructor

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1348,8 +1348,8 @@ fn write_rust_box_extern(out: &mut OutFile, ident: &Pair) {
     writeln!(out, "#define CXXBRIDGE1_RUST_BOX_{}", instance);
     writeln!(
         out,
-        "void cxxbridge1$box${}$uninit(::rust::Box<{}> *ptr) noexcept;",
-        instance, inner,
+        "{} *cxxbridge1$box${}$alloc() noexcept;",
+        inner, instance,
     );
     writeln!(
         out,
@@ -1415,8 +1415,8 @@ fn write_rust_box_impl(out: &mut OutFile, ident: &Pair) {
     let instance = ident.to_symbol();
 
     writeln!(out, "template <>");
-    writeln!(out, "void Box<{}>::uninit() noexcept {{", inner);
-    writeln!(out, "  cxxbridge1$box${}$uninit(this);", instance);
+    writeln!(out, "{} *Box<{}>::alloc() noexcept {{", inner, inner);
+    writeln!(out, "  return cxxbridge1$box${}$alloc();", instance);
     writeln!(out, "}}");
 
     writeln!(out, "template <>");

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -951,11 +951,11 @@ fn type_id(name: &Pair) -> TokenStream {
 
 fn expand_rust_box(ident: &RustName, types: &Types) -> TokenStream {
     let link_prefix = format!("cxxbridge1$box${}$", types.resolve(ident).to_symbol());
-    let link_uninit = format!("{}uninit", link_prefix);
+    let link_alloc = format!("{}alloc", link_prefix);
     let link_drop = format!("{}drop", link_prefix);
 
     let local_prefix = format_ident!("{}__box_", &ident.rust);
-    let local_uninit = format_ident!("{}uninit", local_prefix);
+    let local_alloc = format_ident!("{}alloc", local_prefix);
     let local_drop = format_ident!("{}drop", local_prefix);
 
     let span = ident.span();
@@ -963,14 +963,9 @@ fn expand_rust_box(ident: &RustName, types: &Types) -> TokenStream {
         #[doc(hidden)]
         unsafe impl ::cxx::private::ImplBox for #ident {}
         #[doc(hidden)]
-        #[export_name = #link_uninit]
-        unsafe extern "C" fn #local_uninit(
-            this: *mut ::std::boxed::Box<::std::mem::MaybeUninit<#ident>>,
-        ) {
-            ::std::ptr::write(
-                this,
-                ::std::boxed::Box::new(::std::mem::MaybeUninit::uninit()),
-            );
+        #[export_name = #link_alloc]
+        unsafe extern "C" fn #local_alloc() -> *mut ::std::mem::MaybeUninit<#ident> {
+            ::std::boxed::Box::into_raw(::std::boxed::Box::new(::std::mem::MaybeUninit::uninit()))
         }
         #[doc(hidden)]
         #[export_name = #link_drop]


### PR DESCRIPTION
This produces *maybe* a slightly better diagnostic, but more importantly the new arrangement is more amenable to fixing #570 because it makes it possible to run a T constructor prior to any rust::Box instance existing in C++ yet.

Before:

```console
src/example.cc: In function ‘void test()’:
src/example.cc:12:21: error: ‘rust::cxxbridge1::Box<T>::Box() [with T = Struct]’ is private within this context
   12 |   rust::Box<Struct> box;
      |                     ^~~
In file included from src/example.cc:1:
example-ecfac19134395bcc/out/cxxbridge/include/example/src/main.rs.h:145:1: note: declared private here
  145 | Box<T>::Box() noexcept = default;
      | ^~~~~~
```

After:

```console
src/example.cc: In function ‘void test()’:
src/example.cc:12:21: error: use of deleted function ‘rust::cxxbridge1::Box<T>::Box() [with T = Struct]’
   12 |   rust::Box<Struct> box;
      |                     ^~~
In file included from src/example.cc:1:
example-ecfac19134395bcc/out/cxxbridge/include/example/src/main.rs.h:22:3: note: declared here
   22 |   Box() = delete;
      |   ^~~
```