### PR TITLE
Generate all explicit and implicit impls based on one map

### DIFF
--- a/syntax/map.rs
+++ b/syntax/map.rs
@@ -29,6 +29,10 @@ mod ordered {
         pub fn iter(&self) -> Iter<K, V> {
             Iter(self.vec.iter())
         }
+
+        pub fn keys(&self) -> impl Iterator<Item = &K> {
+            self.vec.iter().map(|(k, _v)| k)
+        }
     }
 
     impl<K, V> OrderedMap<K, V>

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -20,6 +20,7 @@ mod parse;
 mod pod;
 pub mod qualified;
 pub mod report;
+mod resolve;
 pub mod set;
 pub mod symbol;
 mod tokens;

--- a/syntax/resolve.rs
+++ b/syntax/resolve.rs
@@ -1,0 +1,26 @@
+use crate::syntax::{NamedType, Pair, Types};
+use proc_macro2::Ident;
+
+impl<'a> Types<'a> {
+    pub fn resolve(&self, ident: &impl UnresolvedName) -> &Pair {
+        self.resolutions
+            .get(ident.ident())
+            .expect("Unable to resolve type")
+    }
+}
+
+pub trait UnresolvedName {
+    fn ident(&self) -> &Ident;
+}
+
+impl UnresolvedName for Ident {
+    fn ident(&self) -> &Ident {
+        self
+    }
+}
+
+impl UnresolvedName for NamedType {
+    fn ident(&self) -> &Ident {
+        &self.rust
+    }
+}


### PR DESCRIPTION
As part of type checking we precompute an OrderedMap of all the explicit and implicit generic type instantiations that need to be emitted. This eliminates previous duplication of logic between the Rust code generator and C++ code generator (the diff is net -73) but more importantly this refactor will be necessary for #608 because it provides a place to attach information about generic lifetime parameters that go with each of these impls. The lifetime information will be added in a later PR.