### PR TITLE
Clarify error for using enum as method receiver

### DIFF
--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -389,6 +389,8 @@ fn check_api_fn(cx: &mut Check, efn: &ExternFn) {
                 mutability = mutability,
             );
             cx.error(span, msg);
+        } else if cx.types.enums.contains_key(&receiver.ty.rust) {
+            cx.error(span, "C++ does not allow member functions on enums");
         } else if !cx.types.structs.contains_key(&receiver.ty.rust)
             && !cx.types.cxx.contains(&receiver.ty.rust)
             && !cx.types.rust.contains(&receiver.ty.rust)

--- a/tests/ui/enum_receiver.rs
+++ b/tests/ui/enum_receiver.rs
@@ -1,0 +1,11 @@
+#[cxx::bridge]
+mod ffi {
+    enum Enum {
+        Variant,
+    }
+    extern "Rust" {
+        fn f(self: &Enum);
+    }
+}
+
+fn main() {}

--- a/tests/ui/enum_receiver.stderr
+++ b/tests/ui/enum_receiver.stderr
@@ -1,0 +1,5 @@
+error: C++ does not allow member functions on enums
+ --> $DIR/enum_receiver.rs:7:20
+  |
+7 |         fn f(self: &Enum);
+  |                    ^^^^^


### PR DESCRIPTION
Update the syntax checker to print a more specific error when an enum is
used as a method receiver, rather than printing a misleading "unrecognized
receiver type" error.

This is done because C++ prohibits enums from having member functions.

Fixes #578