### PR TITLE
Obtain Slice iterator stride in a way that works for opaque types

### DIFF
--- a/gen/src/builtin.rs
+++ b/gen/src/builtin.rs
@@ -64,6 +64,7 @@ pub(super) fn write(out: &mut OutFile) {
         include.iterator = true;
         include.type_traits = true;
         builtin.friend_impl = true;
+        builtin.layout = true;
         builtin.panic = true;
     }
 
@@ -139,6 +140,12 @@ pub(super) fn write(out: &mut OutFile) {
     }
     if builtin.layout && !builtin.opaque {
         writeln!(out, "class Opaque;");
+    }
+
+    if builtin.rust_slice {
+        out.next_section();
+        writeln!(out, "template <typename T>");
+        writeln!(out, "::std::size_t size_of();");
     }
 
     ifndef::write(out, builtin.rust_string, "CXXBRIDGE1_RUST_STRING");

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -689,7 +689,7 @@ template <typename T>
 typename Slice<T>::iterator Slice<T>::begin() const noexcept {
   iterator it;
   it.pos = const_cast<typename std::remove_const<T>::type *>(this->ptr);
-  it.stride = sizeof(T);
+  it.stride = size_of<T>();
   return it;
 }
 


### PR DESCRIPTION
Part of #532, building on #597 and #600.