### PR TITLE
Enable lifetimes on opaque C++ types

### DIFF
--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -71,11 +71,6 @@ fn check_type_ident(cx: &mut Check, name: &NamedType) {
     {
         let msg = format!("unsupported type: {}", ident);
         cx.error(ident, &msg);
-        return;
-    }
-
-    if !name.generics.lifetimes.is_empty() {
-        cx.error(name, "type with lifetime parameter is not supported yet");
     }
 }
 
@@ -341,7 +336,10 @@ fn check_api_type(cx: &mut Check, ety: &ExternType) {
     }
 
     if let Some(lifetime) = ety.generics.lifetimes.first() {
-        cx.error(lifetime, "extern type with lifetimes is not supported yet");
+        if ety.lang == Lang::Rust {
+            let msg = "extern Rust type with lifetimes is not supported yet";
+            cx.error(lifetime, msg);
+        }
     }
 
     if !ety.bounds.is_empty() {
@@ -446,10 +444,6 @@ fn check_api_type_alias(cx: &mut Check, alias: &TypeAlias) {
     for derive in &alias.derives {
         let msg = format!("derive({}) on extern type alias is not supported", derive);
         cx.error(derive, msg);
-    }
-
-    if let Some(lifetime) = alias.generics.lifetimes.first() {
-        cx.error(lifetime, "extern type with lifetimes is not supported yet");
     }
 }
 

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -210,6 +210,15 @@ pub mod ffi {
         type Job = crate::module::ffi::Job;
     }
 
+    unsafe extern "C++" {
+        type Borrow<'a>;
+
+        fn c_return_borrow<'a>(s: &'a CxxString) -> UniquePtr<Borrow<'a>>;
+
+        #[rust_name = "c_return_borrow_elided"]
+        fn c_return_borrow(s: &CxxString) -> UniquePtr<Borrow>;
+    }
+
     #[repr(u32)]
     #[derive(Hash)]
     enum COwnedEnum {

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -207,6 +207,12 @@ Enum c_return_enum(uint16_t n) {
   }
 }
 
+Borrow::Borrow(const std::string &s) : s(s) {}
+
+std::unique_ptr<Borrow> c_return_borrow(const std::string &s) {
+  return std::unique_ptr<Borrow>(new Borrow(s));
+}
+
 void c_take_primitive(size_t n) {
   if (n == 2020) {
     cxx_test_suite_set_correct();

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -77,6 +77,11 @@ enum COwnedEnum {
   CVAL2,
 };
 
+struct Borrow {
+  Borrow(const std::string &s);
+  const std::string &s;
+};
+
 size_t c_return_primitive();
 Shared c_return_shared();
 ::A::AShared c_return_ns_shared();
@@ -110,6 +115,7 @@ size_t c_return_sum(size_t n1, size_t n2);
 Enum c_return_enum(uint16_t n);
 ::A::AEnum c_return_ns_enum(uint16_t n);
 ::A::B::ABEnum c_return_nested_ns_enum(uint16_t n);
+std::unique_ptr<Borrow> c_return_borrow(const std::string &s);
 
 void c_take_primitive(size_t n);
 void c_take_shared(Shared shared);

--- a/tests/ui/extern_type_lifetime.rs
+++ b/tests/ui/extern_type_lifetime.rs
@@ -1,8 +1,0 @@
-#[cxx::bridge]
-mod ffi {
-    extern "C++" {
-        type Complex<'a, 'b>;
-    }
-}
-
-fn main() {}

--- a/tests/ui/extern_type_lifetime.stderr
+++ b/tests/ui/extern_type_lifetime.stderr
@@ -1,5 +1,0 @@
-error: extern type with lifetimes is not supported yet
- --> $DIR/extern_type_lifetime.rs:4:22
-  |
-4 |         type Complex<'a, 'b>;
-  |                      ^^


### PR DESCRIPTION
Closes #608 (with the help of the large number of other PRs linked to that issue).