### PR TITLE
Eliminate Vec stride symbol in favor of size_of

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1465,11 +1465,6 @@ fn write_rust_vec_extern(out: &mut OutFile, element: &RustName) {
         "void cxxbridge1$rust_vec${}$set_len(::rust::Vec<{}> *ptr, ::std::size_t len) noexcept;",
         instance, inner,
     );
-    writeln!(
-        out,
-        "::std::size_t cxxbridge1$rust_vec${}$stride() noexcept;",
-        instance,
-    );
     writeln!(out, "#endif // CXXBRIDGE1_RUST_VEC_{}", instance);
 }
 
@@ -1568,11 +1563,6 @@ fn write_rust_vec_impl(out: &mut OutFile, element: &RustName) {
         "  return cxxbridge1$rust_vec${}$set_len(this, len);",
         instance,
     );
-    writeln!(out, "}}");
-
-    writeln!(out, "template <>");
-    writeln!(out, "::std::size_t Vec<{}>::stride() noexcept {{", inner);
-    writeln!(out, "  return cxxbridge1$rust_vec${}$stride();", instance);
     writeln!(out, "}}");
 }
 

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -313,7 +313,6 @@ public:
   Vec(unsafe_bitcopy_t, const Vec &) noexcept;
 
 private:
-  static std::size_t stride() noexcept;
   void reserve_total(std::size_t cap) noexcept;
   void set_len(std::size_t len) noexcept;
   void drop() noexcept;
@@ -883,7 +882,7 @@ template <typename T>
 const T &Vec<T>::operator[](std::size_t n) const noexcept {
   assert(n < this->size());
   auto data = reinterpret_cast<const char *>(this->data());
-  return *reinterpret_cast<const T *>(data + n * this->stride());
+  return *reinterpret_cast<const T *>(data + n * size_of<T>());
 }
 
 template <typename T>
@@ -910,7 +909,7 @@ template <typename T>
 T &Vec<T>::operator[](std::size_t n) noexcept {
   assert(n < this->size());
   auto data = reinterpret_cast<char *>(this->data());
-  return *reinterpret_cast<T *>(data + n * this->stride());
+  return *reinterpret_cast<T *>(data + n * size_of<T>());
 }
 
 template <typename T>
@@ -954,7 +953,7 @@ void Vec<T>::emplace_back(Args &&... args) {
   auto size = this->size();
   this->reserve_total(size + 1);
   ::new (reinterpret_cast<T *>(reinterpret_cast<char *>(this->data()) +
-                               size * this->stride()))
+                               size * size_of<T>()))
       T(std::forward<Args>(args)...);
   this->set_len(size + 1);
 }
@@ -1076,7 +1075,7 @@ template <typename T>
 typename Vec<T>::iterator Vec<T>::begin() noexcept {
   iterator it;
   it.pos = const_cast<typename std::remove_const<T>::type *>(this->data());
-  it.stride = this->stride();
+  it.stride = size_of<T>();
   return it;
 }
 
@@ -1101,7 +1100,7 @@ template <typename T>
 typename Vec<T>::const_iterator Vec<T>::cbegin() const noexcept {
   const_iterator it;
   it.pos = const_cast<typename std::remove_const<T>::type *>(this->data());
-  it.stride = this->stride();
+  it.stride = size_of<T>();
   return it;
 }
 

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1029,7 +1029,6 @@ fn expand_rust_vec(elem: &RustName, types: &Types) -> TokenStream {
     let link_data = format!("{}data", link_prefix);
     let link_reserve_total = format!("{}reserve_total", link_prefix);
     let link_set_len = format!("{}set_len", link_prefix);
-    let link_stride = format!("{}stride", link_prefix);
 
     let local_prefix = format_ident!("{}__vec_", elem.rust);
     let local_new = format_ident!("{}new", local_prefix);
@@ -1039,7 +1038,6 @@ fn expand_rust_vec(elem: &RustName, types: &Types) -> TokenStream {
     let local_data = format_ident!("{}data", local_prefix);
     let local_reserve_total = format_ident!("{}reserve_total", local_prefix);
     let local_set_len = format_ident!("{}set_len", local_prefix);
-    let local_stride = format_ident!("{}stride", local_prefix);
 
     let span = elem.span();
     quote_spanned! {span=>
@@ -1079,11 +1077,6 @@ fn expand_rust_vec(elem: &RustName, types: &Types) -> TokenStream {
         #[export_name = #link_set_len]
         unsafe extern "C" fn #local_set_len(this: *mut ::cxx::private::RustVec<#elem>, len: usize) {
             (*this).set_len(len);
-        }
-        #[doc(hidden)]
-        #[export_name = #link_stride]
-        unsafe extern "C" fn #local_stride() -> usize {
-            ::std::mem::size_of::<#elem>()
         }
     }
 }

--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -450,8 +450,7 @@ static_assert(sizeof(std::string) <= kMaxExpectedWordsInString * sizeof(void *),
   void cxxbridge1$rust_vec$##RUST_TYPE##$reserve_total(                        \
       rust::Vec<CXX_TYPE> *ptr, std::size_t cap) noexcept;                     \
   void cxxbridge1$rust_vec$##RUST_TYPE##$set_len(rust::Vec<CXX_TYPE> *ptr,     \
-                                                 std::size_t len) noexcept;    \
-  std::size_t cxxbridge1$rust_vec$##RUST_TYPE##$stride() noexcept;
+                                                 std::size_t len) noexcept;
 
 #define RUST_VEC_OPS(RUST_TYPE, CXX_TYPE)                                      \
   template <>                                                                  \
@@ -481,10 +480,6 @@ static_assert(sizeof(std::string) <= kMaxExpectedWordsInString * sizeof(void *),
   template <>                                                                  \
   void Vec<CXX_TYPE>::set_len(std::size_t len) noexcept {                      \
     cxxbridge1$rust_vec$##RUST_TYPE##$set_len(this, len);                      \
-  }                                                                            \
-  template <>                                                                  \
-  std::size_t Vec<CXX_TYPE>::stride() noexcept {                               \
-    return cxxbridge1$rust_vec$##RUST_TYPE##$stride();                         \
   }
 
 #define SHARED_PTR_OPS(RUST_TYPE, CXX_TYPE)                                    \

--- a/src/symbols/rust_vec.rs
+++ b/src/symbols/rust_vec.rs
@@ -53,12 +53,6 @@ macro_rules! rust_vec_shims {
                     (*this).repr.set_len(len);
                 }
             }
-            attr! {
-                #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$stride")]
-                unsafe extern "C" fn __stride() -> usize {
-                    mem::size_of::<$ty>()
-                }
-            }
         };
     };
 }


### PR DESCRIPTION
As of #597 we have a reliable C++ size accessor for all types, including opaque Rust types. Thus there's no longer a need for Vec shims to contain their own separate stride symbol.