### PR TITLE
Add a void ptr cast for extern type aliases containing Rust-native types

### DIFF
--- a/syntax/improper.rs
+++ b/syntax/improper.rs
@@ -19,7 +19,7 @@ impl<'a> Types<'a> {
                 } else if let Some(strct) = self.structs.get(ident) {
                     Depends(&strct.name.rust) // iterate to fixed-point
                 } else {
-                    Definite(self.rust.contains(ident))
+                    Definite(self.rust.contains(ident) || self.aliases.contains_key(ident))
                 }
             }
             Type::RustBox(_)


### PR DESCRIPTION
Fixes #771.