### PR TITLE
Decouple C++ exception representation from Rust str

### DIFF
--- a/src/result.rs
+++ b/src/result.rs
@@ -1,16 +1,22 @@
 use crate::exception::Exception;
-use crate::rust_str::RustStr;
 use alloc::boxed::Box;
 use alloc::string::{String, ToString};
 use core::fmt::Display;
-use core::ptr;
+use core::ptr::{self, NonNull};
 use core::result::Result as StdResult;
 use core::slice;
 use core::str;
 
 #[repr(C)]
+#[derive(Copy, Clone)]
+struct PtrLen {
+    ptr: NonNull<u8>,
+    len: usize,
+}
+
+#[repr(C)]
 pub union Result {
-    err: RustStr,
+    err: PtrLen,
     ok: *const u8, // null
 }
 
@@ -41,7 +47,10 @@ unsafe fn to_c_error(msg: String) -> Result {
     let copy = error(ptr, len);
     let slice = slice::from_raw_parts(copy, len);
     let string = str::from_utf8_unchecked(slice);
-    let err = RustStr::from(string);
+    let err = PtrLen {
+        ptr: NonNull::from(string).cast::<u8>(),
+        len: string.len(),
+    };
     Result { err }
 }
 


### PR DESCRIPTION
This is necessary in order to update rust::Str to match the layout of &amp;str (using the same techniques we do in rust::String to make it match the representation of String in Rust).

Part of the work on #608. Once we allow lifetimes in general, including in structs, it will be possible to have structs containing &amp;str where we can no longer rely on the code generator to reconcile the representation between the Rust side and C++ side the way we currently do for strs in function argument and function return position.