### PR TITLE
Add ui test of missing_docs lints inside bridge

### DIFF
--- a/tests/ui/deny_missing_docs.rs
+++ b/tests/ui/deny_missing_docs.rs
@@ -1,0 +1,89 @@
+// TODO: More work is needed so that the missing_docs lints produced by rustc
+// are properly positioned inside of the bridge.
+
+//! ...
+
+#![deny(missing_docs)]
+
+/// ...
+#[cxx::bridge]
+pub mod ffi {
+    pub struct UndocumentedStruct {
+        pub undocumented_field: u8,
+    }
+
+    /// ...
+    pub struct DocumentedStruct {
+        /// ...
+        pub documented_field: u8,
+    }
+
+    pub enum UndocumentedEnum {
+        UndocumentedVariant = 0,
+    }
+
+    /// ...
+    pub enum DocumentedEnum {
+        /// ...
+        DocumentedVariant = 0,
+    }
+
+    extern "Rust" {
+        pub type UndocumentedRustType;
+
+        /// ...
+        pub type DocumentedRustType;
+
+        pub fn undocumented_rust_fn() -> u8;
+
+        /// ...
+        pub fn documented_rust_fn() -> u8;
+    }
+
+    unsafe extern "C++" {
+        pub type UndocumentedForeignType;
+
+        /// ...
+        pub type DocumentedForeignType;
+
+        pub type UndocumentedTypeAlias = crate::bindgen::UndocumentedTypeAlias;
+
+        /// ...
+        pub type DocumentedTypeAlias = crate::bindgen::DocumentedTypeAlias;
+
+        pub fn undocumented_foreign_fn() -> u8;
+
+        /// ...
+        pub fn documented_foreign_fn() -> u8;
+    }
+}
+
+struct UndocumentedRustType;
+struct DocumentedRustType;
+
+mod bindgen {
+    use cxx::{type_id, ExternType};
+
+    pub struct UndocumentedTypeAlias;
+    pub struct DocumentedTypeAlias;
+
+    unsafe impl ExternType for UndocumentedTypeAlias {
+        type Id = type_id!("UndocumentedTypeAlias");
+        type Kind = cxx::kind::Opaque;
+    }
+
+    unsafe impl ExternType for DocumentedTypeAlias {
+        type Id = type_id!("DocumentedTypeAlias");
+        type Kind = cxx::kind::Opaque;
+    }
+}
+
+fn undocumented_rust_fn() -> u8 {
+    0
+}
+
+fn documented_rust_fn() -> u8 {
+    0
+}
+
+fn main() {}

--- a/tests/ui/deny_missing_docs.stderr
+++ b/tests/ui/deny_missing_docs.stderr
@@ -1,0 +1,64 @@
+error: missing documentation for a struct
+ --> $DIR/deny_missing_docs.rs:9:1
+  |
+9 | #[cxx::bridge]
+  | ^^^^^^^^^^^^^^
+  |
+note: the lint level is defined here
+ --> $DIR/deny_missing_docs.rs:6:9
+  |
+6 | #![deny(missing_docs)]
+  |         ^^^^^^^^^^^^
+  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: missing documentation for a struct field
+  --> $DIR/deny_missing_docs.rs:12:13
+   |
+12 |         pub undocumented_field: u8,
+   |             ^^^^^^^^^^^^^^^^^^^^^^
+
+error: missing documentation for a struct field
+  --> $DIR/deny_missing_docs.rs:18:13
+   |
+18 |         pub documented_field: u8,
+   |             ^^^^^^^^^^^^^^^^^^^^
+
+error: missing documentation for a struct
+ --> $DIR/deny_missing_docs.rs:9:1
+  |
+9 | #[cxx::bridge]
+  | ^^^^^^^^^^^^^^
+  |
+  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: missing documentation for a struct field
+ --> $DIR/deny_missing_docs.rs:9:1
+  |
+9 | #[cxx::bridge]
+  | ^^^^^^^^^^^^^^
+  |
+  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: missing documentation for an associated constant
+ --> $DIR/deny_missing_docs.rs:9:1
+  |
+9 | #[cxx::bridge]
+  | ^^^^^^^^^^^^^^
+  |
+  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: missing documentation for a type alias
+ --> $DIR/deny_missing_docs.rs:9:1
+  |
+9 | #[cxx::bridge]
+  | ^^^^^^^^^^^^^^
+  |
+  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: missing documentation for a function
+ --> $DIR/deny_missing_docs.rs:9:1
+  |
+9 | #[cxx::bridge]
+  | ^^^^^^^^^^^^^^
+  |
+  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
The spans on the resulting missing_docs lints from rustc are horrible... I will make some follow-up PRs to get that cleaned up preserving all the right spans.