### PR TITLE
Reuse Slice<T>'s iterator for Vec iteration too

### DIFF
--- a/gen/src/builtin.rs
+++ b/gen/src/builtin.rs
@@ -59,6 +59,20 @@ pub(super) fn write(out: &mut OutFile) {
         builtin.friend_impl = true;
     }
 
+    if builtin.rust_vec {
+        include.algorithm = true;
+        include.array = true;
+        include.cstddef = true;
+        include.initializer_list = true;
+        include.iterator = true;
+        include.new = true;
+        include.type_traits = true;
+        include.utility = true;
+        builtin.panic = true;
+        builtin.rust_slice = true;
+        builtin.unsafe_bitcopy = true;
+    }
+
     if builtin.rust_slice {
         include.cstddef = true;
         include.iterator = true;
@@ -72,19 +86,6 @@ pub(super) fn write(out: &mut OutFile) {
         include.new = true;
         include.type_traits = true;
         include.utility = true;
-    }
-
-    if builtin.rust_vec {
-        include.algorithm = true;
-        include.array = true;
-        include.cstddef = true;
-        include.initializer_list = true;
-        include.iterator = true;
-        include.new = true;
-        include.type_traits = true;
-        include.utility = true;
-        builtin.panic = true;
-        builtin.unsafe_bitcopy = true;
     }
 
     if builtin.rust_fn {


### PR DESCRIPTION
This exactly mirrors how the two iterators are handled in the Rust standard library. Both Vec\<T\>'s and &amp;\[T\]'s `iter()` method returns the same iterator type `std::slice::Iter`.

https://doc.rust-lang.org/std/vec/struct.Vec.html#method.iter
https://doc.rust-lang.org/std/primitive.slice.html#method.iter

Originally we had these as separate iterator types in CXX because `rust::Vec` supported opaque Rust types from the beginning since #148 while `rust::Slice` only much later since #603. Now that the two are in parity, we only need one of the iterator implementations.