### PR TITLE
Defer unsafety check for fn with ptr argument

### DIFF
--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -425,6 +425,13 @@ fn check_api_fn(cx: &mut Check, efn: &ExternFn) {
                     "passing a function pointer from C++ to Rust is not implemented yet",
                 );
             }
+        } else if let Type::Ptr(_) = arg.ty {
+            if efn.sig.unsafety.is_none() {
+                cx.error(
+                    arg,
+                    "pointer argument requires that the function be marked unsafe",
+                );
+            }
         } else if is_unsized(cx, &arg.ty) {
             let desc = describe(cx, &arg.ty);
             let msg = format!("passing {} by value is not supported", desc);

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -547,7 +547,6 @@ fn parse_extern_fn(
         ));
     }
 
-    let unsafety = foreign_fn.sig.unsafety;
     let mut receiver = None;
     let mut args = Punctuated::new();
     for arg in foreign_fn.sig.inputs.pairs() {
@@ -584,14 +583,6 @@ fn parse_extern_fn(
                     let attrs = OtherAttrs::none();
                     let visibility = Token![pub](ident.span());
                     let name = pair(Namespace::default(), &ident, None, None);
-                    if let Type::Ptr(_) = &ty {
-                        if unsafety.is_none() {
-                            return Err(Error::new_spanned(
-                                arg,
-                                "pointer argument requires that the function be marked unsafe",
-                            ));
-                        }
-                    }
                     args.push_value(Var {
                         doc,
                         attrs,
@@ -628,6 +619,7 @@ fn parse_extern_fn(
     let mut throws_tokens = None;
     let ret = parse_return_type(&foreign_fn.sig.output, &mut throws_tokens)?;
     let throws = throws_tokens.is_some();
+    let unsafety = foreign_fn.sig.unsafety;
     let fn_token = foreign_fn.sig.fn_token;
     let inherited_span = unsafety.map_or(fn_token.span, |unsafety| unsafety.span);
     let visibility = visibility_pub(&foreign_fn.vis, inherited_span);


### PR DESCRIPTION
That error does not need to be fatal at parse time, because the parser still understands exactly what was written. We accumulate and emit it alongside other type errors that might be present in the same function signature.

Follow-up to #689.