### PR TITLE
Factor out Type traversal to a Visit trait

### DIFF
--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -27,6 +27,7 @@ mod tokens;
 mod toposort;
 pub mod trivial;
 pub mod types;
+mod visit;
 
 use self::attrs::OtherAttrs;
 use self::discriminant::Discriminant;

--- a/syntax/visit.rs
+++ b/syntax/visit.rs
@@ -1,0 +1,34 @@
+use crate::syntax::Type;
+
+pub trait Visit<'a> {
+    fn visit_type(&mut self, ty: &'a Type) {
+        visit_type(self, ty);
+    }
+}
+
+pub fn visit_type<'a, V>(visitor: &mut V, ty: &'a Type)
+where
+    V: Visit<'a> + ?Sized,
+{
+    match ty {
+        Type::Ident(_) | Type::Str(_) | Type::Void(_) => {}
+        Type::RustBox(ty)
+        | Type::UniquePtr(ty)
+        | Type::SharedPtr(ty)
+        | Type::WeakPtr(ty)
+        | Type::CxxVector(ty)
+        | Type::RustVec(ty) => visitor.visit_type(&ty.inner),
+        Type::Ref(r) => visitor.visit_type(&r.inner),
+        Type::Ptr(p) => visitor.visit_type(&p.inner),
+        Type::Array(a) => visitor.visit_type(&a.inner),
+        Type::SliceRef(s) => visitor.visit_type(&s.inner),
+        Type::Fn(fun) => {
+            if let Some(ret) = &fun.ret {
+                visitor.visit_type(ret);
+            }
+            for arg in &fun.args {
+                visitor.visit_type(&arg.ty);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is going to be necessary for recursive traversal of function argument types for #765.

The structure of the `Visit` trait exactly matches the design from [`syn::visit`](https://docs.rs/syn/1.0.65/syn/visit/index.html).