### PR TITLE
Include a launch config for cargo tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,18 @@
                     "kind": "bin"
                 }
             }
-        }
+        },
+        {
+            "name": "Debug cargo tests",
+            "type": "lldb",
+            "request": "launch",
+            "cargo": {
+                "args": ["test", "--no-run"],
+                "filter": {
+                    "name": "test",
+                    "kind": "test"
+                }
+            }
+        },
     ]
 }


### PR DESCRIPTION
First time using VS Code to develop and I found this config made it easier to jump into breakpoint debugging the cargo tests.

"Debug cargo tests" now shows up in the drop-down, and setting a breakpoint in CXX or rust correctly stops.

<img width="1002" alt="Debugger in VSCode" src="https://user-images.githubusercontent.com/962096/103459513-dbcedb80-4cc4-11eb-9892-112e5d43669a.png">
