### PR TITLE
export UniquePtrTarget

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,7 +423,7 @@ pub use crate::exception::Exception;
 pub use crate::extern_type::{kind, ExternType};
 pub use crate::shared_ptr::SharedPtr;
 pub use crate::string::CxxString;
-pub use crate::unique_ptr::UniquePtr;
+pub use crate::unique_ptr::{UniquePtr,UniquePtrTarget};
 #[doc(inline)]
 pub use crate::vector::CxxVector;
 pub use crate::weak_ptr::WeakPtr;


### PR DESCRIPTION
I'm writing a trait which has a function that returns a `UniquePtr` whose type depends on type of the rust struct implemeting it using an associated type.

```rust
trait GetPtr {
    type T: UniquePtrTarget;
    fn get_ptr(self) -> UniquePtr<Self::T>;
}

impl GetPtr for FirstRustType {
    type T = ffi::FirstCppType;
    fn get_ptr(self) -> UniquePtr<Self::T> {
        ffi::get_first_ptr(self);
    }
}

impl GetPtr for SecondRustType {
    type T = ffi::SecondCppType;
    fn get_ptr(self) -> UniquePtr<Self::T> {
        ffi::get_second_ptr(self);
    }
}
```

I need to specifically bound `T` by `UniquePtrTarget`, otherwise I get the following error:

```
the trait bound `<Self as GetPtr>::T: UniquePtrTarget` is not satisfied
the trait `UniquePtrTarget` is not implemented for `<Self as GetPtr>::T`rustcE0277

unique_ptr.rs(17, 8): required by this bound in `UniquePtr`

lib.rs(34, 43): consider further restricting the associated type
```

I'd be glad to hear if there's a better option that I haven't considered.

Thanks,
Oliver