### PR TITLE
Parse generic params on impl block

### DIFF
--- a/syntax/impls.rs
+++ b/syntax/impls.rs
@@ -413,11 +413,13 @@ impl Hash for Impl {
     fn hash<H: Hasher>(&self, state: &mut H) {
         let Impl {
             impl_token: _,
+            generics,
             negative,
             ty,
             brace_token: _,
             negative_token: _,
         } = self;
+        generics.hash(state);
         if *negative {
             negative.hash(state);
         }
@@ -431,6 +433,7 @@ impl PartialEq for Impl {
     fn eq(&self, other: &Impl) -> bool {
         let Impl {
             impl_token: _,
+            generics,
             negative,
             ty,
             brace_token: _,
@@ -438,11 +441,12 @@ impl PartialEq for Impl {
         } = self;
         let Impl {
             impl_token: _,
+            generics: generics2,
             negative: negative2,
             ty: ty2,
             brace_token: _,
             negative_token: _,
         } = other;
-        negative == negative2 && ty == ty2
+        generics == generics2 && negative == negative2 && ty == ty2
     }
 }

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -136,6 +136,7 @@ pub struct TypeAlias {
 
 pub struct Impl {
     pub impl_token: Token![impl],
+    pub generics: Lifetimes,
     pub negative: bool,
     pub ty: Type,
     pub brace_token: Brace,

--- a/syntax/tokens.rs
+++ b/syntax/tokens.rs
@@ -192,12 +192,14 @@ impl ToTokens for Impl {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let Impl {
             impl_token,
+            generics,
             negative: _,
             ty,
             brace_token,
             negative_token,
         } = self;
         impl_token.to_tokens(tokens);
+        generics.to_tokens(tokens);
         negative_token.to_tokens(tokens);
         ty.to_tokens(tokens);
         brace_token.surround(tokens, |_tokens| {});


### PR DESCRIPTION
Part of #608. This ensures that parsing works for impls such as:

```rust
extern "C++" {
    type Object<'a>;
}

impl<'a> UniquePtr<Object<'a>> {}
```