### PR TITLE
Add implementations for Vec<usize> and Vec<isize>

### DIFF
--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -600,6 +600,8 @@ static_assert(sizeof(std::string) <= kMaxExpectedWordsInString * sizeof(void *),
 
 #define FOR_EACH_RUST_VEC(MACRO)                                               \
   FOR_EACH_NUMERIC(MACRO)                                                      \
+  MACRO(usize, std::size_t)                                                    \
+  MACRO(isize, rust::isize)                                                    \
   MACRO(bool, bool)                                                            \
   MACRO(char, char)                                                            \
   MACRO(string, rust::String)                                                  \

--- a/src/symbols/rust_vec.rs
+++ b/src/symbols/rust_vec.rs
@@ -72,6 +72,8 @@ rust_vec_shims_for_primitive!(i8);
 rust_vec_shims_for_primitive!(i16);
 rust_vec_shims_for_primitive!(i32);
 rust_vec_shims_for_primitive!(i64);
+rust_vec_shims_for_primitive!(usize);
+rust_vec_shims_for_primitive!(isize);
 rust_vec_shims_for_primitive!(f32);
 rust_vec_shims_for_primitive!(f64);
 


### PR DESCRIPTION
Fixes #705

Maybe the `MACRO` calls should just be in `FOR_EACH_NUMERIC` but I wasn't sure.