### PR TITLE
Move span of inherited pub to next consecutive token

### DIFF
--- a/tests/ui/enum_match_without_wildcard.stderr
+++ b/tests/ui/enum_match_without_wildcard.stderr
@@ -2,7 +2,7 @@ error[E0004]: non-exhaustive patterns: `A { repr: 2_u8..=u8::MAX }` not covered
   --> $DIR/enum_match_without_wildcard.rs:12:11
    |
 3  |     enum A {
-   |          - `ffi::A` defined here
+   |     ------ `ffi::A` defined here
 ...
 12 |     match a {
    |           ^ pattern `A { repr: 2_u8..=u8::MAX }` not covered


### PR DESCRIPTION
This gives error placement that is more consistent with rustc's ordinary placement of certain errors.