### PR TITLE
Disable lint jobs on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@clippy
@@ -102,6 +103,7 @@ jobs:
   clang-tidy:
     name: Clang Tidy
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v2
       - name: Install clang-tidy


### PR DESCRIPTION
We have been using this approach on the serde repo since last year and it works well (https://github.com/serde-rs/serde/blob/v1.0.125/.github/workflows/ci.yml#L155). It's quite common for Clippy to have low-value lints that we are better off disabling, but a contributor is not necessarily equipped to decide whether to suppress or resolve a lint, and consequently a clippy CI job can end up encouraging PRs submitted with needless workarounds.