### PR TITLE
No-inline documentation of CxxVector within cxx::vector module

### DIFF
--- a/src/cxx_vector.rs
+++ b/src/cxx_vector.rs
@@ -13,9 +13,6 @@ use core::pin::Pin;
 use core::ptr;
 use core::slice;
 
-#[doc(inline)]
-pub use crate::Vector;
-
 /// Binding to C++ `std::vector<T, std::allocator<T>>`.
 ///
 /// # Invariants

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,6 +400,7 @@ extern crate std;
 #[macro_use]
 mod macros;
 
+mod cxx_vector;
 mod exception;
 mod extern_type;
 mod fmt;
@@ -418,17 +419,15 @@ mod symbols;
 mod type_id;
 mod unique_ptr;
 mod unwind;
-#[path = "cxx_vector.rs"]
 pub mod vector;
 mod weak_ptr;
 
+pub use crate::cxx_vector::CxxVector;
 pub use crate::exception::Exception;
 pub use crate::extern_type::{kind, ExternType};
 pub use crate::shared_ptr::SharedPtr;
 pub use crate::string::CxxString;
 pub use crate::unique_ptr::UniquePtr;
-#[doc(inline)]
-pub use crate::vector::CxxVector;
 pub use crate::weak_ptr::WeakPtr;
 pub use cxxbridge_macro::bridge;
 
@@ -449,6 +448,7 @@ pub type Vector<T> = CxxVector<T>;
 // Not public API.
 #[doc(hidden)]
 pub mod private {
+    pub use crate::cxx_vector::VectorElement;
     pub use crate::extern_type::{verify_extern_kind, verify_extern_type};
     pub use crate::function::FatFunction;
     pub use crate::opaque::Opaque;
@@ -462,7 +462,6 @@ pub mod private {
     pub use crate::string::StackString;
     pub use crate::unique_ptr::UniquePtrTarget;
     pub use crate::unwind::catch_unwind;
-    pub use crate::vector::VectorElement;
     pub use crate::weak_ptr::WeakPtrTarget;
     pub use cxxbridge_macro::type_id;
 }

--- a/src/unique_ptr.rs
+++ b/src/unique_ptr.rs
@@ -1,7 +1,7 @@
+use crate::cxx_vector::{CxxVector, VectorElement};
 use crate::fmt::display;
 use crate::kind::Trivial;
 use crate::string::CxxString;
-use crate::vector::{CxxVector, VectorElement};
 use crate::ExternType;
 use core::ffi::c_void;
 use core::fmt::{self, Debug, Display};

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,0 +1,8 @@
+//! Less used details of `CxxVector` are exposed in this module. `CxxVector`
+//! itself is exposed at the crate root.
+
+pub use crate::cxx_vector::{Iter, IterMut};
+#[doc(no_inline)]
+pub use crate::CxxVector;
+#[doc(inline)]
+pub use crate::Vector;

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -2,7 +2,7 @@
 //! itself is exposed at the crate root.
 
 pub use crate::cxx_vector::{Iter, IterMut};
-#[doc(no_inline)]
-pub use crate::CxxVector;
 #[doc(inline)]
 pub use crate::Vector;
+#[doc(no_inline)]
+pub use cxx::CxxVector;


### PR DESCRIPTION
This keeps the focus on types that aren't already available at a more concise path, and avoids duplicating documentation for this type across 2 different URLs (https://docs.rs/cxx/1.0.34/cxx/struct.CxxVector.html vs https://docs.rs/cxx/1.0.34/cxx/vector/struct.CxxVector.html).

<br>

### Before:

![Screenshot from 2021-03-25 01-00-31](https://user-images.githubusercontent.com/1940490/112421534-72230400-8cec-11eb-8115-3b1fecbbba4b.png)

<br>

### After:

![Screenshot from 2021-03-25 01-05-30](https://user-images.githubusercontent.com/1940490/112421829-1311bf00-8ced-11eb-87e3-fede1afaa6eb.png)

