### PR TITLE
Re-export cc's parallel feature for cxx-build

### DIFF
--- a/gen/build/Cargo.toml
+++ b/gen/build/Cargo.toml
@@ -11,6 +11,9 @@ exclude = ["build.rs"]
 keywords = ["ffi"]
 categories = ["development-tools::ffi"]
 
+[features]
+parallel = ["cc/parallel"]
+
 [dependencies]
 cc = "1.0.49"
 codespan-reporting = "0.11"


### PR DESCRIPTION
This allows building in parallel when the feature is enabled.

I wanted to try cxx-build with a fairly large code base and am hoping this will speed up the build. I may end up resorting to some other tool/configuration, but I can't see any reason not to try this first.