### PR TITLE
Add C++ symbol visibility annotations for Rust functions and impls

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -950,6 +950,9 @@ fn write_rust_function_shim_impl(
         // We've already defined this inside the struct.
         return;
     }
+    if !out.header {
+        begin_function_definition(out);
+    }
     write_rust_function_shim_decl(out, local_name, sig, indirect_call);
     if out.header {
         writeln!(out, ";");
@@ -1487,6 +1490,7 @@ fn write_rust_box_impl(out: &mut OutFile, ident: &Pair) {
     let instance = ident.to_symbol();
 
     writeln!(out, "template <>");
+    begin_function_definition(out);
     writeln!(
         out,
         "{} *Box<{}>::allocation::alloc() noexcept {{",
@@ -1496,6 +1500,7 @@ fn write_rust_box_impl(out: &mut OutFile, ident: &Pair) {
     writeln!(out, "}}");
 
     writeln!(out, "template <>");
+    begin_function_definition(out);
     writeln!(
         out,
         "void Box<{}>::allocation::dealloc({} *ptr) noexcept {{",
@@ -1505,6 +1510,7 @@ fn write_rust_box_impl(out: &mut OutFile, ident: &Pair) {
     writeln!(out, "}}");
 
     writeln!(out, "template <>");
+    begin_function_definition(out);
     writeln!(out, "void Box<{}>::drop() noexcept {{", inner);
     writeln!(out, "  cxxbridge1$box${}$drop(this);", instance);
     writeln!(out, "}}");
@@ -1517,16 +1523,19 @@ fn write_rust_vec_impl(out: &mut OutFile, element: &RustName) {
     out.include.cstddef = true;
 
     writeln!(out, "template <>");
+    begin_function_definition(out);
     writeln!(out, "Vec<{}>::Vec() noexcept {{", inner);
     writeln!(out, "  cxxbridge1$rust_vec${}$new(this);", instance);
     writeln!(out, "}}");
 
     writeln!(out, "template <>");
+    begin_function_definition(out);
     writeln!(out, "void Vec<{}>::drop() noexcept {{", inner);
     writeln!(out, "  return cxxbridge1$rust_vec${}$drop(this);", instance);
     writeln!(out, "}}");
 
     writeln!(out, "template <>");
+    begin_function_definition(out);
     writeln!(
         out,
         "::std::size_t Vec<{}>::size() const noexcept {{",
@@ -1536,6 +1545,7 @@ fn write_rust_vec_impl(out: &mut OutFile, element: &RustName) {
     writeln!(out, "}}");
 
     writeln!(out, "template <>");
+    begin_function_definition(out);
     writeln!(
         out,
         "::std::size_t Vec<{}>::capacity() const noexcept {{",
@@ -1549,11 +1559,13 @@ fn write_rust_vec_impl(out: &mut OutFile, element: &RustName) {
     writeln!(out, "}}");
 
     writeln!(out, "template <>");
+    begin_function_definition(out);
     writeln!(out, "const {} *Vec<{0}>::data() const noexcept {{", inner);
     writeln!(out, "  return cxxbridge1$rust_vec${}$data(this);", instance);
     writeln!(out, "}}");
 
     writeln!(out, "template <>");
+    begin_function_definition(out);
     writeln!(
         out,
         "void Vec<{}>::reserve_total(::std::size_t cap) noexcept {{",
@@ -1567,6 +1579,7 @@ fn write_rust_vec_impl(out: &mut OutFile, element: &RustName) {
     writeln!(out, "}}");
 
     writeln!(out, "template <>");
+    begin_function_definition(out);
     writeln!(
         out,
         "void Vec<{}>::set_len(::std::size_t len) noexcept {{",

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -623,13 +623,17 @@ fn write_opaque_type_layout<'a>(out: &mut OutFile<'a>, ety: &'a ExternType) {
     writeln!(out, "}}");
 }
 
+fn begin_function_definition(out: &mut OutFile) {
+    if let Some(annotation) = &out.opt.cxx_impl_annotations {
+        write!(out, "{} ", annotation);
+    }
+}
+
 fn write_cxx_function_shim<'a>(out: &mut OutFile<'a>, efn: &'a ExternFn) {
     out.next_section();
     out.set_namespace(&efn.name.namespace);
     out.begin_block(Block::ExternC);
-    if let Some(annotation) = &out.opt.cxx_impl_annotations {
-        write!(out, "{} ", annotation);
-    }
+    begin_function_definition(out);
     if efn.throws {
         out.builtin.ptr_len = true;
         write!(out, "::rust::repr::PtrLen ");


### PR DESCRIPTION
Closes #612. Based on https://github.com/david-cattermole/cxx/commit/363c18b2982329d6e4fbc2a6e5f324f4fef03661.