### PR TITLE
Demo Box<dyn Trait>

### DIFF
--- a/dyntrait/Cargo.toml
+++ b/dyntrait/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "demo-dyntrait"
+version = "0.0.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+anyhow = "1.0"
+cxx = "1.0"
+
+[build-dependencies]
+cxx-build = "1.0"
+
+[workspace]

--- a/dyntrait/build.rs
+++ b/dyntrait/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    cxx_build::bridge("src/main.rs")
+        .file("src/main.cc")
+        .compile("demo-dyntrait");
+}

--- a/dyntrait/include/mydata.h
+++ b/dyntrait/include/mydata.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <array>
+#include <cstdint>
+#include <type_traits>
+
+class BoxDynMyData {
+public:
+  BoxDynMyData(BoxDynMyData &&) noexcept;
+  ~BoxDynMyData() noexcept;
+  using IsRelocatable = std::true_type;
+
+  void traitfn() const noexcept;
+
+private:
+  std::array<std::uintptr_t, 2> repr;
+};
+
+using PtrBoxDynMyData = BoxDynMyData*;

--- a/dyntrait/src/main.cc
+++ b/dyntrait/src/main.cc
@@ -1,0 +1,20 @@
+#include "demo-dyntrait/src/main.rs"
+
+BoxDynMyData::BoxDynMyData(BoxDynMyData &&other) noexcept : repr(other.repr) {
+  other.repr = {0, 0};
+}
+
+BoxDynMyData::~BoxDynMyData() noexcept {
+  if (repr != std::array<std::uintptr_t, 2>{0, 0}) {
+    dyn_mydata_drop_in_place(this);
+  }
+}
+
+void BoxDynMyData::traitfn() const noexcept {
+  dyn_mydata_traitfn(*this);
+}
+
+int main() {
+  auto mydata = read_data();
+  mydata.traitfn();
+}

--- a/dyntrait/src/main.rs
+++ b/dyntrait/src/main.rs
@@ -1,0 +1,54 @@
+#![no_main]
+
+use anyhow::Result;
+use cxx::ExternType;
+
+pub trait MyData {
+    fn traitfn(&self);
+}
+
+unsafe impl ExternType for Box<dyn MyData> {
+    type Id = cxx::type_id!("BoxDynMyData");
+    type Kind = cxx::kind::Trivial;
+}
+
+#[repr(transparent)]
+pub struct PtrBoxDynMyData(*mut Box<dyn MyData>);
+unsafe impl ExternType for PtrBoxDynMyData {
+    type Id = cxx::type_id!("PtrBoxDynMyData");
+    type Kind = cxx::kind::Trivial;
+}
+
+#[cxx::bridge]
+mod ffi {
+    extern "C++" {
+        include!("demo-dyntrait/include/mydata.h");
+        type BoxDynMyData = Box<dyn crate::MyData>;
+        type PtrBoxDynMyData = crate::PtrBoxDynMyData;
+    }
+
+    extern "Rust" {
+        fn dyn_mydata_traitfn(mydata: &BoxDynMyData);
+        unsafe fn dyn_mydata_drop_in_place(ptr: PtrBoxDynMyData);
+
+        fn read_data() -> Result<BoxDynMyData>;
+    }
+}
+
+fn dyn_mydata_traitfn(mydata: &Box<dyn MyData>) {
+    (**mydata).traitfn();
+}
+
+unsafe fn dyn_mydata_drop_in_place(ptr: PtrBoxDynMyData) {
+    std::ptr::drop_in_place(ptr.0);
+}
+
+fn read_data() -> Result<Box<dyn MyData>> {
+    struct Implementation(usize);
+    impl MyData for Implementation {
+        fn traitfn(&self) {
+            println!("it worked! {}", self.0);
+        }
+    }
+    Ok(Box::new(Implementation(9)))
+}


### PR DESCRIPTION
Demonstrates an alternative to https://github.com/dtolnay/cxx/issues/665#issuecomment-756525215, operating directly with `Box<dyn Trait>` without a double layer of `Box`.

```console
$ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/demo-dyntrait`
it worked! 9
```