### PR TITLE
Explicitly delete opaque Rust type destructors

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -359,9 +359,8 @@ fn write_opaque_type<'a>(out: &mut OutFile<'a>, ety: &'a ExternType, methods: &[
         writeln!(out, ";");
     }
 
-    if !methods.is_empty() {
-        writeln!(out);
-    }
+    writeln!(out, "  ~{}() = delete;", ety.name.cxx);
+    writeln!(out);
 
     out.builtin.layout = true;
     out.include.cstddef = true;


### PR DESCRIPTION
I guess MSVC finds this important enough to emit warnings about otherwise.

```console
cxxbridge\sources\tests\ffi\lib.rs.cc(1220): warning C4624: 'tests::R': destructor was implicitly defined as deleted
```