### PR TITLE
Make memory and vector trait bounds publicly nameable

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1255,6 +1255,7 @@ fn expand_unique_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>)
         || types.aliases.contains_key(ident);
     let new_method = if can_construct_from_value {
         Some(quote! {
+            #[doc(hidden)]
             fn __new(value: Self) -> *mut ::std::ffi::c_void {
                 extern "C" {
                     #[link_name = #link_uninit]
@@ -1276,9 +1277,11 @@ fn expand_unique_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>)
 
     quote_spanned! {end_span=>
         #unsafe_token impl #impl_generics ::cxx::private::UniquePtrTarget for #ident #ty_generics {
+            #[doc(hidden)]
             fn __typename(f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 f.write_str(#name)
             }
+            #[doc(hidden)]
             fn __null() -> *mut ::std::ffi::c_void {
                 extern "C" {
                     #[link_name = #link_null]
@@ -1289,6 +1292,7 @@ fn expand_unique_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>)
                 repr
             }
             #new_method
+            #[doc(hidden)]
             unsafe fn __raw(raw: *mut Self) -> *mut ::std::ffi::c_void {
                 extern "C" {
                     #[link_name = #link_raw]
@@ -1298,6 +1302,7 @@ fn expand_unique_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>)
                 __raw(&mut repr, raw.cast());
                 repr
             }
+            #[doc(hidden)]
             unsafe fn __get(repr: *mut ::std::ffi::c_void) -> *const Self {
                 extern "C" {
                     #[link_name = #link_get]
@@ -1305,6 +1310,7 @@ fn expand_unique_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>)
                 }
                 __get(&repr).cast()
             }
+            #[doc(hidden)]
             unsafe fn __release(mut repr: *mut ::std::ffi::c_void) -> *mut Self {
                 extern "C" {
                     #[link_name = #link_release]
@@ -1312,6 +1318,7 @@ fn expand_unique_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>)
                 }
                 __release(&mut repr).cast()
             }
+            #[doc(hidden)]
             unsafe fn __drop(mut repr: *mut ::std::ffi::c_void) {
                 extern "C" {
                     #[link_name = #link_drop]
@@ -1344,6 +1351,7 @@ fn expand_shared_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>)
         || types.aliases.contains_key(ident);
     let new_method = if can_construct_from_value {
         Some(quote! {
+            #[doc(hidden)]
             unsafe fn __new(value: Self, new: *mut ::std::ffi::c_void) {
                 extern "C" {
                     #[link_name = #link_uninit]
@@ -1363,9 +1371,11 @@ fn expand_shared_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>)
 
     quote_spanned! {end_span=>
         #unsafe_token impl #impl_generics ::cxx::private::SharedPtrTarget for #ident #ty_generics {
+            #[doc(hidden)]
             fn __typename(f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 f.write_str(#name)
             }
+            #[doc(hidden)]
             unsafe fn __null(new: *mut ::std::ffi::c_void) {
                 extern "C" {
                     #[link_name = #link_null]
@@ -1374,6 +1384,7 @@ fn expand_shared_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>)
                 __null(new);
             }
             #new_method
+            #[doc(hidden)]
             unsafe fn __clone(this: *const ::std::ffi::c_void, new: *mut ::std::ffi::c_void) {
                 extern "C" {
                     #[link_name = #link_clone]
@@ -1381,6 +1392,7 @@ fn expand_shared_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>)
                 }
                 __clone(this, new);
             }
+            #[doc(hidden)]
             unsafe fn __get(this: *const ::std::ffi::c_void) -> *const Self {
                 extern "C" {
                     #[link_name = #link_get]
@@ -1388,6 +1400,7 @@ fn expand_shared_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>)
                 }
                 __get(this).cast()
             }
+            #[doc(hidden)]
             unsafe fn __drop(this: *mut ::std::ffi::c_void) {
                 extern "C" {
                     #[link_name = #link_drop]
@@ -1422,9 +1435,11 @@ fn expand_weak_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>) -
 
     quote_spanned! {end_span=>
         #unsafe_token impl #impl_generics ::cxx::private::WeakPtrTarget for #ident #ty_generics {
+            #[doc(hidden)]
             fn __typename(f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 f.write_str(#name)
             }
+            #[doc(hidden)]
             unsafe fn __null(new: *mut ::std::ffi::c_void) {
                 extern "C" {
                     #[link_name = #link_null]
@@ -1432,6 +1447,7 @@ fn expand_weak_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>) -
                 }
                 __null(new);
             }
+            #[doc(hidden)]
             unsafe fn __clone(this: *const ::std::ffi::c_void, new: *mut ::std::ffi::c_void) {
                 extern "C" {
                     #[link_name = #link_clone]
@@ -1439,6 +1455,7 @@ fn expand_weak_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>) -
                 }
                 __clone(this, new);
             }
+            #[doc(hidden)]
             unsafe fn __downgrade(shared: *const ::std::ffi::c_void, weak: *mut ::std::ffi::c_void) {
                 extern "C" {
                     #[link_name = #link_downgrade]
@@ -1446,6 +1463,7 @@ fn expand_weak_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>) -
                 }
                 __downgrade(shared, weak);
             }
+            #[doc(hidden)]
             unsafe fn __upgrade(weak: *const ::std::ffi::c_void, shared: *mut ::std::ffi::c_void) {
                 extern "C" {
                     #[link_name = #link_upgrade]
@@ -1453,6 +1471,7 @@ fn expand_weak_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>) -
                 }
                 __upgrade(weak, shared);
             }
+            #[doc(hidden)]
             unsafe fn __drop(this: *mut ::std::ffi::c_void) {
                 extern "C" {
                     #[link_name = #link_drop]
@@ -1493,9 +1512,11 @@ fn expand_cxx_vector(elem: &Ident, explicit_impl: Option<&Impl>, types: &Types) 
 
     quote_spanned! {end_span=>
         #unsafe_token impl #impl_generics ::cxx::private::VectorElement for #elem #ty_generics {
+            #[doc(hidden)]
             fn __typename(f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 f.write_str(#name)
             }
+            #[doc(hidden)]
             fn __vector_size(v: &::cxx::CxxVector<Self>) -> usize {
                 extern "C" {
                     #[link_name = #link_size]
@@ -1503,6 +1524,7 @@ fn expand_cxx_vector(elem: &Ident, explicit_impl: Option<&Impl>, types: &Types) 
                 }
                 unsafe { __vector_size(v) }
             }
+            #[doc(hidden)]
             unsafe fn __get_unchecked(v: *mut ::cxx::CxxVector<Self>, pos: usize) -> *mut Self {
                 extern "C" {
                     #[link_name = #link_get_unchecked]
@@ -1510,6 +1532,7 @@ fn expand_cxx_vector(elem: &Ident, explicit_impl: Option<&Impl>, types: &Types) 
                 }
                 __get_unchecked(v, pos)
             }
+            #[doc(hidden)]
             fn __unique_ptr_null() -> *mut ::std::ffi::c_void {
                 extern "C" {
                     #[link_name = #link_unique_ptr_null]
@@ -1519,6 +1542,7 @@ fn expand_cxx_vector(elem: &Ident, explicit_impl: Option<&Impl>, types: &Types) 
                 unsafe { __unique_ptr_null(&mut repr) }
                 repr
             }
+            #[doc(hidden)]
             unsafe fn __unique_ptr_raw(raw: *mut ::cxx::CxxVector<Self>) -> *mut ::std::ffi::c_void {
                 extern "C" {
                     #[link_name = #link_unique_ptr_raw]
@@ -1528,6 +1552,7 @@ fn expand_cxx_vector(elem: &Ident, explicit_impl: Option<&Impl>, types: &Types) 
                 __unique_ptr_raw(&mut repr, raw);
                 repr
             }
+            #[doc(hidden)]
             unsafe fn __unique_ptr_get(repr: *mut ::std::ffi::c_void) -> *const ::cxx::CxxVector<Self> {
                 extern "C" {
                     #[link_name = #link_unique_ptr_get]
@@ -1535,6 +1560,7 @@ fn expand_cxx_vector(elem: &Ident, explicit_impl: Option<&Impl>, types: &Types) 
                 }
                 __unique_ptr_get(&repr)
             }
+            #[doc(hidden)]
             unsafe fn __unique_ptr_release(mut repr: *mut ::std::ffi::c_void) -> *mut ::cxx::CxxVector<Self> {
                 extern "C" {
                     #[link_name = #link_unique_ptr_release]
@@ -1542,6 +1568,7 @@ fn expand_cxx_vector(elem: &Ident, explicit_impl: Option<&Impl>, types: &Types) 
                 }
                 __unique_ptr_release(&mut repr)
             }
+            #[doc(hidden)]
             unsafe fn __unique_ptr_drop(mut repr: *mut ::std::ffi::c_void) {
                 extern "C" {
                     #[link_name = #link_unique_ptr_drop]

--- a/src/cxx_vector.rs
+++ b/src/cxx_vector.rs
@@ -260,9 +260,34 @@ where
     }
 }
 
-// Methods are private; not intended to be implemented outside of cxxbridge
-// codebase.
-#[doc(hidden)]
+/// Trait bound for types which may be used as the `T` inside of a
+/// `CxxVector<T>` in generic code.
+///
+/// This trait has no publicly callable or implementable methods. Implementing
+/// it outside of the CXX codebase is not supported.
+///
+/// # Example
+///
+/// A bound `T: VectorElement` may be necessary when manipulating [`CxxVector`]
+/// in generic code.
+///
+/// ```
+/// use cxx::vector::{CxxVector, VectorElement};
+/// use std::fmt::Display;
+///
+/// pub fn take_generic_vector<T>(vector: &CxxVector<T>)
+/// where
+///     T: VectorElement + Display,
+/// {
+///     println!("the vector elements are:");
+///     for element in vector {
+///         println!("  • {}", element);
+///     }
+/// }
+/// ```
+///
+/// Writing the same generic function without a `VectorElement` trait bound
+/// would not compile.
 pub unsafe trait VectorElement: Sized {
     fn __typename(f: &mut fmt::Formatter) -> fmt::Result;
     fn __vector_size(v: &CxxVector<Self>) -> usize;

--- a/src/cxx_vector.rs
+++ b/src/cxx_vector.rs
@@ -289,13 +289,21 @@ where
 /// Writing the same generic function without a `VectorElement` trait bound
 /// would not compile.
 pub unsafe trait VectorElement: Sized {
+    #[doc(hidden)]
     fn __typename(f: &mut fmt::Formatter) -> fmt::Result;
+    #[doc(hidden)]
     fn __vector_size(v: &CxxVector<Self>) -> usize;
+    #[doc(hidden)]
     unsafe fn __get_unchecked(v: *mut CxxVector<Self>, pos: usize) -> *mut Self;
+    #[doc(hidden)]
     fn __unique_ptr_null() -> *mut c_void;
+    #[doc(hidden)]
     unsafe fn __unique_ptr_raw(raw: *mut CxxVector<Self>) -> *mut c_void;
+    #[doc(hidden)]
     unsafe fn __unique_ptr_get(repr: *mut c_void) -> *const CxxVector<Self>;
+    #[doc(hidden)]
     unsafe fn __unique_ptr_release(repr: *mut c_void) -> *mut CxxVector<Self>;
+    #[doc(hidden)]
     unsafe fn __unique_ptr_drop(repr: *mut c_void);
 }
 
@@ -304,9 +312,11 @@ macro_rules! impl_vector_element {
         const_assert_eq!(1, mem::align_of::<CxxVector<$ty>>());
 
         unsafe impl VectorElement for $ty {
+            #[doc(hidden)]
             fn __typename(f: &mut fmt::Formatter) -> fmt::Result {
                 f.write_str($name)
             }
+            #[doc(hidden)]
             fn __vector_size(v: &CxxVector<$ty>) -> usize {
                 extern "C" {
                     attr! {
@@ -316,6 +326,7 @@ macro_rules! impl_vector_element {
                 }
                 unsafe { __vector_size(v) }
             }
+            #[doc(hidden)]
             unsafe fn __get_unchecked(v: *mut CxxVector<$ty>, pos: usize) -> *mut $ty {
                 extern "C" {
                     attr! {
@@ -325,6 +336,7 @@ macro_rules! impl_vector_element {
                 }
                 __get_unchecked(v, pos)
             }
+            #[doc(hidden)]
             fn __unique_ptr_null() -> *mut c_void {
                 extern "C" {
                     attr! {
@@ -336,6 +348,7 @@ macro_rules! impl_vector_element {
                 unsafe { __unique_ptr_null(&mut repr) }
                 repr
             }
+            #[doc(hidden)]
             unsafe fn __unique_ptr_raw(raw: *mut CxxVector<Self>) -> *mut c_void {
                 extern "C" {
                     attr! {
@@ -347,6 +360,7 @@ macro_rules! impl_vector_element {
                 __unique_ptr_raw(&mut repr, raw);
                 repr
             }
+            #[doc(hidden)]
             unsafe fn __unique_ptr_get(repr: *mut c_void) -> *const CxxVector<Self> {
                 extern "C" {
                     attr! {
@@ -356,6 +370,7 @@ macro_rules! impl_vector_element {
                 }
                 __unique_ptr_get(&repr)
             }
+            #[doc(hidden)]
             unsafe fn __unique_ptr_release(mut repr: *mut c_void) -> *mut CxxVector<Self> {
                 extern "C" {
                     attr! {
@@ -365,6 +380,7 @@ macro_rules! impl_vector_element {
                 }
                 __unique_ptr_release(&mut repr)
             }
+            #[doc(hidden)]
             unsafe fn __unique_ptr_drop(mut repr: *mut c_void) {
                 extern "C" {
                     attr! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,6 +405,7 @@ mod exception;
 mod extern_type;
 mod fmt;
 mod function;
+pub mod memory;
 mod opaque;
 mod result;
 mod rust_slice;

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,0 +1,2 @@
+#[doc(no_inline)]
+pub use cxx::{SharedPtr, UniquePtr};

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,3 +1,7 @@
+//! Less used details of `UniquePtr` and `SharedPtr`.
+//!
+//! The pointer types themselves are exposed at the crate root.
+
 pub use crate::shared_ptr::SharedPtrTarget;
 pub use crate::unique_ptr::UniquePtrTarget;
 #[doc(no_inline)]

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,2 +1,4 @@
+pub use crate::shared_ptr::SharedPtrTarget;
+pub use crate::unique_ptr::UniquePtrTarget;
 #[doc(no_inline)]
 pub use cxx::{SharedPtr, UniquePtr};

--- a/src/shared_ptr.rs
+++ b/src/shared_ptr.rs
@@ -152,8 +152,31 @@ where
     }
 }
 
-// Methods are private; not intended to be implemented outside of cxxbridge
-// codebase.
+/// Trait bound for types which may be used as the `T` inside of a
+/// `SharedPtr<T>` in generic code.
+///
+/// This trait has no publicly callable or implementable methods. Implementing
+/// it outside of the CXX codebase is not supported.
+///
+/// # Example
+///
+/// A bound `T: SharedPtrTarget` may be necessary when manipulating
+/// [`SharedPtr`] in generic code.
+///
+/// ```
+/// use cxx::memory::{SharedPtr, SharedPtrTarget};
+/// use std::fmt::Display;
+///
+/// pub fn take_generic_ptr<T>(ptr: SharedPtr<T>)
+/// where
+///     T: SharedPtrTarget + Display,
+/// {
+///     println!("the shared_ptr points to: {}", *ptr);
+/// }
+/// ```
+///
+/// Writing the same generic function without a `SharedPtrTarget` trait bound
+/// would not compile.
 pub unsafe trait SharedPtrTarget {
     #[doc(hidden)]
     fn __typename(f: &mut fmt::Formatter) -> fmt::Result;

--- a/src/shared_ptr.rs
+++ b/src/shared_ptr.rs
@@ -204,9 +204,11 @@ pub unsafe trait SharedPtrTarget {
 macro_rules! impl_shared_ptr_target {
     ($segment:expr, $name:expr, $ty:ty) => {
         unsafe impl SharedPtrTarget for $ty {
+            #[doc(hidden)]
             fn __typename(f: &mut fmt::Formatter) -> fmt::Result {
                 f.write_str($name)
             }
+            #[doc(hidden)]
             unsafe fn __null(new: *mut c_void) {
                 extern "C" {
                     attr! {
@@ -216,6 +218,7 @@ macro_rules! impl_shared_ptr_target {
                 }
                 __null(new);
             }
+            #[doc(hidden)]
             unsafe fn __new(value: Self, new: *mut c_void) {
                 extern "C" {
                     attr! {
@@ -225,6 +228,7 @@ macro_rules! impl_shared_ptr_target {
                 }
                 __uninit(new).cast::<$ty>().write(value);
             }
+            #[doc(hidden)]
             unsafe fn __clone(this: *const c_void, new: *mut c_void) {
                 extern "C" {
                     attr! {
@@ -234,6 +238,7 @@ macro_rules! impl_shared_ptr_target {
                 }
                 __clone(this, new);
             }
+            #[doc(hidden)]
             unsafe fn __get(this: *const c_void) -> *const Self {
                 extern "C" {
                     attr! {
@@ -243,6 +248,7 @@ macro_rules! impl_shared_ptr_target {
                 }
                 __get(this).cast()
             }
+            #[doc(hidden)]
             unsafe fn __drop(this: *mut c_void) {
                 extern "C" {
                     attr! {

--- a/src/unique_ptr.rs
+++ b/src/unique_ptr.rs
@@ -242,9 +242,11 @@ extern "C" {
 }
 
 unsafe impl UniquePtrTarget for CxxString {
+    #[doc(hidden)]
     fn __typename(f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str("CxxString")
     }
+    #[doc(hidden)]
     fn __null() -> *mut c_void {
         let mut repr = ptr::null_mut::<c_void>();
         unsafe {
@@ -252,17 +254,21 @@ unsafe impl UniquePtrTarget for CxxString {
         }
         repr
     }
+    #[doc(hidden)]
     unsafe fn __raw(raw: *mut Self) -> *mut c_void {
         let mut repr = ptr::null_mut::<c_void>();
         unique_ptr_std_string_raw(&mut repr, raw);
         repr
     }
+    #[doc(hidden)]
     unsafe fn __get(repr: *mut c_void) -> *const Self {
         unique_ptr_std_string_get(&repr)
     }
+    #[doc(hidden)]
     unsafe fn __release(mut repr: *mut c_void) -> *mut Self {
         unique_ptr_std_string_release(&mut repr)
     }
+    #[doc(hidden)]
     unsafe fn __drop(mut repr: *mut c_void) {
         unique_ptr_std_string_drop(&mut repr);
     }
@@ -272,21 +278,27 @@ unsafe impl<T> UniquePtrTarget for CxxVector<T>
 where
     T: VectorElement,
 {
+    #[doc(hidden)]
     fn __typename(f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "CxxVector<{}>", display(T::__typename))
     }
+    #[doc(hidden)]
     fn __null() -> *mut c_void {
         T::__unique_ptr_null()
     }
+    #[doc(hidden)]
     unsafe fn __raw(raw: *mut Self) -> *mut c_void {
         T::__unique_ptr_raw(raw)
     }
+    #[doc(hidden)]
     unsafe fn __get(repr: *mut c_void) -> *const Self {
         T::__unique_ptr_get(repr)
     }
+    #[doc(hidden)]
     unsafe fn __release(repr: *mut c_void) -> *mut Self {
         T::__unique_ptr_release(repr)
     }
+    #[doc(hidden)]
     unsafe fn __drop(repr: *mut c_void) {
         T::__unique_ptr_drop(repr);
     }

--- a/src/unique_ptr.rs
+++ b/src/unique_ptr.rs
@@ -178,8 +178,31 @@ where
     }
 }
 
-// Methods are private; not intended to be implemented outside of cxxbridge
-// codebase.
+/// Trait bound for types which may be used as the `T` inside of a
+/// `UniquePtr<T>` in generic code.
+///
+/// This trait has no publicly callable or implementable methods. Implementing
+/// it outside of the CXX codebase is not supported.
+///
+/// # Example
+///
+/// A bound `T: UniquePtrTarget` may be necessary when manipulating
+/// [`UniquePtr`] in generic code.
+///
+/// ```
+/// use cxx::memory::{UniquePtr, UniquePtrTarget};
+/// use std::fmt::Display;
+///
+/// pub fn take_generic_ptr<T>(ptr: UniquePtr<T>)
+/// where
+///     T: UniquePtrTarget + Display,
+/// {
+///     println!("the unique_ptr points to: {}", *ptr);
+/// }
+/// ```
+///
+/// Writing the same generic function without a `UniquePtrTarget` trait bound
+/// would not compile.
 pub unsafe trait UniquePtrTarget {
     #[doc(hidden)]
     fn __typename(f: &mut fmt::Formatter) -> fmt::Result;

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,7 +1,7 @@
 //! Less used details of `CxxVector` are exposed in this module. `CxxVector`
 //! itself is exposed at the crate root.
 
-pub use crate::cxx_vector::{Iter, IterMut};
+pub use crate::cxx_vector::{Iter, IterMut, VectorElement};
 #[doc(inline)]
 pub use crate::Vector;
 #[doc(no_inline)]

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,5 +1,6 @@
-//! Less used details of `CxxVector` are exposed in this module. `CxxVector`
-//! itself is exposed at the crate root.
+//! Less used details of `CxxVector`.
+//!
+//! `CxxVector` itself is exposed at the crate root.
 
 pub use crate::cxx_vector::{Iter, IterMut, VectorElement};
 #[doc(inline)]

--- a/src/weak_ptr.rs
+++ b/src/weak_ptr.rs
@@ -111,9 +111,11 @@ pub unsafe trait WeakPtrTarget {
 macro_rules! impl_weak_ptr_target {
     ($segment:expr, $name:expr, $ty:ty) => {
         unsafe impl WeakPtrTarget for $ty {
+            #[doc(hidden)]
             fn __typename(f: &mut fmt::Formatter) -> fmt::Result {
                 f.write_str($name)
             }
+            #[doc(hidden)]
             unsafe fn __null(new: *mut c_void) {
                 extern "C" {
                     attr! {
@@ -123,6 +125,7 @@ macro_rules! impl_weak_ptr_target {
                 }
                 __null(new);
             }
+            #[doc(hidden)]
             unsafe fn __clone(this: *const c_void, new: *mut c_void) {
                 extern "C" {
                     attr! {
@@ -132,6 +135,7 @@ macro_rules! impl_weak_ptr_target {
                 }
                 __clone(this, new);
             }
+            #[doc(hidden)]
             unsafe fn __downgrade(shared: *const c_void, weak: *mut c_void) {
                 extern "C" {
                     attr! {
@@ -141,6 +145,7 @@ macro_rules! impl_weak_ptr_target {
                 }
                 __downgrade(shared, weak);
             }
+            #[doc(hidden)]
             unsafe fn __upgrade(weak: *const c_void, shared: *mut c_void) {
                 extern "C" {
                     attr! {
@@ -150,6 +155,7 @@ macro_rules! impl_weak_ptr_target {
                 }
                 __upgrade(weak, shared);
             }
+            #[doc(hidden)]
             unsafe fn __drop(this: *mut c_void) {
                 extern "C" {
                     attr! {

--- a/tests/ui/unique_ptr_twice.stderr
+++ b/tests/ui/unique_ptr_twice.stderr
@@ -1,4 +1,4 @@
-error[E0119]: conflicting implementations of trait `cxx::private::UniquePtrTarget` for type `here::C`:
+error[E0119]: conflicting implementations of trait `cxx::memory::UniquePtrTarget` for type `here::C`:
   --> $DIR/unique_ptr_twice.rs:16:5
    |
 7  |     impl UniquePtr<C> {}


### PR DESCRIPTION
These trait bounds enable manipulating UniquePtr, SharedPtr, and CxxVector inside of generic code.

Example:

```rust
use cxx::memory::{UniquePtr, UniquePtrTarget};
use std::fmt::Display;

pub fn take_generic_ptr<T>(ptr: UniquePtr<T>)
where
    T: UniquePtrTarget + Display,
{
    println!("the unique_ptr points to: {}", *ptr);
}
```

Writing the same generic function without a UniquePtrTarget trait bound would not compile.

Closes #685.