### PR TITLE
Include license files in flags crate

### DIFF
--- a/flags/LICENSE-APACHE
+++ b/flags/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/flags/LICENSE-MIT
+++ b/flags/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
Other crates in this repo already include them, and it is a requirement (or at least a strong suggestion) for packaging it into Fedora.