### PR TITLE
Fix warning mismatching struct and class

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -135,7 +135,7 @@ fn write_data_structures<'a>(out: &mut OutFile<'a>, apis: &'a [Api]) {
         }
     }
     for ty in &slice_in_return_position {
-        write!(out, "template struct ");
+        write!(out, "template class ");
         write_type(out, ty);
         writeln!(out, ";");
     }

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -827,12 +827,12 @@ std::unique_ptr<I> ns_c_return_unique_ptr_ns() {
 // > serves as an explicit instantiation of the same kind (declaration or
 // > definition) of each of its non-inherited non-template members that has not
 // > been previously explicitly specialized in the translation unit.
-template struct rust::Box<tests::Shared>;
-template struct rust::Slice<const tests::Shared>;
-template struct rust::Slice<tests::Shared>;
-template struct rust::Slice<const tests::R>;
-template struct rust::Slice<tests::R>;
-template struct rust::Vec<uint8_t>;
-template struct rust::Vec<rust::String>;
-template struct rust::Vec<tests::Shared>;
-template struct rust::Fn<size_t(rust::String)>;
+template class rust::Box<tests::Shared>;
+template class rust::Slice<const tests::Shared>;
+template class rust::Slice<tests::Shared>;
+template class rust::Slice<const tests::R>;
+template class rust::Slice<tests::R>;
+template class rust::Vec<uint8_t>;
+template class rust::Vec<rust::String>;
+template class rust::Vec<tests::Shared>;
+template class rust::Fn<size_t(rust::String)>;


### PR DESCRIPTION
Fix for warning when running cargo test. When looking at the declarations in`include/cxx.h`, the types are defined as `class Str final` etc. This mismatch when compared to `lib.rs.cc` causes a compiler warning to be output.

```
warning: /Users/pickett/Documents/GitHub/cxx/target/debug/build/cxx-test-suite-de711daed7f2e46d/out/cxxbridge/sources/tests/ffi/lib.rs.cc:1256:10: warning: struct template 'Slice' was previously declared as a class template; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
warning: template struct ::rust::Slice<const char>;
warning:          ^
warning: /Users/pickett/Documents/GitHub/cxx/target/debug/build/cxx-test-suite-de711daed7f2e46d/out/cxxbridge/include/rust/cxx.h:146:7: note: previous use is here
warning: class Slice final
warning:       ^
warning: /Users/pickett/Documents/GitHub/cxx/target/debug/build/cxx-test-suite-de711daed7f2e46d/out/cxxbridge/sources/tests/ffi/lib.rs.cc:1256:10: note: did you mean class here?
warning: template struct ::rust::Slice<const char>;
warning:          ^~~~~~
warning:          class
```

The fix is to use `class` instead.