### PR TITLE
RFC: Support rvalue argument

### DIFF
--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -222,9 +222,15 @@ fn check_type_ref(cx: &mut Check, ty: &Ref) {
 
     match ty.inner {
         Type::Fn(_) | Type::Void(_) => {}
-        Type::Ref(_) => {
-            cx.error(ty, "C++ does not allow references to references");
-            return;
+        Type::Ref(ref ty) => {
+            if let Type::Ref(_) = ty.inner {
+                // When the inner of the inner is still a reference (e.g. `&&&Type`).
+                cx.error(ty, "C++ does not allow references to references");
+                return;
+            } else {
+                // However this is fine since we treat `&&` as rvalue annotation.
+                return;
+            }
         }
         _ => return,
     }

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -139,7 +139,7 @@ pub mod ffi {
         fn c_take_unique_ptr_vector_f64(v: UniquePtr<CxxVector<f64>>);
         fn c_take_unique_ptr_vector_string(v: UniquePtr<CxxVector<CxxString>>);
         fn c_take_unique_ptr_vector_shared(v: UniquePtr<CxxVector<Shared>>);
-        // fn c_take_rvalue_unique_ptr(s: &&UniquePtr<CxxString>);
+        fn c_take_rvalue_unique_ptr(s: &&UniquePtr<CxxString>);
         fn c_take_ref_vector(v: &CxxVector<u8>);
         fn c_take_rust_vec(v: Vec<u8>);
         fn c_take_rust_vec_shared(v: Vec<Shared>);

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -139,6 +139,7 @@ pub mod ffi {
         fn c_take_unique_ptr_vector_f64(v: UniquePtr<CxxVector<f64>>);
         fn c_take_unique_ptr_vector_string(v: UniquePtr<CxxVector<CxxString>>);
         fn c_take_unique_ptr_vector_shared(v: UniquePtr<CxxVector<Shared>>);
+        // fn c_take_rvalue_unique_ptr(s: &&UniquePtr<CxxString>);
         fn c_take_ref_vector(v: &CxxVector<u8>);
         fn c_take_rust_vec(v: Vec<u8>);
         fn c_take_rust_vec_shared(v: Vec<Shared>);

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -355,7 +355,7 @@ void c_take_unique_ptr_vector_shared(std::unique_ptr<std::vector<Shared>> v) {
   }
 }
 
-void c_take_unique_ptr_string(std::unique_ptr<std::string> &&s) {
+void c_take_rvalue_unique_ptr(std::unique_ptr<std::string> &&s) {
   if (*s == "2020") {
     cxx_test_suite_set_correct();
   }

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -355,6 +355,12 @@ void c_take_unique_ptr_vector_shared(std::unique_ptr<std::vector<Shared>> v) {
   }
 }
 
+void c_take_unique_ptr_string(std::unique_ptr<std::string> &&s) {
+  if (*s == "2020") {
+    cxx_test_suite_set_correct();
+  }
+}
+
 void c_take_ref_vector(const std::vector<uint8_t> &v) {
   if (v.size() == 4) {
     cxx_test_suite_set_correct();

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -141,6 +141,7 @@ void c_take_unique_ptr_vector_f64(std::unique_ptr<std::vector<double>> v);
 void c_take_unique_ptr_vector_string(
     std::unique_ptr<std::vector<std::string>> v);
 void c_take_unique_ptr_vector_shared(std::unique_ptr<std::vector<Shared>> v);
+void c_take_rvalue_unique_ptr(std::unique_ptr<std::string> &&s);
 void c_take_ref_vector(const std::vector<uint8_t> &v);
 void c_take_rust_vec(rust::Vec<uint8_t> v);
 void c_take_rust_vec_index(rust::Vec<uint8_t> v);

--- a/tests/ui/reference_to_reference.rs
+++ b/tests/ui/reference_to_reference.rs
@@ -2,11 +2,15 @@
 mod ffi {
     unsafe extern "C++" {
         type ThingC;
-        fn repro_c(t: &&ThingC);
+        fn ref_c(t: &ThingC);
+        fn rvalue_c(t: &&ThingC);
+        fn repro_c(t: &&&ThingC);
     }
     extern "Rust" {
         type ThingR;
-        fn repro_r(t: &&ThingR);
+        fn ref_r(t: &ThingC);
+        fn rvalue_r(t: &ThingC);
+        fn repro_r(t: &&&ThingR);
     }
 }
 

--- a/tests/ui/reference_to_reference.stderr
+++ b/tests/ui/reference_to_reference.stderr
@@ -1,11 +1,11 @@
 error: C++ does not allow references to references
- --> $DIR/reference_to_reference.rs:5:23
+ --> $DIR/reference_to_reference.rs:7:23
   |
-5 |         fn repro_c(t: &&ThingC);
-  |                       ^^^^^^^^
+7 |         fn repro_c(t: &&&ThingC);
+  |                       ^^^^^^^^^
 
 error: C++ does not allow references to references
- --> $DIR/reference_to_reference.rs:9:23
-  |
-9 |         fn repro_r(t: &&ThingR);
-  |                       ^^^^^^^^
+  --> $DIR/reference_to_reference.rs:13:23
+   |
+13 |         fn repro_r(t: &&&ThingR);
+   |                       ^^^^^^^^^


### PR DESCRIPTION
See #561.

I opted in the `foo: &&T` syntax instead so editors can still somewhat treat it as Rust code. `&&foo: T` is .. weird and out-of-place and `#[move]` will just break. Please let me know if there is a case for these two instead of `foo: &&T`.

This is a draft since I think relaxing the reference to reference check may have broken some other stuff which I haven't gotten time to test (e.g. what would be generated if I put && in a Rust function signature). 

The handling of `Type::Ref` is also a little manual, and maybe adding a field to `Ref` type to indicate rvalue reference can improve this.