### PR TITLE
Track independent Rust/C++ names on struct fields and fn args

### DIFF
--- a/macro/src/derive.rs
+++ b/macro/src/derive.rs
@@ -104,9 +104,9 @@ fn struct_clone(strct: &Struct, span: Span) -> TokenStream {
     let body = if derive::contains(&strct.derives, Trait::Copy) {
         quote!(*self)
     } else {
-        let fields = strct.fields.iter().map(|field| &field.ident);
+        let fields = strct.fields.iter().map(|field| &field.name.rust);
         let values = strct.fields.iter().map(|field| {
-            let ident = &field.ident;
+            let ident = &field.name.rust;
             let ty = field.ty.to_token_stream();
             let span = ty.into_iter().last().unwrap().span();
             quote_spanned!(span=> &self.#ident)
@@ -128,7 +128,7 @@ fn struct_clone(strct: &Struct, span: Span) -> TokenStream {
 fn struct_debug(strct: &Struct, span: Span) -> TokenStream {
     let ident = &strct.name.rust;
     let struct_name = ident.to_string();
-    let fields = strct.fields.iter().map(|field| &field.ident);
+    let fields = strct.fields.iter().map(|field| &field.name.rust);
     let field_names = fields.clone().map(Ident::to_string);
 
     quote_spanned! {span=>
@@ -144,7 +144,7 @@ fn struct_debug(strct: &Struct, span: Span) -> TokenStream {
 
 fn struct_default(strct: &Struct, span: Span) -> TokenStream {
     let ident = &strct.name.rust;
-    let fields = strct.fields.iter().map(|field| &field.ident);
+    let fields = strct.fields.iter().map(|field| &field.name.rust);
 
     quote_spanned! {span=>
         impl ::std::default::Default for #ident {
@@ -161,7 +161,7 @@ fn struct_default(strct: &Struct, span: Span) -> TokenStream {
 
 fn struct_ord(strct: &Struct, span: Span) -> TokenStream {
     let ident = &strct.name.rust;
-    let fields = strct.fields.iter().map(|field| &field.ident);
+    let fields = strct.fields.iter().map(|field| &field.name.rust);
 
     quote_spanned! {span=>
         impl ::std::cmp::Ord for #ident {
@@ -186,7 +186,7 @@ fn struct_partial_ord(strct: &Struct, span: Span) -> TokenStream {
             ::std::option::Option::Some(::std::cmp::Ord::cmp(self, other))
         }
     } else {
-        let fields = strct.fields.iter().map(|field| &field.ident);
+        let fields = strct.fields.iter().map(|field| &field.name.rust);
         quote! {
             #(
                 match ::std::cmp::PartialOrd::partial_cmp(&self.#fields, &other.#fields) {

--- a/syntax/ident.rs
+++ b/syntax/ident.rs
@@ -26,7 +26,7 @@ pub(crate) fn check_all(cx: &mut Check, apis: &[Api]) {
             Api::Struct(strct) => {
                 check_ident(cx, &strct.name);
                 for field in &strct.fields {
-                    check(cx, &field.ident);
+                    check_ident(cx, &field.name);
                 }
             }
             Api::Enum(enm) => {
@@ -41,7 +41,7 @@ pub(crate) fn check_all(cx: &mut Check, apis: &[Api]) {
             Api::CxxFunction(efn) | Api::RustFunction(efn) => {
                 check(cx, &efn.name.rust);
                 for arg in &efn.args {
-                    check(cx, &arg.ident);
+                    check_ident(cx, &arg.name);
                 }
             }
             Api::TypeAlias(alias) => {

--- a/syntax/impls.rs
+++ b/syntax/impls.rs
@@ -301,14 +301,14 @@ impl PartialEq for Signature {
                     doc: _,
                     attrs: _,
                     visibility: _,
-                    ident: _,
+                    name: _,
                     ty,
                 } = arg;
                 let Var {
                     doc: _,
                     attrs: _,
                     visibility: _,
-                    ident: _,
+                    name: _,
                     ty: ty2,
                 } = arg2;
                 ty == ty2
@@ -336,7 +336,7 @@ impl Hash for Signature {
                 doc: _,
                 attrs: _,
                 visibility: _,
-                ident: _,
+                name: _,
                 ty,
             } = arg;
             ty.hash(state);

--- a/syntax/mangle.rs
+++ b/syntax/mangle.rs
@@ -1,6 +1,5 @@
 use crate::syntax::symbol::{self, Symbol};
 use crate::syntax::{ExternFn, Pair, Types};
-use proc_macro2::Ident;
 
 const CXXBRIDGE: &str = "cxxbridge1";
 
@@ -36,11 +35,11 @@ pub fn operator(receiver: &Pair, operator: &'static str) -> Symbol {
 }
 
 // The C half of a function pointer trampoline.
-pub fn c_trampoline(efn: &ExternFn, var: &Ident, types: &Types) -> Symbol {
-    join!(extern_fn(efn, types), var, 0)
+pub fn c_trampoline(efn: &ExternFn, var: &Pair, types: &Types) -> Symbol {
+    join!(extern_fn(efn, types), var.rust, 0)
 }
 
 // The Rust half of a function pointer trampoline.
-pub fn r_trampoline(efn: &ExternFn, var: &Ident, types: &Types) -> Symbol {
-    join!(extern_fn(efn, types), var, 1)
+pub fn r_trampoline(efn: &ExternFn, var: &Pair, types: &Types) -> Symbol {
+    join!(extern_fn(efn, types), var.rust, 1)
 }

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -167,7 +167,7 @@ pub struct Var {
     pub doc: Doc,
     pub attrs: OtherAttrs,
     pub visibility: Token![pub],
-    pub ident: Ident,
+    pub name: Pair,
     pub ty: Type,
 }
 

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -116,11 +116,12 @@ fn parse_struct(cx: &mut Errors, mut item: ItemStruct, namespace: &Namespace) ->
             }
         };
         let visibility = visibility_pub(&field.vis, &ident);
+        let name = pair(Namespace::default(), &ident, None, None);
         fields.push(Var {
             doc,
             attrs,
             visibility,
-            ident,
+            name,
             ty,
         });
     }
@@ -541,11 +542,12 @@ fn parse_extern_fn(
                     let doc = Doc::new();
                     let attrs = OtherAttrs::none();
                     let visibility = Token![pub](ident.span());
+                    let name = pair(Namespace::default(), &ident, None, None);
                     args.push_value(Var {
                         doc,
                         attrs,
                         visibility,
-                        ident,
+                        name,
                         ty,
                     });
                     if let Some(comma) = comma {
@@ -1177,11 +1179,12 @@ fn parse_type_fn(ty: &TypeBareFn) -> Result<Type> {
             let doc = Doc::new();
             let attrs = OtherAttrs::none();
             let visibility = Token![pub](ident.span());
+            let name = pair(Namespace::default(), &ident, None, None);
             Ok(Var {
                 doc,
                 attrs,
                 visibility,
-                ident,
+                name,
                 ty,
             })
         })

--- a/syntax/tokens.rs
+++ b/syntax/tokens.rs
@@ -41,11 +41,11 @@ impl ToTokens for Var {
             doc: _,
             attrs: _,
             visibility: _,
-            ident,
+            name,
             ty,
         } = self;
-        ident.to_tokens(tokens);
-        Token![:](ident.span()).to_tokens(tokens);
+        name.rust.to_tokens(tokens);
+        Token![:](name.rust.span()).to_tokens(tokens);
         ty.to_tokens(tokens);
     }
 }


### PR DESCRIPTION
This enables adjusting fn arg variable names when the given name is a keyword in the other language, and unblocks supporting #\[rust_name = "..."\] and #\[cxx_name = "..."\] attributes on the fields of shared structs.