### PR TITLE
Remove self assignment checks from move assignment operators

### DIFF
--- a/include/cxx.h
+++ b/include/cxx.h
@@ -824,11 +824,9 @@ Vec<T>::~Vec() noexcept {
 
 template <typename T>
 Vec<T> &Vec<T>::operator=(Vec &&other) noexcept {
-  if (this != &other) {
-    this->drop();
-    this->repr = other.repr;
-    new (&other) Vec();
-  }
+  this->drop();
+  this->repr = other.repr;
+  new (&other) Vec();
   return *this;
 }
 

--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -109,11 +109,9 @@ String &String::operator=(const String &other) noexcept {
 }
 
 String &String::operator=(String &&other) noexcept {
-  if (this != &other) {
-    cxxbridge1$string$drop(this);
-    this->repr = other.repr;
-    cxxbridge1$string$new(&other);
-  }
+  cxxbridge1$string$drop(this);
+  this->repr = other.repr;
+  cxxbridge1$string$new(&other);
   return *this;
 }
 
@@ -392,13 +390,11 @@ Error &Error::operator=(const Error &other) {
 }
 
 Error &Error::operator=(Error &&other) noexcept {
-  if (this != &other) {
-    std::exception::operator=(std::move(other));
-    this->msg = other.msg;
-    this->len = other.len;
-    other.msg = nullptr;
-    other.len = 0;
-  }
+  std::exception::operator=(std::move(other));
+  this->msg = other.msg;
+  this->len = other.len;
+  other.msg = nullptr;
+  other.len = 0;
   return *this;
 }
 


### PR DESCRIPTION
Closes #696.

All of these move assignments have sane and sound behavior in the `this == &other` case. The object ends up in a destructible but unspecified state, which is sufficient.