### PR TITLE
Minor correction in the async example

### DIFF
--- a/book/src/async.md
+++ b/book/src/async.md
@@ -60,7 +60,7 @@ pub async fn do_thing(arg: Arg) -> Ret {
 
     ffi::shim_doThing(
         arg,
-        |tx, ret| { let _ = tx.0.send(ret); },
+        |context, ret| { let _ = context.0.send(ret); },
         context,
     );
 


### PR DESCRIPTION
The first argument of the closure is actually the context, not the sender. Rename it to `context` to make it clearer. Was slightly confused the first time I read it.