### PR TITLE
Force annotation on all functions in both source and header files

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -910,6 +910,7 @@ fn write_rust_function_shim_decl(
     sig: &Signature,
     indirect_call: bool,
 ) {
+    begin_function_definition(out);
     write_return_type(out, &sig.ret);
     write!(out, "{}(", local_name);
     for (i, arg) in sig.args.iter().enumerate() {
@@ -946,9 +947,6 @@ fn write_rust_function_shim_impl(
     if out.header && sig.receiver.is_some() {
         // We've already defined this inside the struct.
         return;
-    }
-    if !out.header {
-        begin_function_definition(out);
     }
     write_rust_function_shim_decl(out, local_name, sig, indirect_call);
     if out.header {


### PR DESCRIPTION
Cherry picked from https://github.com/david-cattermole/cxx/commit/d58c650847d1f734d1c09a4e87d50f5904f2c4f5. See https://github.com/dtolnay/cxx/issues/612#issuecomment-753544437.

> Annotations for symbol visibility (such as `__declspec(dllexport)` and `__attribute__((visibility("default")))`) is the primary use case. Such annotations are expected to be needed on declarations (headers) only, however forcing the annotations into the header file only is causes missing symbols. Therefore the fix is to force the annotations into both declaration (header files) and definition (source files).