### PR TITLE
Preserve &[T]'s Rust representation in rust::Slice

### DIFF
--- a/include/cxx.h
+++ b/include/cxx.h
@@ -180,6 +180,10 @@ public:
   void swap(Slice &) noexcept;
 
 private:
+  friend void sliceInit(void *, const void *, std::size_t) noexcept;
+  friend void *slicePtr(const void *) noexcept;
+  friend std::size_t sliceLen(const void *) noexcept;
+
   std::array<std::uintptr_t, 2> repr;
 };
 
@@ -485,10 +489,6 @@ constexpr unsafe_bitcopy_t unsafe_bitcopy{};
 
 #ifndef CXXBRIDGE1_RUST_SLICE
 #define CXXBRIDGE1_RUST_SLICE
-void sliceInit(void *, const void *, std::size_t) noexcept;
-void *slicePtr(const void *) noexcept;
-std::size_t sliceLen(const void *) noexcept;
-
 template <typename T>
 Slice<T>::Slice() noexcept {
   sliceInit(this, reinterpret_cast<void *>(align_of<T>()), 0);

--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -45,6 +45,12 @@ bool cxxbridge1$str$from(rust::Str *self, const char *ptr,
                          std::size_t len) noexcept;
 const char *cxxbridge1$str$ptr(const rust::Str *self) noexcept;
 std::size_t cxxbridge1$str$len(const rust::Str *self) noexcept;
+
+// rust::Slice
+void cxxbridge1$slice$new(void *self, const void *ptr,
+                          std::size_t len) noexcept;
+void *cxxbridge1$slice$ptr(const void *self) noexcept;
+std::size_t cxxbridge1$slice$len(const void *self) noexcept;
 } // extern "C"
 
 namespace rust {
@@ -272,6 +278,16 @@ void Str::swap(Str &rhs) noexcept { std::swap(*this, rhs); }
 std::ostream &operator<<(std::ostream &os, const Str &s) {
   os.write(s.data(), s.size());
   return os;
+}
+
+void sliceInit(void *self, const void *ptr, std::size_t len) noexcept {
+  cxxbridge1$slice$new(self, ptr, len);
+}
+
+void *slicePtr(const void *self) noexcept { return cxxbridge1$slice$ptr(self); }
+
+std::size_t sliceLen(const void *self) noexcept {
+  return cxxbridge1$slice$len(self);
 }
 
 // Rust specifies that usize is ABI compatible with C's uintptr_t.

--- a/src/rust_slice.rs
+++ b/src/rust_slice.rs
@@ -1,36 +1,37 @@
 use core::mem;
-use core::ptr::NonNull;
+use core::ptr::{self, NonNull};
 use core::slice;
 
-// Not necessarily ABI compatible with &[T]. Codegen performs the translation.
 #[repr(C)]
-#[derive(Copy, Clone)]
 pub struct RustSlice {
-    pub(crate) ptr: NonNull<()>,
-    pub(crate) len: usize,
+    pub(crate) repr: NonNull<[()]>,
 }
 
 impl RustSlice {
-    pub fn from_ref<T>(s: &[T]) -> Self {
+    pub fn from_ref<T>(slice: &[T]) -> Self {
+        let ptr = ptr::slice_from_raw_parts::<()>(slice.as_ptr().cast(), slice.len());
         RustSlice {
-            ptr: NonNull::from(s).cast::<()>(),
-            len: s.len(),
+            repr: unsafe { NonNull::new_unchecked(ptr as *mut _) },
         }
     }
 
-    pub fn from_mut<T>(s: &mut [T]) -> Self {
+    pub fn from_mut<T>(slice: &mut [T]) -> Self {
+        let ptr = ptr::slice_from_raw_parts_mut(slice.as_mut_ptr().cast(), slice.len());
         RustSlice {
-            len: s.len(),
-            ptr: NonNull::from(s).cast::<()>(),
+            repr: unsafe { NonNull::new_unchecked(ptr) },
         }
     }
 
     pub unsafe fn as_slice<'a, T>(self) -> &'a [T] {
-        slice::from_raw_parts(self.ptr.as_ptr().cast::<T>(), self.len)
+        let ptr = self.repr.as_ptr();
+        let len = self.repr.as_ref().len();
+        slice::from_raw_parts(ptr.cast(), len)
     }
 
     pub unsafe fn as_mut_slice<'a, T>(self) -> &'a mut [T] {
-        slice::from_raw_parts_mut(self.ptr.as_ptr().cast::<T>(), self.len)
+        let ptr = self.repr.as_ptr();
+        let len = self.repr.as_ref().len();
+        slice::from_raw_parts_mut(ptr.cast(), len)
     }
 }
 

--- a/src/symbols/mod.rs
+++ b/src/symbols/mod.rs
@@ -1,4 +1,5 @@
 mod exception;
+mod rust_slice;
 mod rust_str;
 mod rust_string;
 mod rust_vec;

--- a/src/symbols/rust_slice.rs
+++ b/src/symbols/rust_slice.rs
@@ -1,0 +1,22 @@
+use crate::rust_slice::RustSlice;
+use core::mem::MaybeUninit;
+use core::ptr::{self, NonNull};
+
+#[export_name = "cxxbridge1$slice$new"]
+unsafe extern "C" fn slice_new(this: &mut MaybeUninit<RustSlice>, ptr: *const (), len: usize) {
+    let ptr = ptr::slice_from_raw_parts(ptr, len);
+    let rust_slice = RustSlice {
+        repr: NonNull::new_unchecked(ptr as *mut _),
+    };
+    ptr::write(this.as_mut_ptr(), rust_slice);
+}
+
+#[export_name = "cxxbridge1$slice$ptr"]
+unsafe extern "C" fn slice_ptr(this: &RustSlice) -> *const () {
+    this.repr.as_ptr().cast()
+}
+
+#[export_name = "cxxbridge1$slice$len"]
+unsafe extern "C" fn slice_len(this: &RustSlice) -> usize {
+    this.repr.as_ref().len()
+}


### PR DESCRIPTION
#645, but for slices too.

Part of #608.