### PR TITLE
Defer Cargo links metadata printing until after code generation

### DIFF
--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -206,7 +206,6 @@ fn build(rust_source_files: &mut dyn Iterator<Item = impl AsRef<Path>>) -> Resul
     let ref prj = Project::init()?;
     validate_cfg(prj)?;
     let this_crate = make_this_crate(prj)?;
-    this_crate.print_to_cargo();
 
     let mut build = Build::new();
     build.cpp(true);
@@ -216,6 +215,7 @@ fn build(rust_source_files: &mut dyn Iterator<Item = impl AsRef<Path>>) -> Resul
         generate_bridge(prj, &mut build, path.as_ref())?;
     }
 
+    this_crate.print_to_cargo();
     eprintln!("\nCXX include path:");
     for header_dir in this_crate.header_dirs {
         build.include(&header_dir.path);


### PR DESCRIPTION
This results in slightly less noise when code generation produces an error during a Cargo build.

#### Before:

```console
process didn't exit successfully: `/git/example-cxx/target/debug/build/example-f20ef12178a95a23/build-script-build` (exit code: 1)
--- stdout
cargo:CXXBRIDGE_PREFIX=example
cargo:CXXBRIDGE_DIR0=/git/example-cxx/target/debug/build/example-188c8410ffc8bb7d/out/cxxbridge/include
cargo:CXXBRIDGE_DIR1=/git/example-cxx/target/debug/build/example-188c8410ffc8bb7d/out/cxxbridge/crate

--- stderr

error[cxxbridge]: extern type with lifetimes is not supported yet
  ┌─ src/main.rs:9:21
  │
9 │         type Object<'a>;
  │                     ^^ extern type with lifetimes is not supported yet
```

#### After:

```console
process didn't exit successfully: `/git/example-cxx/target/debug/build/example-f20ef12178a95a23/build-script-build` (exit code: 1)
--- stderr

error[cxxbridge]: extern type with lifetimes is not supported yet
  ┌─ src/main.rs:9:21
  │
9 │         type Object<'a>;
  │                     ^^ extern type with lifetimes is not supported yet
```