### PR TITLE
Upgrade the dependency on codespan_reporting

### DIFF
--- a/gen/build/Cargo.toml
+++ b/gen/build/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["development-tools::ffi"]
 
 [dependencies]
 cc = "1.0.49"
-codespan-reporting = "0.9"
+codespan-reporting = "0.11"
 lazy_static = "1.4"
 proc-macro2 = { version = "1.0.17", default-features = false, features = ["span-locations"] }
 quote = { version = "1.0", default-features = false }

--- a/gen/cmd/Cargo.toml
+++ b/gen/cmd/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = "2.33"
-codespan-reporting = "0.9"
+codespan-reporting = "0.11"
 proc-macro2 = { version = "1.0.17", default-features = false, features = ["span-locations"] }
 quote = { version = "1.0", default-features = false }
 syn = { version = "1.0.57", default-features = false, features = ["parsing", "printing", "clone-impls", "full"] }

--- a/gen/lib/Cargo.toml
+++ b/gen/lib/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools::ffi"]
 
 [dependencies]
 cc = "1.0.49"
-codespan-reporting = "0.9"
+codespan-reporting = "0.11"
 proc-macro2 = { version = "1.0.17", default-features = false, features = ["span-locations"] }
 quote = { version = "1.0", default-features = false }
 syn = { version = "1.0.57", default-features = false, features = ["parsing", "printing", "clone-impls", "full"] }

--- a/third-party/BUCK
+++ b/third-party/BUCK
@@ -25,7 +25,7 @@ rust_library(
 
 rust_library(
     name = "codespan-reporting",
-    srcs = glob(["vendor/codespan-reporting-0.9.5/src/**"]),
+    srcs = glob(["vendor/codespan-reporting-0.11.0/src/**"]),
     visibility = ["PUBLIC"],
     deps = [
         ":termcolor",

--- a/third-party/BUILD
+++ b/third-party/BUILD
@@ -31,7 +31,7 @@ rust_library(
 
 rust_library(
     name = "codespan-reporting",
-    srcs = glob(["vendor/codespan-reporting-0.9.5/src/**"]),
+    srcs = glob(["vendor/codespan-reporting-0.11.0/src/**"]),
     visibility = ["//visibility:public"],
     deps = [
         ":termcolor",

--- a/third-party/Cargo.lock
+++ b/third-party/Cargo.lock
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
-version = "0.9.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0762455306b1ed42bc651ef6a2197aabda5e1d4a43c34d5eab5c1a3634e81d"
+checksum = "c6ce42b8998a383572e0a802d859b1f00c79b7b7474e62fff88ee5c2845d9c13"
 dependencies = [
  "termcolor",
  "unicode-width",


### PR DESCRIPTION
This is to avoid a downstream dependency to depend on multiple versions of that crate.