### PR TITLE
Support for Vec<usize> and Vec<isize> on macOS

### DIFF
--- a/src/symbols/rust_vec.rs
+++ b/src/symbols/rust_vec.rs
@@ -68,10 +68,12 @@ rust_vec_shims_for_primitive!(u8);
 rust_vec_shims_for_primitive!(u16);
 rust_vec_shims_for_primitive!(u32);
 rust_vec_shims_for_primitive!(u64);
+rust_vec_shims_for_primitive!(usize);
 rust_vec_shims_for_primitive!(i8);
 rust_vec_shims_for_primitive!(i16);
 rust_vec_shims_for_primitive!(i32);
 rust_vec_shims_for_primitive!(i64);
+rust_vec_shims_for_primitive!(isize);
 rust_vec_shims_for_primitive!(f32);
 rust_vec_shims_for_primitive!(f64);
 

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -817,6 +817,14 @@ extern "C" const char *cxx_run_test() noexcept {
   ASSERT(vec1[0] == 3 && vec1[1] == 4);
   ASSERT(vec2[0] == 1 && vec2[1] == 2);
 
+  // Test Vec<usize> and Vec<isize>. These are weird because on Linux and
+  // Windows size_t is exactly the same C++ type as one of the sized integer
+  // types (typically uint64_t, both of which are defined as unsigned long),
+  // while on macOS it is a distinct type.
+  // https://github.com/dtolnay/cxx/issues/705
+  (void)rust::Vec<size_t>();
+  (void)rust::Vec<rust::isize>();
+
   cxx_test_suite_set_correct();
   return nullptr;
 }


### PR DESCRIPTION
Like #706 but without symbol collision on non-macOS platforms. Closes #706. Closes #705.