### PR TITLE
Parameterize shim trait impl blocks over lifetimes

### DIFF
--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -141,13 +141,15 @@ pub struct TypeAlias {
 
 pub struct Impl {
     pub impl_token: Token![impl],
-    pub generics: Lifetimes,
+    pub impl_generics: Lifetimes,
     pub negative: bool,
     pub ty: Type,
+    pub ty_generics: Lifetimes,
     pub brace_token: Brace,
     pub negative_token: Option<Token![!]>,
 }
 
+#[derive(Clone, Default)]
 pub struct Lifetimes {
     pub lt_token: Option<Token![<]>,
     pub lifetimes: Punctuated<Lifetime, Token![,]>,

--- a/syntax/tokens.rs
+++ b/syntax/tokens.rs
@@ -192,14 +192,15 @@ impl ToTokens for Impl {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let Impl {
             impl_token,
-            generics,
+            impl_generics,
             negative: _,
             ty,
+            ty_generics: _,
             brace_token,
             negative_token,
         } = self;
         impl_token.to_tokens(tokens);
-        generics.to_tokens(tokens);
+        impl_generics.to_tokens(tokens);
         negative_token.to_tokens(tokens);
         ty.to_tokens(tokens);
         brace_token.surround(tokens, |_tokens| {});


### PR DESCRIPTION
Part of #608. This updates all Rust generated code when instantiating generic types containing lifetime parameters. This builds on the lifetimes collected by the name resolver in #634.

```rust
#[cxx::bridge]
mod ffi {
    extern "C++" {
        type Borrowed<'a>;
                     ^^^^
        fn demo<'b>(s: &'b str) -> UniquePtr<Borrowed<'b>>;
    }
}
```

*turns into:*

```rust
unsafe impl<'a> UniquePtrTarget for Borrowed<'a> {...}
           ^^^^                             ^^^^
```