### PR TITLE
Remove Str and Slice swaps

### DIFF
--- a/include/cxx.h
+++ b/include/cxx.h
@@ -106,8 +106,6 @@ public:
   std::size_t size() const noexcept;
   std::size_t length() const noexcept;
 
-  void swap(Str &) noexcept;
-
   // Important in order for System V ABI to pass in registers.
   Str(const Str &) noexcept = default;
   ~Str() noexcept = default;
@@ -127,8 +125,6 @@ public:
   bool operator>=(const Str &) const noexcept;
 
 private:
-  friend void swap(Str &lhs, Str &rhs) noexcept { lhs.swap(rhs); }
-
   // Not necessarily ABI compatible with &str. Codegen will translate to
   // cxx::rust_str::RustStr which matches this layout.
   const char *ptr;
@@ -168,8 +164,6 @@ public:
   std::size_t length() const noexcept;
   bool empty() const noexcept;
 
-  void swap(Slice &) noexcept;
-
   T &operator[](std::size_t n) const noexcept;
   T &at(std::size_t n) const;
   T &front() const noexcept;
@@ -184,8 +178,6 @@ public:
   iterator end() const noexcept;
 
 private:
-  friend void swap(Slice<T> &lhs, Slice<T> &rhs) noexcept { lhs.swap(rhs); }
-
   // Not necessarily ABI compatible with &[T]. Codegen will translate to
   // cxx::rust_slice::RustSlice which matches this layout.
   void *ptr;
@@ -524,13 +516,6 @@ std::size_t Slice<T>::size() const noexcept {
 template <typename T>
 std::size_t Slice<T>::length() const noexcept {
   return this->len;
-}
-
-template <typename T>
-void Slice<T>::swap(Slice<T> &rhs) noexcept {
-  using std::swap;
-  swap(this->ptr, rhs.ptr);
-  swap(this->len, rhs.len);
 }
 
 template <typename T>

--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -215,12 +215,6 @@ Str::operator std::string() const {
   return std::string(this->data(), this->size());
 }
 
-void Str::swap(Str &rhs) noexcept {
-  using std::swap;
-  swap(this->ptr, rhs.ptr);
-  swap(this->len, rhs.len);
-}
-
 Str::const_iterator Str::begin() const noexcept { return this->cbegin(); }
 
 Str::const_iterator Str::end() const noexcept { return this->cend(); }

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -751,6 +751,8 @@ extern "C" const char *cxx_run_test() noexcept {
   ASSERT(r->get() == 2020);
   ASSERT(r->set(2021) == 2021);
   ASSERT(r->get() == 2021);
+
+  using std::swap;
   auto r2 = r_return_box();
   swap(r, r2);
   ASSERT(r->get() == 2020);


### PR DESCRIPTION
Both of these types are "is_trivially_move_constructible" and "is_trivially_move_assignable", so the default std::swap would already correctly do exactly the same thing that these are doing.

We keep the custom swap on Box, String, Vec which are not trivially movable, their moves do stuff to the source object to move around ownership.

FYI @capickett 