### PR TITLE
Add CxxChar to bind to C++ char32_t type

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -211,7 +211,7 @@ fn pick_includes_and_builtins(out: &mut OutFile, apis: &[Api]) {
                 Some(Isize) => out.builtin.rust_isize = true,
                 Some(CxxString) => out.include.string = true,
                 Some(RustString) => out.builtin.rust_string = true,
-                Some(Bool) | Some(Char) | Some(F32) | Some(F64) | None => {}
+                Some(Bool) | Some(Char) | Some(F32) | Some(F64) | Some(CxxChar) | None => {}
             },
             Type::RustBox(_) => out.builtin.rust_box = true,
             Type::RustVec(_) => out.builtin.rust_vec = true,
@@ -1230,6 +1230,7 @@ fn write_atom(out: &mut OutFile, atom: Atom) {
         Isize => write!(out, "::rust::isize"),
         F32 => write!(out, "float"),
         F64 => write!(out, "double"),
+        CxxChar => write!(out, "char32_t"),
         CxxString => write!(out, "::std::string"),
         RustString => write!(out, "::rust::String"),
     }

--- a/src/cxx_char.rs
+++ b/src/cxx_char.rs
@@ -1,0 +1,21 @@
+use std::char::CharTryFromError;
+use std::convert::{From, TryFrom};
+
+/// Binding to C++ `char32_t`.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[repr(transparent)]
+pub struct CxxChar(u32);
+
+impl TryFrom<CxxChar> for char {
+    type Error = CharTryFromError;
+
+    fn try_from(value: CxxChar) -> Result<Self, Self::Error> {
+        char::try_from(value.0)
+    }
+}
+
+impl From<char> for CxxChar {
+    fn from(ch: char) -> Self {
+        CxxChar(ch as u32)
+    }
+}

--- a/src/extern_type.rs
+++ b/src/extern_type.rs
@@ -1,5 +1,5 @@
 use self::kind::{Kind, Opaque, Trivial};
-use crate::CxxString;
+use crate::{CxxChar, CxxString};
 use alloc::string::String;
 
 /// A type for which the layout is determined by its C++ definition.
