### PR TITLE
Make rust_cxx_bridge usable from other repositories

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,5 @@
+workspace(name = "cxx.rs")
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//tools/bazel:vendor.bzl", "vendor")
 

--- a/tools/bazel/rust_cxx_bridge.bzl
+++ b/tools/bazel/rust_cxx_bridge.bzl
@@ -34,7 +34,7 @@ def rust_cxx_bridge(name, src, deps = []):
             "-o",
             "$(location %s.cc)" % src,
         ],
-        tool = "//:codegen",
+        tool = "@cxx.rs//:codegen",
     )
 
     cc_library(


### PR DESCRIPTION
Currently the `rust_cxx_bridge.bzl` has to be copied to the main repository (and edited) if it is to be used from a different repository than cxx's own one in Bazel. After giving the cxx repo a name and using the label with the repository name the bzl file is now usable from outside as well.

Thanks! :)