### PR TITLE
Preserve &str's original Rust representation in C++

### DIFF
--- a/include/cxx.h
+++ b/include/cxx.h
@@ -88,6 +88,7 @@ private:
 #endif // CXXBRIDGE1_RUST_STRING
 
 #ifndef CXXBRIDGE1_RUST_STR
+#define CXXBRIDGE1_RUST_STR
 // https://cxx.rs/binding/str.html
 class Str final {
 public:
@@ -125,10 +126,7 @@ public:
   bool operator>=(const Str &) const noexcept;
 
 private:
-  // Not necessarily ABI compatible with &str. Codegen will translate to
-  // cxx::rust_str::RustStr which matches this layout.
-  const char *ptr;
-  std::size_t len;
+  std::array<std::uintptr_t, 2> repr;
 };
 #endif // CXXBRIDGE1_RUST_STR
 
@@ -483,15 +481,6 @@ struct unsafe_bitcopy_t final {
 
 constexpr unsafe_bitcopy_t unsafe_bitcopy{};
 #endif // CXXBRIDGE1_RUST_BITCOPY
-
-#ifndef CXXBRIDGE1_RUST_STR
-#define CXXBRIDGE1_RUST_STR
-inline const char *Str::data() const noexcept { return this->ptr; }
-
-inline std::size_t Str::size() const noexcept { return this->len; }
-
-inline std::size_t Str::length() const noexcept { return this->len; }
-#endif // CXXBRIDGE1_RUST_STR
 
 #ifndef CXXBRIDGE1_RUST_SLICE
 #define CXXBRIDGE1_RUST_SLICE

--- a/src/rust_str.rs
+++ b/src/rust_str.rs
@@ -1,27 +1,20 @@
 use core::mem;
 use core::ptr::NonNull;
-use core::slice;
 use core::str;
 
-// Not necessarily ABI compatible with &str. Codegen performs the translation.
 #[repr(C)]
-#[derive(Copy, Clone)]
 pub struct RustStr {
-    pub(crate) ptr: NonNull<u8>,
-    pub(crate) len: usize,
+    repr: NonNull<str>,
 }
 
 impl RustStr {
-    pub fn from(s: &str) -> Self {
-        RustStr {
-            ptr: NonNull::from(s).cast::<u8>(),
-            len: s.len(),
-        }
+    pub fn from(repr: &str) -> Self {
+        let repr = NonNull::from(repr);
+        RustStr { repr }
     }
 
     pub unsafe fn as_str<'a>(self) -> &'a str {
-        let slice = slice::from_raw_parts(self.ptr.as_ptr(), self.len);
-        str::from_utf8_unchecked(slice)
+        &*self.repr.as_ptr()
     }
 }
 

--- a/src/symbols/rust_str.rs
+++ b/src/symbols/rust_str.rs
@@ -1,8 +1,37 @@
+use alloc::string::String;
+use core::mem::MaybeUninit;
+use core::ptr;
 use core::slice;
 use core::str;
 
-#[export_name = "cxxbridge1$str$valid"]
-unsafe extern "C" fn str_valid(ptr: *const u8, len: usize) -> bool {
+#[export_name = "cxxbridge1$str$new"]
+unsafe extern "C" fn str_new(this: &mut MaybeUninit<&str>) {
+    ptr::write(this.as_mut_ptr(), "");
+}
+
+#[export_name = "cxxbridge1$str$ref"]
+unsafe extern "C" fn str_ref<'a>(this: &mut MaybeUninit<&'a str>, string: &'a String) {
+    ptr::write(this.as_mut_ptr(), string.as_str());
+}
+
+#[export_name = "cxxbridge1$str$from"]
+unsafe extern "C" fn str_from(this: &mut MaybeUninit<&str>, ptr: *const u8, len: usize) -> bool {
     let slice = slice::from_raw_parts(ptr, len);
-    str::from_utf8(slice).is_ok()
+    match str::from_utf8(slice) {
+        Ok(s) => {
+            ptr::write(this.as_mut_ptr(), s);
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+#[export_name = "cxxbridge1$str$ptr"]
+unsafe extern "C" fn str_ptr(this: &&str) -> *const u8 {
+    this.as_ptr()
+}
+
+#[export_name = "cxxbridge1$str$len"]
+unsafe extern "C" fn str_len(this: &&str) -> usize {
+    this.len()
 }


### PR DESCRIPTION
Part of the work on #608. Once we allow lifetimes in general, including in structs, it will be possible to have structs containing &str where we can no longer rely on the code generator to reconcile the representation between the Rust side and C++ side the way we currently do for strs in function argument and function return position.