### PR TITLE
Update to clang-tidy 11

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,7 @@ Checks:
   -cppcoreguidelines-pro-type-const-cast,
   -cppcoreguidelines-pro-type-member-init,
   -cppcoreguidelines-pro-type-reinterpret-cast,
+  -cppcoreguidelines-pro-type-vararg,
   -cppcoreguidelines-special-member-functions,
   -modernize-use-default-member-init,
   -modernize-use-equals-default,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install clang-tidy
-        run: sudo apt-get install clang-tidy-10
+        run: sudo apt-get install clang-tidy-11
       - name: Run clang-tidy
-        run: clang-tidy-10 src/cxx.cc --warnings-as-errors=*
+        run: clang-tidy-11 src/cxx.cc --warnings-as-errors=*


### PR DESCRIPTION
This adds a suppression for cppcoreguidelines-pro-type-vararg which appears newly in 11. I don't understand why this specific lint is triggering in the two cases below but the code seems fine in both cases.

```console
include/cxx.h:882:3: error: do not declare variables of type va_list; use variadic templates instead [cppcoreguidelines-pro-type-vararg,-warnings-as-errors]
  auto data = reinterpret_cast<char *>(this->data());
  ^
src/cxx.cc:355:3: error: do not declare variables of type va_list; use variadic templates instead [cppcoreguidelines-pro-type-vararg,-warnings-as-errors]
  char *copy = new char[len];
  ^
```