### PR TITLE
Propagate rust lint control attributes into macro output

### DIFF
--- a/gen/src/nested.rs
+++ b/gen/src/nested.rs
@@ -51,6 +51,7 @@ fn sort_by_inner_namespace(apis: Vec<&Api>, depth: usize) -> NamespaceEntries {
 #[cfg(test)]
 mod tests {
     use super::NamespaceEntries;
+    use crate::syntax::attrs::OtherAttrs;
     use crate::syntax::namespace::Namespace;
     use crate::syntax::{Api, Doc, ExternType, Lang, Lifetimes, Pair};
     use proc_macro2::{Ident, Span};
@@ -131,6 +132,7 @@ mod tests {
             lang: Lang::Rust,
             doc: Doc::new(),
             derives: Vec::new(),
+            attrs: OtherAttrs::none(),
             type_token: Token![type](Span::call_site()),
             name: Pair {
                 namespace: ns,

--- a/syntax/attrs.rs
+++ b/syntax/attrs.rs
@@ -39,7 +39,7 @@ pub struct Parser<'a> {
     pub(crate) _more: (),
 }
 
-pub(super) fn parse(cx: &mut Errors, attrs: &[Attribute], mut parser: Parser) {
+pub(super) fn parse(cx: &mut Errors, attrs: Vec<Attribute>, mut parser: Parser) {
     for attr in attrs {
         if attr.path.is_ident("doc") {
             match parse_doc_attribute.parse2(attr.tokens.clone()) {

--- a/syntax/attrs.rs
+++ b/syntax/attrs.rs
@@ -101,6 +101,13 @@ pub(super) fn parse(cx: &mut Errors, attrs: Vec<Attribute>, mut parser: Parser) 
                 }
                 Err(err) => return cx.push(err),
             }
+        } else if attr.path.is_ident("allow")
+            || attr.path.is_ident("warn")
+            || attr.path.is_ident("deny")
+            || attr.path.is_ident("forbid")
+        {
+            // https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes
+            continue;
         }
         return cx.error(attr, "unsupported attribute");
     }

--- a/syntax/attrs.rs
+++ b/syntax/attrs.rs
@@ -13,9 +13,9 @@ use syn::{Attribute, Error, LitStr, Path, Result, Token};
 //     let mut cxx_name = None;
 //     let mut rust_name = None;
 //     /* ... */
-//     attrs::parse(
+//     let attrs = attrs::parse(
 //         cx,
-//         &item.attrs,
+//         item.attrs,
 //         attrs::Parser {
 //             doc: Some(&mut doc),
 //             cxx_name: Some(&mut cxx_name),

--- a/syntax/impls.rs
+++ b/syntax/impls.rs
@@ -298,12 +298,14 @@ impl PartialEq for Var {
     fn eq(&self, other: &Var) -> bool {
         let Var {
             doc: _,
+            attrs: _,
             visibility: _,
             ident,
             ty,
         } = self;
         let Var {
             doc: _,
+            attrs: _,
             visibility: _,
             ident: ident2,
             ty: ty2,
@@ -316,6 +318,7 @@ impl Hash for Var {
     fn hash<H: Hasher>(&self, state: &mut H) {
         let Var {
             doc: _,
+            attrs: _,
             visibility: _,
             ident,
             ty,

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -25,6 +25,7 @@ mod toposort;
 pub mod trivial;
 pub mod types;
 
+use self::attrs::OtherAttrs;
 use self::discriminant::Discriminant;
 use self::namespace::Namespace;
 use self::parse::kw;
@@ -32,7 +33,7 @@ use self::symbol::Symbol;
 use proc_macro2::{Ident, Span};
 use syn::punctuated::Punctuated;
 use syn::token::{Brace, Bracket, Paren};
-use syn::{Attribute, Expr, Generics, Lifetime, LitInt, Token, Type as RustType};
+use syn::{Expr, Generics, Lifetime, LitInt, Token, Type as RustType};
 
 pub use self::atom::Atom;
 pub use self::derive::{Derive, Trait};
@@ -72,7 +73,7 @@ pub struct ExternType {
     pub lang: Lang,
     pub doc: Doc,
     pub derives: Vec<Derive>,
-    pub attrs: Vec<Attribute>,
+    pub attrs: OtherAttrs,
     pub type_token: Token![type],
     pub name: Pair,
     pub generics: Lifetimes,
@@ -85,7 +86,7 @@ pub struct ExternType {
 pub struct Struct {
     pub doc: Doc,
     pub derives: Vec<Derive>,
-    pub attrs: Vec<Attribute>,
+    pub attrs: OtherAttrs,
     pub visibility: Token![pub],
     pub struct_token: Token![struct],
     pub name: Pair,
@@ -96,7 +97,7 @@ pub struct Struct {
 pub struct Enum {
     pub doc: Doc,
     pub derives: Vec<Derive>,
-    pub attrs: Vec<Attribute>,
+    pub attrs: OtherAttrs,
     pub enum_token: Token![enum],
     pub name: Pair,
     pub brace_token: Brace,
@@ -109,7 +110,7 @@ pub struct Enum {
 pub struct ExternFn {
     pub lang: Lang,
     pub doc: Doc,
-    pub attrs: Vec<Attribute>,
+    pub attrs: OtherAttrs,
     pub name: Pair,
     pub sig: Signature,
     pub semi_token: Token![;],
@@ -119,7 +120,7 @@ pub struct ExternFn {
 pub struct TypeAlias {
     pub doc: Doc,
     pub derives: Vec<Derive>,
-    pub attrs: Vec<Attribute>,
+    pub attrs: OtherAttrs,
     pub type_token: Token![type],
     pub name: Pair,
     pub generics: Lifetimes,
@@ -156,7 +157,7 @@ pub struct Signature {
 
 pub struct Var {
     pub doc: Doc,
-    pub attrs: Vec<Attribute>,
+    pub attrs: OtherAttrs,
     pub visibility: Token![pub],
     pub ident: Ident,
     pub ty: Type,
@@ -176,7 +177,7 @@ pub struct Receiver {
 
 pub struct Variant {
     pub doc: Doc,
-    pub attrs: Vec<Attribute>,
+    pub attrs: OtherAttrs,
     pub name: Pair,
     pub discriminant: Discriminant,
     pub expr: Option<Expr>,

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -1,7 +1,7 @@
 // Functionality that is shared between the cxxbridge macro and the cmd.
 
 pub mod atom;
-mod attrs;
+pub mod attrs;
 pub mod check;
 pub mod derive;
 mod discriminant;
@@ -32,7 +32,7 @@ use self::symbol::Symbol;
 use proc_macro2::{Ident, Span};
 use syn::punctuated::Punctuated;
 use syn::token::{Brace, Bracket, Paren};
-use syn::{Expr, Generics, Lifetime, LitInt, Token, Type as RustType};
+use syn::{Attribute, Expr, Generics, Lifetime, LitInt, Token, Type as RustType};
 
 pub use self::atom::Atom;
 pub use self::derive::{Derive, Trait};
@@ -72,6 +72,7 @@ pub struct ExternType {
     pub lang: Lang,
     pub doc: Doc,
     pub derives: Vec<Derive>,
+    pub attrs: Vec<Attribute>,
     pub type_token: Token![type],
     pub name: Pair,
     pub generics: Lifetimes,
@@ -84,6 +85,7 @@ pub struct ExternType {
 pub struct Struct {
     pub doc: Doc,
     pub derives: Vec<Derive>,
+    pub attrs: Vec<Attribute>,
     pub visibility: Token![pub],
     pub struct_token: Token![struct],
     pub name: Pair,
@@ -94,6 +96,7 @@ pub struct Struct {
 pub struct Enum {
     pub doc: Doc,
     pub derives: Vec<Derive>,
+    pub attrs: Vec<Attribute>,
     pub enum_token: Token![enum],
     pub name: Pair,
     pub brace_token: Brace,
@@ -106,6 +109,7 @@ pub struct Enum {
 pub struct ExternFn {
     pub lang: Lang,
     pub doc: Doc,
+    pub attrs: Vec<Attribute>,
     pub name: Pair,
     pub sig: Signature,
     pub semi_token: Token![;],
@@ -115,6 +119,7 @@ pub struct ExternFn {
 pub struct TypeAlias {
     pub doc: Doc,
     pub derives: Vec<Derive>,
+    pub attrs: Vec<Attribute>,
     pub type_token: Token![type],
     pub name: Pair,
     pub generics: Lifetimes,
@@ -151,6 +156,7 @@ pub struct Signature {
 
 pub struct Var {
     pub doc: Doc,
+    pub attrs: Vec<Attribute>,
     pub visibility: Token![pub],
     pub ident: Ident,
     pub ty: Type,
@@ -170,6 +176,7 @@ pub struct Receiver {
 
 pub struct Variant {
     pub doc: Doc,
+    pub attrs: Vec<Attribute>,
     pub name: Pair,
     pub discriminant: Discriminant,
     pub expr: Option<Expr>,

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -1,3 +1,4 @@
+use crate::syntax::attrs::OtherAttrs;
 use crate::syntax::discriminant::DiscriminantSet;
 use crate::syntax::file::{Item, ItemForeignMod};
 use crate::syntax::report::Errors;
@@ -544,7 +545,7 @@ fn parse_extern_fn(
                 let ty = parse_type(&arg.ty)?;
                 if ident != "self" {
                     let doc = Doc::new();
-                    let attrs = Vec::new();
+                    let attrs = OtherAttrs::none();
                     let visibility = Token![pub](ident.span());
                     args.push_value(Var {
                         doc,
@@ -1122,7 +1123,7 @@ fn parse_type_fn(ty: &TypeBareFn) -> Result<Type> {
                 None => format_ident!("arg{}", i),
             };
             let doc = Doc::new();
-            let attrs = Vec::new();
+            let attrs = OtherAttrs::none();
             let visibility = Token![pub](ident.span());
             Ok(Var {
                 doc,

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -57,15 +57,14 @@ pub fn parse_items(
 }
 
 fn parse_struct(cx: &mut Errors, mut item: ItemStruct, namespace: &Namespace) -> Result<Api> {
-    let attrs = mem::take(&mut item.attrs);
     let mut doc = Doc::new();
     let mut derives = Vec::new();
     let mut namespace = namespace.clone();
     let mut cxx_name = None;
     let mut rust_name = None;
-    attrs::parse(
+    let attrs = attrs::parse(
         cx,
-        attrs,
+        mem::take(&mut item.attrs),
         attrs::Parser {
             doc: Some(&mut doc),
             derives: Some(&mut derives),
@@ -100,7 +99,7 @@ fn parse_struct(cx: &mut Errors, mut item: ItemStruct, namespace: &Namespace) ->
     for field in named_fields.named {
         let ident = field.ident.unwrap();
         let mut doc = Doc::new();
-        attrs::parse(
+        let attrs = attrs::parse(
             cx,
             field.attrs,
             attrs::Parser {
@@ -123,6 +122,7 @@ fn parse_struct(cx: &mut Errors, mut item: ItemStruct, namespace: &Namespace) ->
         });
         fields.push(Var {
             doc,
+            attrs,
             visibility,
             ident,
             ty,
@@ -142,6 +142,7 @@ fn parse_struct(cx: &mut Errors, mut item: ItemStruct, namespace: &Namespace) ->
     Ok(Api::Struct(Struct {
         doc,
         derives,
+        attrs,
         visibility,
         struct_token,
         name,
@@ -157,7 +158,7 @@ fn parse_enum(cx: &mut Errors, item: ItemEnum, namespace: &Namespace) -> Result<
     let mut namespace = namespace.clone();
     let mut cxx_name = None;
     let mut rust_name = None;
-    attrs::parse(
+    let attrs = attrs::parse(
         cx,
         item.attrs,
         attrs::Parser {
@@ -213,6 +214,7 @@ fn parse_enum(cx: &mut Errors, item: ItemEnum, namespace: &Namespace) -> Result<
     Ok(Api::Enum(Enum {
         doc,
         derives,
+        attrs,
         enum_token,
         name,
         brace_token,
@@ -228,13 +230,12 @@ fn parse_variant(
     mut variant: RustVariant,
     discriminants: &mut DiscriminantSet,
 ) -> Result<Variant> {
-    let attrs = mem::take(&mut variant.attrs);
     let mut doc = Doc::new();
     let mut cxx_name = None;
     let mut rust_name = None;
-    attrs::parse(
+    let attrs = attrs::parse(
         cx,
-        attrs,
+        mem::take(&mut variant.attrs),
         attrs::Parser {
             doc: Some(&mut doc),
             cxx_name: Some(&mut cxx_name),
@@ -266,6 +267,7 @@ fn parse_variant(
 
     Ok(Variant {
         doc,
+        attrs,
         name,
         discriminant,
         expr,
@@ -403,7 +405,7 @@ fn parse_extern_type(
     let mut namespace = namespace.clone();
     let mut cxx_name = None;
     let mut rust_name = None;
-    attrs::parse(
+    let attrs = attrs::parse(
         cx,
         foreign_type.attrs,
         attrs::Parser {
@@ -434,6 +436,7 @@ fn parse_extern_type(
         lang,
         doc,
         derives,
+        attrs,
         type_token,
         name,
         generics,
@@ -451,14 +454,13 @@ fn parse_extern_fn(
     trusted: bool,
     namespace: &Namespace,
 ) -> Result<Api> {
-    let attrs = mem::take(&mut foreign_fn.attrs);
     let mut doc = Doc::new();
     let mut namespace = namespace.clone();
     let mut cxx_name = None;
     let mut rust_name = None;
-    attrs::parse(
+    let attrs = attrs::parse(
         cx,
-        attrs,
+        mem::take(&mut foreign_fn.attrs),
         attrs::Parser {
             doc: Some(&mut doc),
             namespace: Some(&mut namespace),
@@ -542,9 +544,11 @@ fn parse_extern_fn(
                 let ty = parse_type(&arg.ty)?;
                 if ident != "self" {
                     let doc = Doc::new();
+                    let attrs = Vec::new();
                     let visibility = Token![pub](ident.span());
                     args.push_value(Var {
                         doc,
+                        attrs,
                         visibility,
                         ident,
                         ty,
@@ -591,6 +595,7 @@ fn parse_extern_fn(
     }(ExternFn {
         lang,
         doc,
+        attrs,
         name,
         sig: Signature {
             unsafety,
@@ -701,7 +706,7 @@ fn parse_type_alias(
     let mut namespace = namespace.clone();
     let mut cxx_name = None;
     let mut rust_name = None;
-    attrs::parse(
+    let attrs = attrs::parse(
         cx,
         attrs,
         attrs::Parser {
@@ -725,6 +730,7 @@ fn parse_type_alias(
     Ok(Api::TypeAlias(TypeAlias {
         doc,
         derives,
+        attrs,
         type_token,
         name,
         generics,
@@ -783,7 +789,7 @@ fn parse_extern_type_bounded(
     let mut namespace = namespace.clone();
     let mut cxx_name = None;
     let mut rust_name = None;
-    attrs::parse(
+    let attrs = attrs::parse(
         cx,
         attrs,
         attrs::Parser {
@@ -805,6 +811,7 @@ fn parse_extern_type_bounded(
         lang,
         doc,
         derives,
+        attrs,
         type_token,
         name,
         generics,
@@ -1115,9 +1122,11 @@ fn parse_type_fn(ty: &TypeBareFn) -> Result<Type> {
                 None => format_ident!("arg{}", i),
             };
             let doc = Doc::new();
+            let attrs = Vec::new();
             let visibility = Token![pub](ident.span());
             Ok(Var {
                 doc,
+                attrs,
                 visibility,
                 ident,
                 ty,

--- a/tests/ui/deny_missing_docs.rs
+++ b/tests/ui/deny_missing_docs.rs
@@ -56,6 +56,11 @@ pub mod ffi {
         /// ...
         pub fn documented_foreign_fn() -> u8;
     }
+
+    #[allow(missing_docs)]
+    pub struct SuppressUndocumentedStruct {
+        pub undocumented_field: u8,
+    }
 }
 
 struct UndocumentedRustType;

--- a/tests/ui/deny_missing_docs.stderr
+++ b/tests/ui/deny_missing_docs.stderr
@@ -1,5 +1,61 @@
-error: unsupported attribute
-  --> $DIR/deny_missing_docs.rs:60:5
+error: missing documentation for a struct
+  --> $DIR/deny_missing_docs.rs:11:5
    |
-60 |     #[allow(missing_docs)]
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+11 |     pub struct UndocumentedStruct {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/deny_missing_docs.rs:6:9
+   |
+6  | #![deny(missing_docs)]
+   |         ^^^^^^^^^^^^
+
+error: missing documentation for a struct field
+  --> $DIR/deny_missing_docs.rs:12:9
+   |
+12 |         pub undocumented_field: u8,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: missing documentation for a struct
+ --> $DIR/deny_missing_docs.rs:9:1
+  |
+9 | #[cxx::bridge]
+  | ^^^^^^^^^^^^^^
+  |
+  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: missing documentation for an associated constant
+ --> $DIR/deny_missing_docs.rs:9:1
+  |
+9 | #[cxx::bridge]
+  | ^^^^^^^^^^^^^^
+  |
+  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: missing documentation for a type alias
+ --> $DIR/deny_missing_docs.rs:9:1
+  |
+9 | #[cxx::bridge]
+  | ^^^^^^^^^^^^^^
+  |
+  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: missing documentation for a function
+ --> $DIR/deny_missing_docs.rs:9:1
+  |
+9 | #[cxx::bridge]
+  | ^^^^^^^^^^^^^^
+  |
+  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: missing documentation for a struct
+  --> $DIR/deny_missing_docs.rs:61:5
+   |
+61 |     pub struct SuppressUndocumentedStruct {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: missing documentation for a struct field
+  --> $DIR/deny_missing_docs.rs:62:9
+   |
+62 |         pub undocumented_field: u8,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/deny_missing_docs.stderr
+++ b/tests/ui/deny_missing_docs.stderr
@@ -1,49 +1,5 @@
-error: missing documentation for a struct
-  --> $DIR/deny_missing_docs.rs:11:5
+error: unsupported attribute
+  --> $DIR/deny_missing_docs.rs:60:5
    |
-11 |     pub struct UndocumentedStruct {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: the lint level is defined here
-  --> $DIR/deny_missing_docs.rs:6:9
-   |
-6  | #![deny(missing_docs)]
-   |         ^^^^^^^^^^^^
-
-error: missing documentation for a struct field
-  --> $DIR/deny_missing_docs.rs:12:9
-   |
-12 |         pub undocumented_field: u8,
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: missing documentation for a struct
- --> $DIR/deny_missing_docs.rs:9:1
-  |
-9 | #[cxx::bridge]
-  | ^^^^^^^^^^^^^^
-  |
-  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: missing documentation for an associated constant
- --> $DIR/deny_missing_docs.rs:9:1
-  |
-9 | #[cxx::bridge]
-  | ^^^^^^^^^^^^^^
-  |
-  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: missing documentation for a type alias
- --> $DIR/deny_missing_docs.rs:9:1
-  |
-9 | #[cxx::bridge]
-  | ^^^^^^^^^^^^^^
-  |
-  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: missing documentation for a function
- --> $DIR/deny_missing_docs.rs:9:1
-  |
-9 | #[cxx::bridge]
-  | ^^^^^^^^^^^^^^
-  |
-  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+60 |     #[allow(missing_docs)]
+   |     ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/deny_missing_docs.stderr
+++ b/tests/ui/deny_missing_docs.stderr
@@ -47,15 +47,3 @@ error: missing documentation for a function
   | ^^^^^^^^^^^^^^
   |
   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: missing documentation for a struct
-  --> $DIR/deny_missing_docs.rs:61:5
-   |
-61 |     pub struct SuppressUndocumentedStruct {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: missing documentation for a struct field
-  --> $DIR/deny_missing_docs.rs:62:9
-   |
-62 |         pub undocumented_field: u8,
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
https://doc.rust-lang.org/reference/attributes/diagnostics.html#lint-check-attributes

- `#[allow(...)]`
- `#[warn(...)]`
- `#[deny(...)]`
- `#[forbid(...)]`
