### PR TITLE
Expose public vector module

### DIFF
--- a/src/cxx_vector.rs
+++ b/src/cxx_vector.rs
@@ -1,3 +1,6 @@
+//! Less used details of `CxxVector` are exposed in this module. `CxxVector`
+//! itself is exposed at the crate root.
+
 use crate::extern_type::ExternType;
 use crate::kind::Trivial;
 use crate::string::CxxString;
@@ -7,6 +10,9 @@ use core::marker::{PhantomData, PhantomPinned};
 use core::mem;
 use core::ptr;
 use core::slice;
+
+#[doc(inline)]
+pub use crate::Vector;
 
 /// Binding to C++ `std::vector<T, std::allocator<T>>`.
 ///
@@ -94,6 +100,9 @@ where
     }
 }
 
+/// Iterator over elements of a `CxxVector` by shared reference.
+///
+/// The iterator element type is `&'a T`.
 pub struct Iter<'a, T> {
     v: &'a CxxVector<T>,
     index: usize,
@@ -133,7 +142,7 @@ where
     }
 }
 
-pub struct TypeName<T> {
+pub(crate) struct TypeName<T> {
     element: PhantomData<T>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,13 +409,14 @@ mod symbols;
 mod unique_ptr;
 mod unwind;
 #[path = "cxx_vector.rs"]
-mod vector;
+pub mod vector;
 
 pub use crate::exception::Exception;
 pub use crate::extern_type::{kind, ExternType};
 pub use crate::shared_ptr::SharedPtr;
 pub use crate::string::CxxString;
 pub use crate::unique_ptr::UniquePtr;
+#[doc(inline)]
 pub use crate::vector::CxxVector;
 pub use cxxbridge_macro::bridge;
 


### PR DESCRIPTION
This change doesn't yet expose a VectorElement trait as needed by #547, but this module is where that would be exposed. For now the only newly accessible API is the shared reference iterator `cxx::vector::Iter` which matches the convention of how e.g. [`std::slice::Iter`](https://doc.rust-lang.org/std/slice/struct.Iter.html) and [`std::collections::hash_map::Iter`](https://doc.rust-lang.org/std/collections/hash_map/struct.Iter.html) are named.