### PR TITLE
Enable lifetimes on opaque Rust types

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -677,11 +677,12 @@ fn expand_rust_type_import(ety: &ExternType) -> TokenStream {
 
 fn expand_rust_type_impl(ety: &ExternType) -> TokenStream {
     let ident = &ety.name.rust;
+    let generics = &ety.generics;
     let span = ident.span();
     let unsafe_impl = quote_spanned!(ety.type_token.span=> unsafe impl);
 
     let mut impls = quote_spanned! {span=>
-        #unsafe_impl ::cxx::private::RustType for #ident {}
+        #unsafe_impl #generics ::cxx::private::RustType for #ident #generics {}
     };
 
     for derive in &ety.derives {
@@ -689,7 +690,7 @@ fn expand_rust_type_impl(ety: &ExternType) -> TokenStream {
             let type_id = type_id(&ety.name);
             let span = derive.span;
             impls.extend(quote_spanned! {span=>
-                unsafe impl ::cxx::ExternType for #ident {
+                unsafe impl #generics ::cxx::ExternType for #ident #generics {
                     type Id = #type_id;
                     type Kind = ::cxx::kind::Opaque;
                 }

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -335,13 +335,6 @@ fn check_api_type(cx: &mut Check, ety: &ExternType) {
         cx.error(derive, msg);
     }
 
-    if let Some(lifetime) = ety.generics.lifetimes.first() {
-        if ety.lang == Lang::Rust {
-            let msg = "extern Rust type with lifetimes is not supported yet";
-            cx.error(lifetime, msg);
-        }
-    }
-
     if !ety.bounds.is_empty() {
         let bounds = &ety.bounds;
         let span = quote!(#(#bounds)*);

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -210,6 +210,11 @@ pub mod ffi {
         type Job = crate::module::ffi::Job;
     }
 
+    extern "Rust" {
+        #[derive(ExternType)]
+        type Reference<'a>;
+    }
+
     unsafe extern "C++" {
         type Borrow<'a>;
 
@@ -376,6 +381,8 @@ impl R {
         n
     }
 }
+
+pub struct Reference<'a>(&'a String);
 
 impl ffi::Shared {
     fn r_method_on_shared(&self) -> String {


### PR DESCRIPTION
Follow-up to #608.