### PR TITLE
Fix span placement on shared structs

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -163,13 +163,20 @@ fn expand_struct(strct: &Struct) -> TokenStream {
     let mut derives = None;
     let derived_traits = derive::expand_struct(strct, &mut derives);
 
+    let span = ident.span();
+    let visibility = strct.visibility;
+    let struct_token = strct.struct_token;
+    let struct_def = quote_spanned! {span=>
+        #visibility #struct_token #ident {
+            #(#fields,)*
+        }
+    };
+
     quote! {
         #doc
         #derives
         #[repr(C)]
-        pub struct #ident {
-            #(#fields,)*
-        }
+        #struct_def
 
         unsafe impl ::cxx::ExternType for #ident {
             type Id = #type_id;

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -84,6 +84,7 @@ pub struct ExternType {
 pub struct Struct {
     pub doc: Doc,
     pub derives: Vec<Derive>,
+    pub visibility: Token![pub],
     pub struct_token: Token![struct],
     pub name: Pair,
     pub brace_token: Brace,

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -117,6 +117,12 @@ fn parse_struct(cx: &mut Errors, item: ItemStruct, namespace: &Namespace) -> Res
         });
     }
 
+    let visibility = Token![pub](match item.vis {
+        Visibility::Public(vis) => vis.pub_token.span,
+        Visibility::Crate(vis) => vis.crate_token.span,
+        Visibility::Restricted(vis) => vis.pub_token.span,
+        Visibility::Inherited => item.ident.span(),
+    });
     let struct_token = item.struct_token;
     let name = pair(namespace, &item.ident, cxx_name, rust_name);
     let brace_token = named_fields.brace_token;
@@ -124,6 +130,7 @@ fn parse_struct(cx: &mut Errors, item: ItemStruct, namespace: &Namespace) -> Res
     Ok(Api::Struct(Struct {
         doc,
         derives,
+        visibility,
         struct_token,
         name,
         brace_token,

--- a/tests/ui/deny_missing_docs.stderr
+++ b/tests/ui/deny_missing_docs.stderr
@@ -1,15 +1,14 @@
 error: missing documentation for a struct
- --> $DIR/deny_missing_docs.rs:9:1
-  |
-9 | #[cxx::bridge]
-  | ^^^^^^^^^^^^^^
-  |
+  --> $DIR/deny_missing_docs.rs:11:5
+   |
+11 |     pub struct UndocumentedStruct {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
 note: the lint level is defined here
- --> $DIR/deny_missing_docs.rs:6:9
-  |
-6 | #![deny(missing_docs)]
-  |         ^^^^^^^^^^^^
-  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> $DIR/deny_missing_docs.rs:6:9
+   |
+6  | #![deny(missing_docs)]
+   |         ^^^^^^^^^^^^
 
 error: missing documentation for a struct field
   --> $DIR/deny_missing_docs.rs:12:9


### PR DESCRIPTION
Part of improving #617.

Before:

```console
error: missing documentation for a struct
 --> $DIR/deny_missing_docs.rs:9:1
  |
9 | #[cxx::bridge]
  | ^^^^^^^^^^^^^^
```

After:

```console
error: missing documentation for a struct
  --> $DIR/deny_missing_docs.rs:11:5
   |
11 |     pub struct UndocumentedStruct {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```