@@ -213,6 +213,7 @@ impl_extern_type! {
     f64 = "double"
     String = "rust::String"
 
+    CxxChar = "char32_t"
     [Opaque]
     CxxString = "std::string"
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,6 +399,8 @@ extern crate std;
 #[macro_use]
 mod macros;
 
+#[path = "cxx_char.rs"]
+mod char;
 mod exception;
 mod extern_type;
 mod function;
@@ -420,6 +422,7 @@ mod unwind;
 pub mod vector;
 mod weak_ptr;
 
+pub use crate::char::CxxChar;
 pub use crate::exception::Exception;
 pub use crate::extern_type::{kind, ExternType};
 pub use crate::shared_ptr::SharedPtr;
@@ -429,6 +432,13 @@ pub use crate::unique_ptr::UniquePtr;
 pub use crate::vector::CxxVector;
 pub use crate::weak_ptr::WeakPtr;
 pub use cxxbridge_macro::bridge;
+
+/// Synonym for `CxxChar`.
+///
+/// To avoid confusion with Rust's built-in char type you probably
+/// shouldn't import this type with `use`. Instead, write `cxx::Char`, or
+/// import and use `CxxChar`.
+pub type Char = CxxChar;
 
 /// Synonym for `CxxString`.
 ///

--- a/syntax/atom.rs
+++ b/syntax/atom.rs
@@ -18,6 +18,7 @@ pub enum Atom {
     Isize,
     F32,
     F64,
+    CxxChar,
     CxxString,
     RustString,
 }
@@ -44,6 +45,7 @@ impl Atom {
             "isize" => Some(Isize),
             "f32" => Some(F32),
             "f64" => Some(F64),
+            "CxxChar" => Some(CxxChar),
             "CxxString" => Some(CxxString),
             "String" => Some(RustString),
             _ => None,
@@ -75,6 +77,7 @@ impl AsRef<str> for Atom {
             Isize => "isize",
             F32 => "f32",
             F64 => "f64",
+            CxxChar => "CxxChar",
             CxxString => "CxxString",
             RustString => "String",
         }

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -107,7 +107,7 @@ fn check_type_rust_vec(cx: &mut Check, ty: &Ty1) {
             match Atom::from(&ident.rust) {
                 None | Some(Char) | Some(U8) | Some(U16) | Some(U32) | Some(U64) | Some(Usize)
                 | Some(I8) | Some(I16) | Some(I32) | Some(I64) | Some(Isize) | Some(F32)
-                | Some(F64) | Some(RustString) => return,
+                | Some(F64) | Some(RustString) | Some(CxxChar) => return,
                 Some(Bool) => { /* todo */ }
                 Some(CxxString) => {}
             }
@@ -147,7 +147,7 @@ fn check_type_shared_ptr(cx: &mut Check, ptr: &Ty1) {
         match Atom::from(&ident.rust) {
             None | Some(Bool) | Some(U8) | Some(U16) | Some(U32) | Some(U64) | Some(Usize)
             | Some(I8) | Some(I16) | Some(I32) | Some(I64) | Some(Isize) | Some(F32)
-            | Some(F64) | Some(CxxString) => return,
+            | Some(F64) | Some(CxxChar) | Some(CxxString) => return,
             Some(Char) | Some(RustString) => {}
         }
     } else if let Type::CxxVector(_) = &ptr.inner {
@@ -168,7 +168,7 @@ fn check_type_weak_ptr(cx: &mut Check, ptr: &Ty1) {
         match Atom::from(&ident.rust) {
             None | Some(Bool) | Some(U8) | Some(U16) | Some(U32) | Some(U64) | Some(Usize)
             | Some(I8) | Some(I16) | Some(I32) | Some(I64) | Some(Isize) | Some(F32)
-            | Some(F64) | Some(CxxString) => return,
+            | Some(F64) | Some(CxxChar) | Some(CxxString) => return,
             Some(Char) | Some(RustString) => {}
         }
     } else if let Type::CxxVector(_) = &ptr.inner {
@@ -192,7 +192,7 @@ fn check_type_cxx_vector(cx: &mut Check, ptr: &Ty1) {
         match Atom::from(&ident.rust) {
             None | Some(U8) | Some(U16) | Some(U32) | Some(U64) | Some(Usize) | Some(I8)
             | Some(I16) | Some(I32) | Some(I64) | Some(Isize) | Some(F32) | Some(F64)
-            | Some(CxxString) => return,
+            | Some(CxxChar) | Some(CxxString) => return,
             Some(Char) => { /* todo */ }
             Some(Bool) | Some(RustString) => {}
         }

--- a/syntax/pod.rs
+++ b/syntax/pod.rs
@@ -9,7 +9,7 @@ impl<'a> Types<'a> {
                 if let Some(atom) = Atom::from(ident) {
                     match atom {
                         Bool | Char | U8 | U16 | U32 | U64 | Usize | I8 | I16 | I32 | I64
-                        | Isize | F32 | F64 => true,
+                        | Isize | F32 | F64 | CxxChar => true,
                         CxxString | RustString => false,
                     }
                 } else if let Some(strct) = self.structs.get(ident) {

--- a/syntax/tokens.rs
+++ b/syntax/tokens.rs
@@ -14,7 +14,7 @@ impl ToTokens for Type {
                 if ident.rust == Char {
                     let span = ident.rust.span();
                     tokens.extend(quote_spanned!(span=> ::std::os::raw::));
-                } else if ident.rust == CxxString {
+                } else if ident.rust == CxxChar || ident.rust == CxxString {
                     let span = ident.rust.span();
                     tokens.extend(quote_spanned!(span=> ::cxx::));
                 }

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -14,7 +14,8 @@
 pub mod cast;
 pub mod module;
 
-use cxx::{CxxString, CxxVector, SharedPtr, UniquePtr};
+use cxx::{CxxChar, CxxString, CxxVector, SharedPtr, UniquePtr};
+use std::convert::TryInto;
 use std::fmt::{self, Display};
 use std::mem::MaybeUninit;
 use std::os::raw::c_char;
@@ -240,6 +241,7 @@ pub mod ffi {
         type R;
 
         fn r_return_primitive() -> usize;
+        fn r_return_char() -> CxxChar;
         fn r_return_shared() -> Shared;
         fn r_return_box() -> Box<R>;
         fn r_return_unique_ptr() -> UniquePtr<C>;
@@ -261,6 +263,7 @@ pub mod ffi {
         fn r_return_enum(n: u32) -> Enum;
 
         fn r_take_primitive(n: usize);
+        fn r_take_char(c: CxxChar);
         fn r_take_shared(shared: Shared);
         fn r_take_box(r: Box<R>);
         fn r_take_unique_ptr(c: UniquePtr<C>);
@@ -414,6 +417,10 @@ fn r_return_primitive() -> usize {
     2020
 }
 
+fn r_return_char() -> CxxChar {
+    '🙃'.into()
+}
+
 fn r_return_shared() -> ffi::Shared {
     ffi::Shared { z: 2020 }
 }
@@ -516,6 +523,10 @@ fn r_return_enum(n: u32) -> ffi::Enum {
 
 fn r_take_primitive(n: usize) {
     assert_eq!(n, 2020);
+}
+
+fn r_take_char(c: CxxChar) {
+    assert_eq!(Some('🙃'), c.try_into().ok());
 }
 
 fn r_take_shared(shared: ffi::Shared) {

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -718,6 +718,7 @@ extern "C" const char *cxx_run_test() noexcept {
   ASSERT(rust::align_of<size_t>() == alignof(size_t));
 
   ASSERT(r_return_primitive() == 2020);
+  ASSERT(r_return_char() == U'🙃');
   ASSERT(r_return_shared().z == 2020);
   ASSERT(cxx_test_suite_r_is_correct(&*r_return_box()));
   ASSERT(r_return_unique_ptr()->get() == 2020);
@@ -733,6 +734,7 @@ extern "C" const char *cxx_run_test() noexcept {
   ASSERT(r_return_enum(2021) == Enum::CVal);
 
   r_take_primitive(2020);
+  r_take_char(U'🙃');
   r_take_shared(Shared{2020});
   r_take_unique_ptr(std::unique_ptr<C>(new C{2020}));
   r_take_shared_ptr(std::shared_ptr<C>(new C{2020}));


### PR DESCRIPTION
This makes it possible to implement functions in Rust that accept a `char32_t`. The `CxxChar` type is necessary because C++ does not guarantee that `char32_t` contains a valid Unicode scalar value.

There is not yet a way for C++ code to create a Rust `char`.

I'll update the docs after getting feedback on the design and implementation.

Partly addresses #592.