### PR TITLE
Emit lifetimes on extern type into Rust macro output

### DIFF
--- a/gen/src/nested.rs
+++ b/gen/src/nested.rs
@@ -52,9 +52,10 @@ fn sort_by_inner_namespace(apis: Vec<&Api>, depth: usize) -> NamespaceEntries {
 mod tests {
     use super::NamespaceEntries;
     use crate::syntax::namespace::Namespace;
-    use crate::syntax::{Api, Doc, ExternType, Lang, Pair};
+    use crate::syntax::{Api, Doc, ExternType, Lang, Lifetimes, Pair};
     use proc_macro2::{Ident, Span};
     use std::iter::FromIterator;
+    use syn::punctuated::Punctuated;
     use syn::Token;
 
     #[test]
@@ -136,7 +137,11 @@ mod tests {
                 cxx: ident.clone(),
                 rust: ident,
             },
-            lifetimes: Vec::new(),
+            generics: Lifetimes {
+                lt_token: None,
+                lifetimes: Punctuated::new(),
+                gt_token: None,
+            },
             colon_token: None,
             bounds: Vec::new(),
             semi_token: Token![;](Span::call_site()),

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -337,7 +337,7 @@ fn check_api_type(cx: &mut Check, ety: &ExternType) {
         cx.error(derive, msg);
     }
 
-    if let Some(lifetime) = ety.lifetimes.first() {
+    if let Some(lifetime) = ety.generics.lifetimes.first() {
         cx.error(lifetime, "extern type with lifetimes is not supported yet");
     }
 
@@ -445,7 +445,7 @@ fn check_api_type_alias(cx: &mut Check, alias: &TypeAlias) {
         cx.error(derive, msg);
     }
 
-    if let Some(lifetime) = alias.lifetimes.first() {
+    if let Some(lifetime) = alias.generics.lifetimes.first() {
         cx.error(lifetime, "extern type with lifetimes is not supported yet");
     }
 }

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -74,7 +74,7 @@ pub struct ExternType {
     pub derives: Vec<Derive>,
     pub type_token: Token![type],
     pub name: Pair,
-    pub lifetimes: Vec<Lifetime>,
+    pub generics: Lifetimes,
     pub colon_token: Option<Token![:]>,
     pub bounds: Vec<Derive>,
     pub semi_token: Token![;],
@@ -116,7 +116,7 @@ pub struct TypeAlias {
     pub derives: Vec<Derive>,
     pub type_token: Token![type],
     pub name: Pair,
-    pub lifetimes: Vec<Lifetime>,
+    pub generics: Lifetimes,
     pub eq_token: Token![=],
     pub ty: RustType,
     pub semi_token: Token![;],
@@ -128,6 +128,12 @@ pub struct Impl {
     pub ty: Type,
     pub brace_token: Brace,
     pub negative_token: Option<Token![!]>,
+}
+
+pub struct Lifetimes {
+    pub lt_token: Option<Token![<]>,
+    pub lifetimes: Punctuated<Lifetime, Token![,]>,
+    pub gt_token: Option<Token![>]>,
 }
 
 pub struct Signature {

--- a/syntax/tokens.rs
+++ b/syntax/tokens.rs
@@ -1,7 +1,7 @@
 use crate::syntax::atom::Atom::*;
 use crate::syntax::{
-    Array, Atom, Derive, Enum, ExternFn, ExternType, Impl, Receiver, Ref, RustName, Signature,
-    SliceRef, Struct, Ty1, Type, TypeAlias, Var,
+    Array, Atom, Derive, Enum, ExternFn, ExternType, Impl, Lifetimes, Receiver, Ref, RustName,
+    Signature, SliceRef, Struct, Ty1, Type, TypeAlias, Var,
 };
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote_spanned, ToTokens};
@@ -154,6 +154,14 @@ impl ToTokens for Impl {
         self.negative_token.to_tokens(tokens);
         self.ty.to_tokens(tokens);
         self.brace_token.surround(tokens, |_tokens| {});
+    }
+}
+
+impl ToTokens for Lifetimes {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.lt_token.to_tokens(tokens);
+        self.lifetimes.to_tokens(tokens);
+        self.gt_token.to_tokens(tokens);
     }
 }
 


### PR DESCRIPTION
Part of #608.

An extern type `type Example<'a, 'b>;` turns into:

```rust
#[repr(C)]
pub struct Example<'a, 'b> {
    _private: ::cxx::private::Opaque,
    _lifetime_a: ::std::marker::PhantomData<&'a ()>,
    _lifetime_b: ::std::marker::PhantomData<&'b ()>,
}

unsafe impl<'a, 'b> ::cxx::ExternType for Asdf<'a, 'b> {
    type Id = ::cxx::type_id!("Example");
    type Kind = ::cxx::kind::Opaque;
}
```

Note that we assume covariant lifetimes. It's possible we'll also expose contravariant and invariant lifetimes something like the `ghost` crate (https://github.com/dtolnay/ghost#variance).