### PR TITLE
Obtain accurate alignment for empty slice of opaque Rust type

### DIFF
--- a/gen/src/builtin.rs
+++ b/gen/src/builtin.rs
@@ -146,6 +146,8 @@ pub(super) fn write(out: &mut OutFile) {
         out.next_section();
         writeln!(out, "template <typename T>");
         writeln!(out, "::std::size_t size_of();");
+        writeln!(out, "template <typename T>");
+        writeln!(out, "::std::size_t align_of();");
     }
 
     ifndef::write(out, builtin.rust_string, "CXXBRIDGE1_RUST_STRING");

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -521,7 +521,8 @@ inline std::size_t Str::length() const noexcept { return this->len; }
 #ifndef CXXBRIDGE1_RUST_SLICE
 #define CXXBRIDGE1_RUST_SLICE
 template <typename T>
-Slice<T>::Slice() noexcept : ptr(reinterpret_cast<T *>(alignof(T))), len(0) {}
+Slice<T>::Slice() noexcept
+    : ptr(reinterpret_cast<T *>(align_of<T>())), len(0) {}
 
 template <typename T>
 Slice<T>::Slice(T *s, std::size_t count) noexcept : ptr(s), len(count) {}


### PR DESCRIPTION
Rust requires that references are always sufficiently aligned. We don't yet allow slices of opaque Rust types to exist on the language boundary, but once we do (#532), we will need empty slices instantiated by C++ to have sufficient alignment. Without this change, C++ would think `alignof(T)` is 1 for opaque Rust types and passing an empty slice from C++ to Rust would be UB if the real alignment were higher than 1.