### PR TITLE
Add rust::size_of, align_of accessors that work for opaque types

### DIFF
--- a/gen/src/builtin.rs
+++ b/gen/src/builtin.rs
@@ -13,6 +13,7 @@ pub struct Builtins<'a> {
     pub rust_fn: bool,
     pub rust_isize: bool,
     pub opaque: bool,
+    pub layout: bool,
     pub unsafe_bitcopy: bool,
     pub rust_error: bool,
     pub manually_drop: bool,
@@ -102,6 +103,12 @@ pub(super) fn write(out: &mut OutFile) {
         include.type_traits = true;
     }
 
+    if builtin.layout {
+        include.type_traits = true;
+        include.cstddef = true;
+        builtin.is_complete = true;
+    }
+
     if builtin.is_complete {
         include.cstddef = true;
         include.type_traits = true;
@@ -125,9 +132,12 @@ pub(super) fn write(out: &mut OutFile) {
         out.end_block(Block::AnonymousNamespace);
     }
 
+    out.next_section();
     if builtin.rust_str && !builtin.rust_string {
-        out.next_section();
         writeln!(out, "class String;");
+    }
+    if builtin.layout && !builtin.opaque {
+        writeln!(out, "class Opaque;");
     }
 
     ifndef::write(out, builtin.rust_string, "CXXBRIDGE1_RUST_STRING");
@@ -140,8 +150,9 @@ pub(super) fn write(out: &mut OutFile) {
     ifndef::write(out, builtin.rust_error, "CXXBRIDGE1_RUST_ERROR");
     ifndef::write(out, builtin.rust_isize, "CXXBRIDGE1_RUST_ISIZE");
     ifndef::write(out, builtin.opaque, "CXXBRIDGE1_RUST_OPAQUE");
-    ifndef::write(out, builtin.relocatable, "CXXBRIDGE1_RELOCATABLE");
     ifndef::write(out, builtin.is_complete, "CXXBRIDGE1_IS_COMPLETE");
+    ifndef::write(out, builtin.layout, "CXXBRIDGE1_LAYOUT");
+    ifndef::write(out, builtin.relocatable, "CXXBRIDGE1_RELOCATABLE");
 
     out.begin_block(Block::Namespace("detail"));
 

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -333,8 +333,10 @@ fn write_opaque_type<'a>(out: &mut OutFile<'a>, ety: &'a ExternType, methods: &[
         writeln!(out);
     }
 
+    out.builtin.layout = true;
     out.include.cstddef = true;
     writeln!(out, "private:");
+    writeln!(out, "  friend ::rust::layout;");
     writeln!(out, "  struct layout {{");
     writeln!(out, "    static ::std::size_t size() noexcept;");
     writeln!(out, "    static ::std::size_t align() noexcept;");

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -668,6 +668,11 @@ extern "C" const char *cxx_run_test() noexcept {
     }                                                                          \
   } while (false)
 
+  ASSERT(rust::size_of<R>() == sizeof(size_t));
+  ASSERT(rust::align_of<R>() == alignof(size_t));
+  ASSERT(rust::size_of<size_t>() == sizeof(size_t));
+  ASSERT(rust::align_of<size_t>() == alignof(size_t));
+
   ASSERT(r_return_primitive() == 2020);
   ASSERT(r_return_shared().z == 2020);
   ASSERT(cxx_test_suite_r_is_correct(&*r_return_box()));


### PR DESCRIPTION
```diff
  namespace rust {
+ template <typename T> size_t size_of();
+ template <typename T> size_t align_of();
  }
```

Using `rust::size_of<T>()` / `rust::align_of<T>()` produces an accurate size/align for opaque Rust types (via the symbols from #595) as well as shared data structures and native C++ types.

Support for opaque Rust types in slices (#532) can be easily implemented on top of these.