### PR TITLE
Add checked and unchecked indexing to rust::Slice

### DIFF
--- a/book/src/binding/slice.md
+++ b/book/src/binding/slice.md
@@ -25,6 +25,12 @@ public:
   T *data() const noexcept;
   size_t size() const noexcept;
   size_t length() const noexcept;
+  bool empty() const noexcept;
+
+  T &operator[](size_t n) const noexcept;
+  T &at(size_t n) const;
+  T &front() const noexcept;
+  T &back() const noexcept;
 
   class iterator;
   iterator begin() const noexcept;

--- a/gen/src/builtin.rs
+++ b/gen/src/builtin.rs
@@ -64,6 +64,7 @@ pub(super) fn write(out: &mut OutFile) {
         include.iterator = true;
         include.type_traits = true;
         builtin.friend_impl = true;
+        builtin.panic = true;
     }
 
     if builtin.rust_box {

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -156,6 +156,12 @@ public:
   T *data() const noexcept;
   std::size_t size() const noexcept;
   std::size_t length() const noexcept;
+  bool empty() const noexcept;
+
+  T &operator[](std::size_t n) const noexcept;
+  T &at(std::size_t n) const;
+  T &front() const noexcept;
+  T &back() const noexcept;
 
   // Important in order for System V ABI to pass in registers.
   Slice(const Slice<T> &) noexcept = default;
@@ -517,6 +523,37 @@ std::size_t Slice<T>::size() const noexcept {
 template <typename T>
 std::size_t Slice<T>::length() const noexcept {
   return this->len;
+}
+
+template <typename T>
+bool Slice<T>::empty() const noexcept {
+  return this->len == 0;
+}
+
+template <typename T>
+T &Slice<T>::operator[](std::size_t n) const noexcept {
+  assert(n < this->size());
+  return this->ptr[n];
+}
+
+template <typename T>
+T &Slice<T>::at(std::size_t n) const {
+  if (n >= this->size()) {
+    panic<std::out_of_range>("rust::Slice index out of range");
+  }
+  return (*this)[n];
+}
+
+template <typename T>
+T &Slice<T>::front() const noexcept {
+  assert(!this->empty());
+  return this->ptr[0];
+}
+
+template <typename T>
+T &Slice<T>::back() const noexcept {
+  assert(!this->empty());
+  return this->ptr[this->len - 1];
 }
 
 template <typename T>

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -274,7 +274,8 @@ void c_take_slice_char(rust::Slice<const char> s) {
 }
 
 void c_take_slice_shared(rust::Slice<const Shared> s) {
-  if (s.size() == 2 && s.data()->z == 2020 && (s.data() + 1)->z == 2021) {
+  if (s.size() == 2 && s.data()->z == 2020 && s[1].z == 2021 &&
+      s.at(1).z == 2021 && s.front().z == 2020 && s.back().z == 2021) {
     cxx_test_suite_set_correct();
   }
 }


### PR DESCRIPTION
```diff
  template <typename T>
  class Slice {
  public:
    ...
+   bool empty() const noexcept;
+   T &operator[](size_t n) const noexcept;
+   T &at(size_t n) const;
+   T &front() const noexcept;
+   T &back() const noexcept;
  };
```