### PR TITLE
Fix wording of unsupported vector element type error

### DIFF
--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -199,7 +199,7 @@ fn check_type_cxx_vector(cx: &mut Check, ptr: &Ty1) {
         }
     }
 
-    cx.error(ptr, "unsupported vector target type");
+    cx.error(ptr, "unsupported vector element type");
 }
 
 fn check_type_ref(cx: &mut Check, ty: &Ref) {

--- a/tests/ui/ptr_unsupported.stderr
+++ b/tests/ui/ptr_unsupported.stderr
@@ -10,7 +10,7 @@ error: unsupported unique_ptr target type
 7 |         fn get_uniqueptr_to_ptr() -> UniquePtr<*mut C>;
   |                                      ^^^^^^^^^^^^^^^^^
 
-error: unsupported vector target type
+error: unsupported vector element type
  --> $DIR/ptr_unsupported.rs:8:45
   |
 8 |         fn get_vector_of_ptr() -> UniquePtr<CxxVector<*mut C>>;


### PR DESCRIPTION
Vectors have elements, not targets. (Pointers, like unique_ptr and shared_ptr, have targets -- matching the terminology of Target in the [std::ops::Deref](https://doc.rust-lang.org/std/ops/trait.Deref.html) trait.)