### PR TITLE
MSVC workaround for "C linkage function cannot return C++ class"

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -119,6 +119,22 @@ fn write_data_structures<'a>(out: &mut OutFile<'a>, apis: &'a [Api]) {
         }
     }
 
+    out.set_namespace(Default::default());
+
+    out.next_section();
+    for ty in out.types {
+        // MSVC workaround for "C linkage function cannot return C++ class"
+        // error. Apparently the compiler fails to perform implicit
+        // instantiations as part of an extern declaration. Instead we
+        // instantiate explicitly.
+        // See https://stackoverflow.com/a/57429504/6086311.
+        if let Type::SliceRef(_) = ty {
+            write!(out, "template struct ");
+            write_type(out, ty);
+            writeln!(out, ";");
+        }
+    }
+
     out.next_section();
     for api in apis {
         if let Api::TypeAlias(ety) = api {

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -828,13 +828,6 @@ std::unique_ptr<I> ns_c_return_unique_ptr_ns() {
 // > definition) of each of its non-inherited non-template members that has not
 // > been previously explicitly specialized in the translation unit.
 template struct rust::Box<tests::Shared>;
-template struct rust::Slice<const char>;
-template struct rust::Slice<const uint8_t>;
-template struct rust::Slice<uint8_t>;
-template struct rust::Slice<const tests::Shared>;
-template struct rust::Slice<tests::Shared>;
-template struct rust::Slice<const tests::R>;
-template struct rust::Slice<tests::R>;
 template struct rust::Vec<uint8_t>;
 template struct rust::Vec<rust::String>;
 template struct rust::Vec<tests::Shared>;


### PR DESCRIPTION
Unblocks #636. MSVC fails to compile code like the following unless there is an explicit instantiation of the class template:

```cpp
template <typename T>
class slice {};

//template class slice<int>;

extern "C" slice<int> repro() { return {}; }
```

Error:

```console
<source>(6): error C2526: 'repro': C linkage function cannot return C++ class 'slice<int>'
<source>(6): note: see declaration of 'slice<int>'
<source>(6): error C2562: 'repro': 'void' function returning a value
<source>(6): note: see declaration of 'repro'
Compiler returned: 2
```