### PR TITLE
Remove rust::Str repr conversion in C++

### DIFF
--- a/gen/src/builtin.rs
+++ b/gen/src/builtin.rs
@@ -20,8 +20,6 @@ pub struct Builtins<'a> {
     pub maybe_uninit: bool,
     pub trycatch: bool,
     pub ptr_len: bool,
-    pub rust_str_new_unchecked: bool,
-    pub rust_str_repr: bool,
     pub rust_slice_new: bool,
     pub rust_slice_repr: bool,
     pub exception: bool,
@@ -232,33 +230,6 @@ pub(super) fn write(out: &mut OutFile) {
         writeln!(out, "  ::std::size_t len;");
         writeln!(out, "}};");
         out.end_block(Block::Namespace("repr"));
-    }
-
-    if builtin.rust_str_new_unchecked || builtin.rust_str_repr {
-        out.next_section();
-        writeln!(out, "template <>");
-        writeln!(out, "class impl<Str> final {{");
-        writeln!(out, "public:");
-        if builtin.rust_str_new_unchecked {
-            writeln!(
-                out,
-                "  static Str new_unchecked(repr::PtrLen repr) noexcept {{",
-            );
-            writeln!(out, "    Str str;");
-            writeln!(out, "    str.ptr = static_cast<const char *>(repr.ptr);");
-            writeln!(out, "    str.len = repr.len;");
-            writeln!(out, "    return str;");
-            writeln!(out, "  }}");
-        }
-        if builtin.rust_str_repr {
-            writeln!(out, "  static repr::PtrLen repr(Str str) noexcept {{");
-            writeln!(
-                out,
-                "    return repr::PtrLen{{const_cast<char *>(str.ptr), str.len}};",
-            );
-            writeln!(out, "  }}");
-        }
-        writeln!(out, "}};");
     }
 
     if builtin.rust_slice_new || builtin.rust_slice_repr {

--- a/tests/cxx_gen.rs
+++ b/tests/cxx_gen.rs
@@ -20,7 +20,7 @@ fn test_extern_c_function() {
     let output = str::from_utf8(&generated.implementation).unwrap();
     // To avoid continual breakage we won't test every byte.
     // Let's look for the major features.
-    assert!(output.contains("void cxxbridge1$do_cpp_thing(::rust::repr::PtrLen foo)"));
+    assert!(output.contains("void cxxbridge1$do_cpp_thing(::rust::Str foo)"));
 }
 
 #[test]
@@ -30,5 +30,5 @@ fn test_impl_annotation() {
     let source = BRIDGE0.parse().unwrap();
     let generated = generate_header_and_cc(source, &opt).unwrap();
     let output = str::from_utf8(&generated.implementation).unwrap();
-    assert!(output.contains("ANNOTATION void cxxbridge1$do_cpp_thing(::rust::repr::PtrLen foo)"));
+    assert!(output.contains("ANNOTATION void cxxbridge1$do_cpp_thing(::rust::Str foo)"));
 }


### PR DESCRIPTION
Extracted from #636 since it does not depend on #637.