### PR TITLE
Add mutable indexing for CxxVector

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1737,10 +1737,10 @@ fn write_cxx_vector(out: &mut OutFile, element: &RustName) {
     writeln!(out, "}}");
     writeln!(
         out,
-        "const {} *cxxbridge1$std$vector${}$get_unchecked(const ::std::vector<{}> &s, ::std::size_t pos) noexcept {{",
+        "{} *cxxbridge1$std$vector${}$get_unchecked(::std::vector<{}> *s, ::std::size_t pos) noexcept {{",
         inner, instance, inner,
     );
-    writeln!(out, "  return &s[pos];");
+    writeln!(out, "  return &(*s)[pos];");
     writeln!(out, "}}");
 
     out.include.memory = true;

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1229,10 +1229,10 @@ fn expand_cxx_vector(elem: &RustName, explicit_impl: Option<&Impl>, types: &Type
                 }
                 unsafe { __vector_size(v) }
             }
-            unsafe fn __get_unchecked(v: &::cxx::CxxVector<Self>, pos: usize) -> *const Self {
+            unsafe fn __get_unchecked(v: *mut ::cxx::CxxVector<Self>, pos: usize) -> *mut Self {
                 extern "C" {
                     #[link_name = #link_get_unchecked]
-                    fn __get_unchecked(_: &::cxx::CxxVector<#elem>, _: usize) -> *const #elem;
+                    fn __get_unchecked(_: *mut ::cxx::CxxVector<#elem>, _: usize) -> *mut #elem;
                 }
                 __get_unchecked(v, pos)
             }

--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -408,9 +408,9 @@ static_assert(sizeof(std::string) <= kMaxExpectedWordsInString * sizeof(void *),
       const std::vector<CXX_TYPE> &s) noexcept {                               \
     return s.size();                                                           \
   }                                                                            \
-  const CXX_TYPE *cxxbridge1$std$vector$##RUST_TYPE##$get_unchecked(           \
-      const std::vector<CXX_TYPE> &s, std::size_t pos) noexcept {              \
-    return &s[pos];                                                            \
+  CXX_TYPE *cxxbridge1$std$vector$##RUST_TYPE##$get_unchecked(                 \
+      std::vector<CXX_TYPE> *s, std::size_t pos) noexcept {                    \
+    return &(*s)[pos];                                                         \
   }                                                                            \
   void cxxbridge1$unique_ptr$std$vector$##RUST_TYPE##$null(                    \
       std::unique_ptr<std::vector<CXX_TYPE>> *ptr) noexcept {                  \


### PR DESCRIPTION
```diff
  impl<T> CxxVector<T> {
      ...

+     pub fn get_mut(&mut self, pos: usize) -> Option<Pin<&mut T>>;
+     pub unsafe fn get_unchecked_mut(&mut self, pos: usize) -> Pin<&mut T>;
  }
```