### PR TITLE
Fix uninitialized Drop on exception in rust::Box<T>::in_place

### DIFF
--- a/include/cxx.h
+++ b/include/cxx.h
@@ -621,10 +621,7 @@ T &Box<T>::operator*() noexcept {
 template <typename T>
 template <typename... Fields>
 Box<T> Box<T>::in_place(Fields &&... fields) {
-  Box box = uninit{};
-  box.ptr = alloc();
-  ::new (box.ptr) T{std::forward<Fields>(fields)...};
-  return box;
+  return from_raw(::new (alloc()) T{std::forward<Fields>(fields)...});
 }
 
 template <typename T>


### PR DESCRIPTION
Fixes part of #570. This still leaks if T's constructor throws but Rust considers that safe and it will be fixed separately.