### PR TITLE
Updated Bazel Rust rules version

### DIFF
--- a/.devcontainer/build.Dockerfile
+++ b/.devcontainer/build.Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends openjdk-11-jdk lld \
     && rustup default nightly 2>&1 \
     && rustup component add rust-analyzer-preview rustfmt clippy 2>&1 \
-    && wget -q -O bin/install-bazel https://github.com/bazelbuild/bazel/releases/download/2.1.1/bazel-2.1.1-installer-linux-x86_64.sh \
+    && wget -q -O bin/install-bazel https://github.com/bazelbuild/bazel/releases/download/4.0.0/bazel-4.0.0-installer-linux-x86_64.sh \
     && wget -q -O bin/buck https://jitpack.io/com/github/facebook/buck/a5f0342ae3/buck-a5f0342ae3-java11.pex \
     && wget -q -O bin/buildifier https://github.com/bazelbuild/buildtools/releases/latest/download/buildifier \
     && wget -q -O tmp/watchman.zip https://github.com/facebook/watchman/releases/download/v2020.09.21.00/watchman-v2020.09.21.00-linux.zip \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Bazel
         run: |
-          wget -q -O install.sh https://github.com/bazelbuild/bazel/releases/download/2.1.1/bazel-2.1.1-installer-linux-x86_64.sh
+          wget -q -O install.sh https://github.com/bazelbuild/bazel/releases/download/4.0.0/bazel-4.0.0-installer-linux-x86_64.sh
           chmod +x install.sh
           ./install.sh --user
           echo $HOME/bin >> $GITHUB_PATH

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,39 +2,18 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//tools/bazel:vendor.bzl", "vendor")
 
 http_archive(
-    name = "io_bazel_rules_rust",
-    sha256 = "5ed804fcd10a506a5b8e9e59bc6b3b7f43bc30c87ce4670e6f78df43604894fd",
-    strip_prefix = "rules_rust-fdf9655ba95616e0314b4e0ebab40bb0c5fe005c",
-    # Master branch as of 2020-07-30
-    url = "https://github.com/bazelbuild/rules_rust/archive/fdf9655ba95616e0314b4e0ebab40bb0c5fe005c.tar.gz",
-)
-
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
+    name = "rules_rust",
+    sha256 = "e6d835ee673f388aa5b62dc23d82db8fc76497e93fa47d8a4afe97abaf09b10d",
+    strip_prefix = "rules_rust-f37b9d6a552e9412285e627f30cb124e709f4f7a",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+        # Master branch as of 2021-01-27
+        "https://github.com/bazelbuild/rules_rust/archive/f37b9d6a552e9412285e627f30cb124e709f4f7a.tar.gz",
     ],
 )
 
-load("@io_bazel_rules_rust//:workspace.bzl", "bazel_version")
+load("@rules_rust//rust:repositories.bzl", "rust_repositories")
 
-bazel_version(name = "bazel_version")
-
-load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repository_set")
-
-rust_repository_set(
-    name = "rust_1_48_linux",
-    exec_triple = "x86_64-unknown-linux-gnu",
-    version = "1.48.0",
-)
-
-rust_repository_set(
-    name = "rust_1_48_darwin",
-    exec_triple = "x86_64-apple-darwin",
-    version = "1.48.0",
-)
+rust_repositories()
 
 vendor(
     name = "third-party",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,7 +13,10 @@ http_archive(
 
 load("@rules_rust//rust:repositories.bzl", "rust_repositories")
 
-rust_repositories()
+rust_repositories(
+    edition = "2018",
+    version = "1.48.0",
+)
 
 vendor(
     name = "third-party",

--- a/third-party/BUILD
+++ b/third-party/BUILD
@@ -1,10 +1,8 @@
 load(
     "//tools/bazel:rust.bzl",
     glob = "third_party_glob",
-    rust_binary = "third_party_rust_binary",
     rust_library = "third_party_rust_library",
 )
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 rust_library(
     name = "bitflags",

--- a/tools/bazel/BUILD
+++ b/tools/bazel/BUILD
@@ -1,0 +1,7 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "bzl_srcs",
+    srcs = glob(["**/*.bzl"]),
+    visibility = ["//visibility:public"],
+)

--- a/tools/bazel/rust.bzl
+++ b/tools/bazel/rust.bzl
@@ -1,5 +1,7 @@
+"""A module wrapping the core rules of `rules_rust`"""
+
 load(
-    "@io_bazel_rules_rust//rust:rust.bzl",
+    "@rules_rust//rust:rust.bzl",
     _rust_binary = "rust_binary",
     _rust_library = "rust_library",
     _rust_test = "rust_test",

--- a/tools/bazel/rust_cxx_bridge.bzl
+++ b/tools/bazel/rust_cxx_bridge.bzl
@@ -1,7 +1,15 @@
+# buildifier: disable=module-docstring
 load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 def rust_cxx_bridge(name, src, deps = []):
+    """A macro defining a cxx bridge library
+
+    Args:
+        name (string): The name of the new target
+        src (string): The rust source file to generate a bridge for
+        deps (list, optional): A list of dependencies for the underlying cc_library. Defaults to [].
+    """
     native.alias(
         name = "%s/header" % name,
         actual = src + ".h",

--- a/tools/bazel/vendor.bzl
+++ b/tools/bazel/vendor.bzl
@@ -52,7 +52,7 @@ def _log_cargo_vendor(repository_ctx, result):
         repository_ctx.execute(print, quiet = False)
 
 vendor = repository_rule(
-    doc = "A rule used to vender the dependencies of a crate in the current workspace",
+    doc = "A rule used to vendor the dependencies of a crate in the current workspace",
     attrs = {
         "lockfile": attr.label(
             doc = "A lockfile providing the set of crates to vendor",

--- a/tools/bazel/vendor.bzl
+++ b/tools/bazel/vendor.bzl
@@ -1,3 +1,7 @@
+"""A module defining a repository rule for vendoring the dependencies
+of a crate in the current workspace.
+"""
+
 def _impl(repository_ctx):
     # Link cxx repository into @third-party.
     lockfile = repository_ctx.path(repository_ctx.attr.lockfile)
@@ -48,7 +52,12 @@ def _log_cargo_vendor(repository_ctx, result):
         repository_ctx.execute(print, quiet = False)
 
 vendor = repository_rule(
-    attrs = {"lockfile": attr.label()},
+    doc = "A rule used to vender the dependencies of a crate in the current workspace",
+    attrs = {
+        "lockfile": attr.label(
+            doc = "A lockfile providing the set of crates to vendor",
+        ),
+    },
     local = True,
     implementation = _impl,
 )


### PR DESCRIPTION
As of https://github.com/bazelbuild/rules_rust/commit/1fe23158e5316c17b2ee2a252ee7165c5d83cc93 the Bazel rust rules have been renamed from `io_bazel_rules_rust` to `rules_rust`. This PR updates the name here.