### PR TITLE
WIP: Allow for Clone bound on extern Rust type + Box clone

### DIFF
--- a/gen/src/builtin.rs
+++ b/gen/src/builtin.rs
@@ -26,7 +26,7 @@ pub struct Builtins<'a> {
     pub rust_slice_new: bool,
     pub rust_slice_repr: bool,
     pub exception: bool,
-    pub relocatable: bool,
+    pub traits: bool,
     pub friend_impl: bool,
     pub is_complete: bool,
     pub deleter_if: bool,
@@ -107,7 +107,7 @@ pub(super) fn write(out: &mut OutFile) {
         include.sys_types = true;
     }
 
-    if builtin.relocatable {
+    if builtin.traits {
         include.type_traits = true;
     }
 
@@ -168,7 +168,7 @@ pub(super) fn write(out: &mut OutFile) {
     ifndef::write(out, builtin.opaque, "CXXBRIDGE1_RUST_OPAQUE");
     ifndef::write(out, builtin.is_complete, "CXXBRIDGE1_IS_COMPLETE");
     ifndef::write(out, builtin.layout, "CXXBRIDGE1_LAYOUT");
-    ifndef::write(out, builtin.relocatable, "CXXBRIDGE1_RELOCATABLE");
+    ifndef::write(out, builtin.traits, "CXXBRIDGE1_TRAITS");
 
     if builtin.rust_str_new_unchecked {
         out.next_section();

--- a/syntax/resolve.rs
+++ b/syntax/resolve.rs
@@ -1,10 +1,12 @@
-use crate::syntax::{Lifetimes, NamedType, Pair, Types};
+use crate::syntax::{Derive, Lifetimes, NamedType, Pair, Types};
 use proc_macro2::Ident;
 
 #[derive(Copy, Clone)]
 pub struct Resolution<'a> {
     pub name: &'a Pair,
     pub generics: &'a Lifetimes,
+    pub derives: Option<&'a Vec<Derive>>,
+    pub bounds: Option<&'a Vec<Derive>>,
 }
 
 impl<'a> Types<'a> {

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -125,6 +125,7 @@ pub mod ffi {
         fn c_take_primitive(n: usize);
         fn c_take_shared(shared: Shared);
         fn c_take_box(r: Box<R>);
+        fn c_clone_box(r: Box<R>);
         fn c_take_ref_r(r: &R);
         fn c_take_ref_c(c: &C);
         fn c_take_str(s: &str);
@@ -237,7 +238,7 @@ pub mod ffi {
     }
 
     extern "Rust" {
-        type R;
+        type R: Clone;
 
         fn r_return_primitive() -> usize;
         fn r_return_shared() -> Shared;
@@ -371,7 +372,7 @@ mod other {
     }
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct R(pub usize);
 
 impl R {

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -247,6 +247,13 @@ void c_take_box(rust::Box<R> r) {
   }
 }
 
+void c_clone_box(rust::Box<R> r) {
+  auto cloned = r.clone();
+  if (cxx_test_suite_r_is_correct(&*cloned)) {
+    cxx_test_suite_set_correct();
+  }
+}
+
 void c_take_unique_ptr(std::unique_ptr<C> c) {
   if (c->get() == 2020) {
     cxx_test_suite_set_correct();

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -124,6 +124,7 @@ void c_take_shared(Shared shared);
 void c_take_ns_shared(::A::AShared shared);
 void c_take_nested_ns_shared(::A::B::ABShared shared);
 void c_take_box(rust::Box<R> r);
+void c_clone_box(rust::Box<R> r);
 void c_take_unique_ptr(std::unique_ptr<C> c);
 void c_take_ref_r(const R &r);
 void c_take_ref_c(const C &c);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -120,6 +120,7 @@ fn test_c_take() {
     check!(ffi::ns_c_take_ns_shared(ffi::AShared { z: 2020 }));
     check!(ffi::c_take_nested_ns_shared(ffi::ABShared { z: 2020 }));
     check!(ffi::c_take_box(Box::new(R(2020))));
+    check!(ffi::c_clone_box(Box::new(R(2020))));
     check!(ffi::c_take_ref_c(&unique_ptr));
     check!(ffi2::c_take_ref_ns_c(&unique_ptr_ns));
     check!(cxx_test_suite::module::ffi::c_take_unique_ptr(unique_ptr));


### PR DESCRIPTION
Fixes #105.

First, extends the parsing syntax to allow for `Clone` bounds added to an extern Rust type.
Then, introduces a public `Box clone() const noexcept;` member on `Box<T>` that will only be callable if `T` is declared as `Cloneable`.
Finally, exposes a clone FFI function callable from C++ to clone the Box. These bindings are only generated if the type derives `Clone` or has a trait bound for `Clone`.

Tested with `cargo test`

Still todo:

- [ ] Fix trybuilt test cases
- [ ] Make sure the approach makes sense.
- [ ] Extend documentation to describe the new behavior.