### PR TITLE
Omit most builtins if bridge explicitly includes "rust/cxx.h"

### DIFF
--- a/gen/src/builtin.rs
+++ b/gen/src/builtin.rs
@@ -48,11 +48,6 @@ pub(super) fn write(out: &mut OutFile) {
     let builtin = &mut out.builtin;
     let out = &mut builtin.content;
 
-    let cxx_header = include
-        .custom
-        .iter()
-        .any(|header| header.path == "rust/cxx.h" || header.path == "rust\\cxx.h");
-
     if builtin.rust_string {
         include.array = true;
         include.cstdint = true;
@@ -132,6 +127,7 @@ pub(super) fn write(out: &mut OutFile) {
     out.begin_block(Block::Namespace("rust"));
     out.begin_block(Block::InlineNamespace("cxxbridge1"));
 
+    let cxx_header = include.has_cxx_header();
     if !cxx_header {
         writeln!(out, "// #include \"rust/cxx.h\"");
 

--- a/gen/src/include.rs
+++ b/gen/src/include.rs
@@ -50,6 +50,12 @@ impl<'a> Includes<'a> {
     pub fn insert(&mut self, include: impl Into<Include>) {
         self.custom.push(include.into());
     }
+
+    pub fn has_cxx_header(&self) -> bool {
+        self.custom
+            .iter()
+            .any(|header| header.path == "rust/cxx.h" || header.path == "rust\\cxx.h")
+    }
 }
 
 pub(super) fn write(out: &mut OutFile) {

--- a/gen/src/include.rs
+++ b/gen/src/include.rs
@@ -61,6 +61,7 @@ impl<'a> Includes<'a> {
 pub(super) fn write(out: &mut OutFile) {
     let header = out.header;
     let include = &mut out.include;
+    let cxx_header = include.has_cxx_header();
     let out = &mut include.content;
 
     if header {
@@ -101,69 +102,69 @@ pub(super) fn write(out: &mut OutFile) {
         content: _,
     } = *include;
 
-    if algorithm {
+    if algorithm && !cxx_header {
         writeln!(out, "#include <algorithm>");
     }
-    if array {
+    if array && !cxx_header {
         writeln!(out, "#include <array>");
     }
-    if cassert {
+    if cassert && !cxx_header {
         writeln!(out, "#include <cassert>");
     }
-    if cstddef {
+    if cstddef && !cxx_header {
         writeln!(out, "#include <cstddef>");
     }
-    if cstdint {
+    if cstdint && !cxx_header {
         writeln!(out, "#include <cstdint>");
     }
     if cstring {
         writeln!(out, "#include <cstring>");
     }
-    if exception {
+    if exception && !cxx_header {
         writeln!(out, "#include <exception>");
     }
     if functional {
         writeln!(out, "#include <functional>");
     }
-    if initializer_list {
+    if initializer_list && !cxx_header {
         writeln!(out, "#include <initializer_list>");
     }
-    if iterator {
+    if iterator && !cxx_header {
         writeln!(out, "#include <iterator>");
     }
     if memory {
         writeln!(out, "#include <memory>");
     }
-    if new {
+    if new && !cxx_header {
         writeln!(out, "#include <new>");
     }
-    if string {
+    if string && !cxx_header {
         writeln!(out, "#include <string>");
     }
-    if type_traits {
+    if type_traits && !cxx_header {
         writeln!(out, "#include <type_traits>");
     }
-    if utility {
+    if utility && !cxx_header {
         writeln!(out, "#include <utility>");
     }
-    if vector {
+    if vector && !cxx_header {
         writeln!(out, "#include <vector>");
     }
-    if basetsd {
+    if basetsd && !cxx_header {
         writeln!(out, "#if defined(_WIN32)");
         writeln!(out, "#include <basetsd.h>");
     }
-    if sys_types {
+    if sys_types && !cxx_header {
         if basetsd {
             writeln!(out, "#else");
         } else {
             writeln!(out, "#if not defined(_WIN32)");
         }
     }
-    if sys_types {
+    if sys_types && !cxx_header {
         writeln!(out, "#include <sys/types.h>");
     }
-    if basetsd || sys_types {
+    if (basetsd || sys_types) && !cxx_header {
         writeln!(out, "#endif");
     }
 }


### PR DESCRIPTION
Closes #703. Builtins are not dumped into the generated output file if *either* the #\[cxx::bridge\] module contains `include!("rust/cxx.h")` *or* the cxxbridge CLI is invoked to pass it as an additional include via `--include rust/cxx.h`.

**Before:**

```console
$ echo '#[cxx::bridge] mod ffi { struct Test { s: String } }' | cxxbridge /dev/stdin
#include <array>
#include <cstdint>
#include <string>
#include <type_traits>

namespace rust {
inline namespace cxxbridge1 {
// #include "rust/cxx.h"

#ifndef CXXBRIDGE1_RUST_STRING
#define CXXBRIDGE1_RUST_STRING
class String final {
  ...
  ...
  ...
};
#endif // CXXBRIDGE1_RUST_STRING
} // namespace cxxbridge1
} // namespace rust

struct Test;

#ifndef CXXBRIDGE1_STRUCT_Test
#define CXXBRIDGE1_STRUCT_Test
struct Test final {
  ::rust::String s;

  using IsRelocatable = ::std::true_type;
};
#endif // CXXBRIDGE1_STRUCT_Test
```

**After** (`--include rust/cxx.h`):

```console
$ echo '#[cxx::bridge] mod ffi { struct Test { s: String } }' | cxxbridge /dev/stdin --include rust/cxx.h
#include "rust/cxx.h"

struct Test;

#ifndef CXXBRIDGE1_STRUCT_Test
#define CXXBRIDGE1_STRUCT_Test
struct Test final {
  ::rust::String s;

  using IsRelocatable = ::std::true_type;
};
#endif // CXXBRIDGE1_STRUCT_Test
```

**After** (`include!("rust/cxx.h");`):

```console
$ echo '#[cxx::bridge] mod ffi { extern "C++" { include!("rust/cxx.h"); } struct Test { s: String } }' | cxxbridge /dev/stdin
#include "rust/cxx.h"

struct Test;

#ifndef CXXBRIDGE1_STRUCT_Test
#define CXXBRIDGE1_STRUCT_Test
struct Test final {
  ::rust::String s;

  using IsRelocatable = ::std::true_type;
};
#endif // CXXBRIDGE1_STRUCT_Test
```