### PR TITLE
Remove rust::Slice repr conversion in C++

### DIFF
--- a/gen/src/builtin.rs
+++ b/gen/src/builtin.rs
@@ -20,8 +20,6 @@ pub struct Builtins<'a> {
     pub maybe_uninit: bool,
     pub trycatch: bool,
     pub ptr_len: bool,
-    pub rust_slice_new: bool,
-    pub rust_slice_repr: bool,
     pub exception: bool,
     pub relocatable: bool,
     pub friend_impl: bool,
@@ -230,31 +228,6 @@ pub(super) fn write(out: &mut OutFile) {
         writeln!(out, "  ::std::size_t len;");
         writeln!(out, "}};");
         out.end_block(Block::Namespace("repr"));
-    }
-
-    if builtin.rust_slice_new || builtin.rust_slice_repr {
-        out.next_section();
-        writeln!(out, "template <typename T>");
-        writeln!(out, "class impl<Slice<T>> final {{");
-        writeln!(out, "public:");
-        if builtin.rust_slice_new {
-            writeln!(
-                out,
-                "  static Slice<T> slice(repr::PtrLen repr) noexcept {{",
-            );
-            writeln!(out, "    return {{static_cast<T *>(repr.ptr), repr.len}};");
-            writeln!(out, "  }}");
-        }
-        if builtin.rust_slice_repr {
-            include.type_traits = true;
-            writeln!(
-                out,
-                "  static repr::PtrLen repr(Slice<T> slice) noexcept {{",
-            );
-            writeln!(out, "    return repr::PtrLen{{slice.ptr, slice.len}};");
-            writeln!(out, "  }}");
-        }
-        writeln!(out, "}};");
     }
 
     if builtin.rust_error {

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -120,7 +120,6 @@ public:
   bool operator>=(const Str &) const noexcept;
 
 private:
-  friend impl<Str>;
   // Not necessarily ABI compatible with &str. Codegen will translate to
   // cxx::rust_str::RustStr which matches this layout.
   const char *ptr;
@@ -174,7 +173,6 @@ public:
   iterator end() const noexcept;
 
 private:
-  friend impl<Slice>;
   // Not necessarily ABI compatible with &[T]. Codegen will translate to
   // cxx::rust_slice::RustSlice which matches this layout.
   void *ptr;


### PR DESCRIPTION
These layout conversions between pod and non-pod were made obsolete by #387, as since then `rust::Str` and `rust::Slice<T>` are correctly implemented as pod.