### PR TITLE
Emit private layout struct for all opaque types

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -311,22 +311,32 @@ fn write_opaque_type<'a>(out: &mut OutFile<'a>, ety: &'a ExternType, methods: &[
     for line in ety.doc.to_string().lines() {
         writeln!(out, "//{}", line);
     }
+
     out.builtin.opaque = true;
-    write!(
+    writeln!(
         out,
         "struct {} final : public ::rust::Opaque {{",
         ety.name.cxx,
     );
+
     for method in methods {
-        write!(out, "\n  ");
+        write!(out, "  ");
         let sig = &method.sig;
         let local_name = method.name.cxx.to_string();
         write_rust_function_shim_decl(out, &local_name, sig, false);
-        write!(out, ";");
+        writeln!(out, ";");
     }
+
     if !methods.is_empty() {
         writeln!(out);
     }
+
+    out.include.cstddef = true;
+    writeln!(out, "private:");
+    writeln!(out, "  struct layout {{");
+    writeln!(out, "    static ::std::size_t size() noexcept;");
+    writeln!(out, "    static ::std::size_t align() noexcept;");
+    writeln!(out, "  }};");
     writeln!(out, "}};");
     writeln!(out, "#endif // {}", guard);
 }

--- a/tests/ui/opaque_not_sized.stderr
+++ b/tests/ui/opaque_not_sized.stderr
@@ -9,3 +9,21 @@ error[E0277]: the size for values of type `str` cannot be known at compilation t
   |
   = help: within `TypeR`, the trait `Sized` is not implemented for `str`
   = note: required because it appears within the type `TypeR`
+
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+   --> $DIR/opaque_not_sized.rs:4:14
+    |
+4   |         type TypeR;
+    |              ^^^^^ doesn't have a size known at compile-time
+    |
+    = help: within `TypeR`, the trait `Sized` is not implemented for `str`
+    = note: required because it appears within the type `TypeR`
+
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+   --> $DIR/opaque_not_sized.rs:4:14
+    |
+4   |         type TypeR;
+    |              ^^^^^ doesn't have a size known at compile-time
+    |
+    = help: within `TypeR`, the trait `Sized` is not implemented for `str`
+    = note: required because it appears within the type `TypeR`


### PR DESCRIPTION
The generated code looks like:

```rust
// input

#[cxx::bridge]
mod ffi {
    extern "Rust" {
        type MyStruct;
    }
}
```

```cpp
// generated

struct MyStruct final : public ::rust::Opaque {
private:
  struct layout {
    static ::std::size_t size() noexcept;
    static ::std::size_t align() noexcept;
  };
};
```

The accessors are private so it's not directly usable right away but I'll be adding some `friend` items in a separate PR which builds on top of these.