### PR TITLE
Add swap members + ADL functions

### DIFF
--- a/book/src/binding/box.md
+++ b/book/src/binding/box.md
@@ -25,6 +25,8 @@ public:
   explicit Box(const T &);
   explicit Box(T &&);
 
+  void swap(Box &) noexcept;
+
   Box &operator=(const Box &);
   Box &operator=(Box &&) noexcept;
 

--- a/book/src/binding/slice.md
+++ b/book/src/binding/slice.md
@@ -32,6 +32,8 @@ public:
   size_t length() const noexcept;
   bool empty() const noexcept;
 
+  void swap(Slice & rhs) noexcept;
+
   T &operator[](size_t n) const noexcept;
   T &at(size_t n) const;
   T &front() const noexcept;

--- a/book/src/binding/str.md
+++ b/book/src/binding/str.md
@@ -31,6 +31,8 @@ public:
   size_t size() const noexcept;
   size_t length() const noexcept;
 
+  void swap(Str & rhs) noexcept;
+
   using iterator = const char *;
   using const_iterator = const char *;
   const_iterator begin() const noexcept;

--- a/book/src/binding/string.md
+++ b/book/src/binding/string.md
@@ -35,6 +35,8 @@ public:
 
   const char *c_str() noexcept;
 
+  void swap(String & rhs) noexcept;
+
   using iterator = char *;
   iterator begin() noexcept;
   iterator end() noexcept;

--- a/book/src/binding/vec.md
+++ b/book/src/binding/vec.md
@@ -31,6 +31,8 @@ public:
   const T *data() const noexcept;
   T *data() noexcept;
   size_t capacity() const noexcept;
+  
+  void swap(Vec & rhs) noexcept;
 
   const T &operator[](size_t n) const noexcept;
   const T &at(size_t n) const;

--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -130,6 +130,11 @@ const char *String::c_str() noexcept {
   return ptr;
 }
 
+void String::swap(String& rhs) noexcept {
+  using std::swap;
+  swap(this->repr, rhs.repr);
+}
+
 String::iterator String::begin() noexcept {
   return const_cast<char *>(this->data());
 }
@@ -208,6 +213,12 @@ Str::Str(const char *s, std::size_t len)
 
 Str::operator std::string() const {
   return std::string(this->data(), this->size());
+}
+
+void Str::swap(Str& rhs) noexcept {
+  using std::swap;
+  swap(this->ptr, rhs.ptr);
+  swap(this->len, rhs.len);
 }
 
 Str::const_iterator Str::begin() const noexcept { return this->cbegin(); }

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -752,8 +752,12 @@ extern "C" const char *cxx_run_test() noexcept {
   ASSERT(r->get() == 2020);
   ASSERT(r->set(2021) == 2021);
   ASSERT(r->get() == 2021);
-  ASSERT(r->set(2020) == 2020);
+  auto r2 = r_return_box();
+  swap(r, r2);
   ASSERT(r->get() == 2020);
+  ASSERT(r2->get() == 2021);
+
+
   ASSERT(std::string(Shared{0}.r_method_on_shared()) == "2020");
 
   ASSERT(std::string(rAliasedFunction(2020)) == "2020");
@@ -785,6 +789,23 @@ extern "C" const char *cxx_run_test() noexcept {
   ASSERT(strncmp(cstring.data(), "test", 4) == 0);
   ASSERT(strncmp(cstring.c_str(), "test", 5) == 0);
   ASSERT(cstring.length() == 4);
+
+  rust::String other_cstring = "foo";
+  swap(cstring, other_cstring);
+  ASSERT(cstring == "foo");
+  ASSERT(other_cstring == "test");
+
+  rust::Str cstr = "test";
+  rust::Str other_cstr = "foo";
+  swap(cstr, other_cstr);
+  ASSERT(cstr == "foo");
+  ASSERT(other_cstr == "test");
+
+  rust::Vec<int> vec1{1, 2};
+  rust::Vec<int> vec2{3, 4};
+  swap(vec1, vec2);
+  ASSERT(vec1[0] == 3 && vec1[1] == 4);
+  ASSERT(vec2[0] == 1 && vec2[1] == 2);
 
   cxx_test_suite_set_correct();
   return nullptr;


### PR DESCRIPTION
Fixes #58.

Adds `swap` members to each of `Slice`, `Str`, `Vec`, `Box`, and `String`. Also adds private friend functions so that Argument Dependent Lookup may function via the `using std::swap;` idiom.