### PR TITLE
Consider mut receiver for allowing mut C++ return type

### DIFF
--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -464,6 +464,12 @@ fn check_mut_return_restriction(cx: &mut Check, efn: &ExternFn) {
         _ => return,
     }
 
+    if let Some(r) = &efn.receiver {
+        if r.mutable {
+            return;
+        }
+    }
+
     for arg in &efn.args {
         if let Type::Ref(ty) = &arg.ty {
             if ty.mutable {

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -165,9 +165,13 @@ pub mod ffi {
         fn get(self: &C) -> usize;
         fn set(self: Pin<&mut C>, n: usize) -> usize;
         fn get2(&self) -> usize;
+        fn getRef(self: &C) -> &usize;
+        fn getMut(self: Pin<&mut C>) -> &mut usize;
         fn set_succeed(self: Pin<&mut C>, n: usize) -> Result<usize>;
         fn get_fail(self: Pin<&mut C>) -> Result<usize>;
         fn c_method_on_shared(self: &Shared) -> usize;
+        fn c_method_ref_on_shared(self: &Shared) -> &usize;
+        fn c_method_mut_on_shared(self: &mut Shared) -> &mut usize;
         fn c_set_array(self: &mut Array, value: i32);
 
         #[rust_name = "i32_overloaded_method"]

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -22,6 +22,10 @@ size_t C::get() const { return this->n; }
 
 size_t C::get2() const { return this->n; }
 
+const size_t &C::getRef() const { return this->n; }
+
+size_t &C::getMut() { return this->n; }
+
 size_t C::set(size_t n) {
   this->n = n;
   return this->n;
@@ -32,6 +36,12 @@ size_t C::set_succeed(size_t n) { return this->set(n); }
 size_t C::get_fail() { throw std::runtime_error("unimplemented"); }
 
 size_t Shared::c_method_on_shared() const noexcept { return 2021; }
+
+const size_t &Shared::c_method_ref_on_shared() const noexcept {
+  return this->z;
+}
+
+size_t &Shared::c_method_mut_on_shared() noexcept { return this->z; }
 
 void Array::c_set_array(int32_t val) noexcept {
   this->a = {val, val, val, val};

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -45,6 +45,8 @@ public:
   size_t get() const;
   size_t set(size_t n);
   size_t get2() const;
+  const size_t &getRef() const;
+  size_t &getMut();
   size_t set_succeed(size_t n);
   size_t get_fail();
   const std::vector<uint8_t> &get_v() const;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -210,9 +210,13 @@ fn test_c_method_calls() {
     assert_eq!(2021, unique_ptr.pin_mut().set(2021));
     assert_eq!(2021, unique_ptr.get());
     assert_eq!(2021, unique_ptr.get2());
+    assert_eq!(2021, *unique_ptr.getRef());
+    assert_eq!(2021, *unique_ptr.pin_mut().getMut());
     assert_eq!(2022, unique_ptr.pin_mut().set_succeed(2022).unwrap());
     assert!(unique_ptr.pin_mut().get_fail().is_err());
     assert_eq!(2021, ffi::Shared { z: 0 }.c_method_on_shared());
+    assert_eq!(2022, *ffi::Shared { z: 2022 }.c_method_ref_on_shared());
+    assert_eq!(2023, *ffi::Shared { z: 2023 }.c_method_mut_on_shared());
 
     let val = 42;
     let mut array = ffi::Array { a: [0, 0, 0, 0] };


### PR DESCRIPTION
Fixes #583.