### PR TITLE
Improve span of errors on implicitly generated shim impls

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1374,8 +1374,7 @@ fn write_generic_instantiations(out: &mut OutFile) {
 }
 
 fn write_rust_box_extern(out: &mut OutFile, key: NamedImplKey) {
-    let ident = key.rust;
-    let resolve = out.types.resolve(ident);
+    let resolve = out.types.resolve(&key);
     let inner = resolve.name.to_fully_qualified();
     let instance = resolve.name.to_symbol();
 
@@ -1441,8 +1440,7 @@ fn write_rust_vec_extern(out: &mut OutFile, key: NamedImplKey) {
 }
 
 fn write_rust_box_impl(out: &mut OutFile, key: NamedImplKey) {
-    let ident = key.rust;
-    let resolve = out.types.resolve(ident);
+    let resolve = out.types.resolve(&key);
     let inner = resolve.name.to_fully_qualified();
     let instance = resolve.name.to_symbol();
 
@@ -1741,8 +1739,7 @@ fn write_shared_ptr(out: &mut OutFile, key: NamedImplKey) {
 }
 
 fn write_weak_ptr(out: &mut OutFile, key: NamedImplKey) {
-    let ident = key.rust;
-    let resolve = out.types.resolve(ident);
+    let resolve = out.types.resolve(&key);
     let inner = resolve.name.to_fully_qualified();
     let instance = resolve.name.to_symbol();
 

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -3,7 +3,7 @@ use crate::gen::nested::NamespaceEntries;
 use crate::gen::out::OutFile;
 use crate::gen::{builtin, include, Opt};
 use crate::syntax::atom::Atom::{self, *};
-use crate::syntax::instantiate::ImplKey;
+use crate::syntax::instantiate::{ImplKey, NamedImplKey};
 use crate::syntax::map::UnorderedMap as Map;
 use crate::syntax::set::UnorderedSet;
 use crate::syntax::symbol::Symbol;
@@ -1349,7 +1349,7 @@ fn write_generic_instantiations(out: &mut OutFile) {
     out.begin_block(Block::ExternC);
     for impl_key in out.types.impls.keys() {
         out.next_section();
-        match impl_key {
+        match *impl_key {
             ImplKey::RustBox(ident) => write_rust_box_extern(out, ident),
             ImplKey::RustVec(ident) => write_rust_vec_extern(out, ident),
             ImplKey::UniquePtr(ident) => write_unique_ptr(out, ident),
@@ -1363,7 +1363,7 @@ fn write_generic_instantiations(out: &mut OutFile) {
     out.begin_block(Block::Namespace("rust"));
     out.begin_block(Block::InlineNamespace("cxxbridge1"));
     for impl_key in out.types.impls.keys() {
-        match impl_key {
+        match *impl_key {
             ImplKey::RustBox(ident) => write_rust_box_impl(out, ident),
             ImplKey::RustVec(ident) => write_rust_vec_impl(out, ident),
             _ => {}
@@ -1373,7 +1373,8 @@ fn write_generic_instantiations(out: &mut OutFile) {
     out.end_block(Block::Namespace("rust"));
 }
 
-fn write_rust_box_extern(out: &mut OutFile, ident: &Ident) {
+fn write_rust_box_extern(out: &mut OutFile, key: NamedImplKey) {
+    let ident = key.rust;
     let resolve = out.types.resolve(ident);
     let inner = resolve.name.to_fully_qualified();
     let instance = resolve.name.to_symbol();
@@ -1395,7 +1396,8 @@ fn write_rust_box_extern(out: &mut OutFile, ident: &Ident) {
     );
 }
 
-fn write_rust_vec_extern(out: &mut OutFile, element: &Ident) {
+fn write_rust_vec_extern(out: &mut OutFile, key: NamedImplKey) {
+    let element = key.rust;
     let inner = element.to_typename(out.types);
     let instance = element.to_mangled(out.types);
 
@@ -1438,7 +1440,8 @@ fn write_rust_vec_extern(out: &mut OutFile, element: &Ident) {
     );
 }
 
-fn write_rust_box_impl(out: &mut OutFile, ident: &Ident) {
+fn write_rust_box_impl(out: &mut OutFile, key: NamedImplKey) {
+    let ident = key.rust;
     let resolve = out.types.resolve(ident);
     let inner = resolve.name.to_fully_qualified();
     let instance = resolve.name.to_symbol();
@@ -1470,7 +1473,8 @@ fn write_rust_box_impl(out: &mut OutFile, ident: &Ident) {
     writeln!(out, "}}");
 }
 
-fn write_rust_vec_impl(out: &mut OutFile, element: &Ident) {
+fn write_rust_vec_impl(out: &mut OutFile, key: NamedImplKey) {
+    let element = key.rust;
     let inner = element.to_typename(out.types);
     let instance = element.to_mangled(out.types);
 
@@ -1547,8 +1551,8 @@ fn write_rust_vec_impl(out: &mut OutFile, element: &Ident) {
     writeln!(out, "}}");
 }
 
-fn write_unique_ptr(out: &mut OutFile, ident: &Ident) {
-    let ty = UniquePtr::Ident(ident);
+fn write_unique_ptr(out: &mut OutFile, key: NamedImplKey) {
+    let ty = UniquePtr::Ident(key.rust);
     write_unique_ptr_common(out, ty);
 }
 
@@ -1663,7 +1667,8 @@ fn write_unique_ptr_common(out: &mut OutFile, ty: UniquePtr) {
     writeln!(out, "}}");
 }
 
-fn write_shared_ptr(out: &mut OutFile, ident: &Ident) {
+fn write_shared_ptr(out: &mut OutFile, key: NamedImplKey) {
+    let ident = key.rust;
     let resolve = out.types.resolve(ident);
     let inner = resolve.name.to_fully_qualified();
     let instance = resolve.name.to_symbol();
@@ -1735,7 +1740,8 @@ fn write_shared_ptr(out: &mut OutFile, ident: &Ident) {
     writeln!(out, "}}");
 }
 
-fn write_weak_ptr(out: &mut OutFile, ident: &Ident) {
+fn write_weak_ptr(out: &mut OutFile, key: NamedImplKey) {
+    let ident = key.rust;
     let resolve = out.types.resolve(ident);
     let inner = resolve.name.to_fully_qualified();
     let instance = resolve.name.to_symbol();
@@ -1794,7 +1800,8 @@ fn write_weak_ptr(out: &mut OutFile, ident: &Ident) {
     writeln!(out, "}}");
 }
 
-fn write_cxx_vector(out: &mut OutFile, element: &Ident) {
+fn write_cxx_vector(out: &mut OutFile, key: NamedImplKey) {
+    let element = key.rust;
     let inner = element.to_typename(out.types);
     let instance = element.to_mangled(out.types);
 

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1140,9 +1140,8 @@ fn expand_rust_box(key: NamedImplKey, types: &Types, explicit_impl: Option<&Impl
 
     let (impl_generics, ty_generics) = generics::split_for_impl(key, explicit_impl, resolve);
 
-    let begin_span =
-        explicit_impl.map_or_else(Span::call_site, |explicit| explicit.impl_token.span);
-    let end_span = explicit_impl.map_or_else(Span::call_site, |explicit| explicit.brace_token.span);
+    let begin_span = explicit_impl.map_or(key.begin_span, |explicit| explicit.impl_token.span);
+    let end_span = explicit_impl.map_or(key.end_span, |explicit| explicit.brace_token.span);
     let unsafe_token = format_ident!("unsafe", span = begin_span);
 
     quote_spanned! {end_span=>
@@ -1189,9 +1188,8 @@ fn expand_rust_vec(key: NamedImplKey, types: &Types, explicit_impl: Option<&Impl
 
     let (impl_generics, ty_generics) = generics::split_for_impl(key, explicit_impl, resolve);
 
-    let begin_span =
-        explicit_impl.map_or_else(Span::call_site, |explicit| explicit.impl_token.span);
-    let end_span = explicit_impl.map_or_else(Span::call_site, |explicit| explicit.brace_token.span);
+    let begin_span = explicit_impl.map_or(key.begin_span, |explicit| explicit.impl_token.span);
+    let end_span = explicit_impl.map_or(key.end_span, |explicit| explicit.brace_token.span);
     let unsafe_token = format_ident!("unsafe", span = begin_span);
 
     quote_spanned! {end_span=>
@@ -1273,9 +1271,8 @@ fn expand_unique_ptr(
         None
     };
 
-    let begin_span =
-        explicit_impl.map_or_else(Span::call_site, |explicit| explicit.impl_token.span);
-    let end_span = explicit_impl.map_or_else(Span::call_site, |explicit| explicit.brace_token.span);
+    let begin_span = explicit_impl.map_or(key.begin_span, |explicit| explicit.impl_token.span);
+    let end_span = explicit_impl.map_or(key.end_span, |explicit| explicit.brace_token.span);
     let unsafe_token = format_ident!("unsafe", span = begin_span);
 
     quote_spanned! {end_span=>
@@ -1368,9 +1365,8 @@ fn expand_shared_ptr(
         None
     };
 
-    let begin_span =
-        explicit_impl.map_or_else(Span::call_site, |explicit| explicit.impl_token.span);
-    let end_span = explicit_impl.map_or_else(Span::call_site, |explicit| explicit.brace_token.span);
+    let begin_span = explicit_impl.map_or(key.begin_span, |explicit| explicit.impl_token.span);
+    let end_span = explicit_impl.map_or(key.end_span, |explicit| explicit.brace_token.span);
     let unsafe_token = format_ident!("unsafe", span = begin_span);
 
     quote_spanned! {end_span=>
@@ -1429,9 +1425,8 @@ fn expand_weak_ptr(key: NamedImplKey, types: &Types, explicit_impl: Option<&Impl
 
     let (impl_generics, ty_generics) = generics::split_for_impl(key, explicit_impl, resolve);
 
-    let begin_span =
-        explicit_impl.map_or_else(Span::call_site, |explicit| explicit.impl_token.span);
-    let end_span = explicit_impl.map_or_else(Span::call_site, |explicit| explicit.brace_token.span);
+    let begin_span = explicit_impl.map_or(key.begin_span, |explicit| explicit.impl_token.span);
+    let end_span = explicit_impl.map_or(key.end_span, |explicit| explicit.brace_token.span);
     let unsafe_token = format_ident!("unsafe", span = begin_span);
 
     quote_spanned! {end_span=>
@@ -1507,9 +1502,8 @@ fn expand_cxx_vector(
 
     let (impl_generics, ty_generics) = generics::split_for_impl(key, explicit_impl, resolve);
 
-    let begin_span =
-        explicit_impl.map_or_else(Span::call_site, |explicit| explicit.impl_token.span);
-    let end_span = explicit_impl.map_or_else(Span::call_site, |explicit| explicit.brace_token.span);
+    let begin_span = explicit_impl.map_or(key.begin_span, |explicit| explicit.impl_token.span);
+    let end_span = explicit_impl.map_or(key.end_span, |explicit| explicit.brace_token.span);
     let unsafe_token = format_ident!("unsafe", span = begin_span);
 
     quote_spanned! {end_span=>

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1138,7 +1138,7 @@ fn expand_rust_box(key: NamedImplKey, types: &Types, explicit_impl: Option<&Impl
     let local_dealloc = format_ident!("{}dealloc", local_prefix);
     let local_drop = format_ident!("{}drop", local_prefix);
 
-    let (impl_generics, ty_generics) = generics::split_for_impl(explicit_impl, resolve);
+    let (impl_generics, ty_generics) = generics::split_for_impl(key, explicit_impl, resolve);
 
     let begin_span =
         explicit_impl.map_or_else(Span::call_site, |explicit| explicit.impl_token.span);
@@ -1187,7 +1187,7 @@ fn expand_rust_vec(key: NamedImplKey, types: &Types, explicit_impl: Option<&Impl
     let local_reserve_total = format_ident!("{}reserve_total", local_prefix);
     let local_set_len = format_ident!("{}set_len", local_prefix);
 
-    let (impl_generics, ty_generics) = generics::split_for_impl(explicit_impl, resolve);
+    let (impl_generics, ty_generics) = generics::split_for_impl(key, explicit_impl, resolve);
 
     let begin_span =
         explicit_impl.map_or_else(Span::call_site, |explicit| explicit.impl_token.span);
@@ -1251,7 +1251,7 @@ fn expand_unique_ptr(
     let link_release = format!("{}release", prefix);
     let link_drop = format!("{}drop", prefix);
 
-    let (impl_generics, ty_generics) = generics::split_for_impl(explicit_impl, resolve);
+    let (impl_generics, ty_generics) = generics::split_for_impl(key, explicit_impl, resolve);
 
     let can_construct_from_value = types.structs.contains_key(ident)
         || types.enums.contains_key(ident)
@@ -1348,7 +1348,7 @@ fn expand_shared_ptr(
     let link_get = format!("{}get", prefix);
     let link_drop = format!("{}drop", prefix);
 
-    let (impl_generics, ty_generics) = generics::split_for_impl(explicit_impl, resolve);
+    let (impl_generics, ty_generics) = generics::split_for_impl(key, explicit_impl, resolve);
 
     let can_construct_from_value = types.structs.contains_key(ident)
         || types.enums.contains_key(ident)
@@ -1427,7 +1427,7 @@ fn expand_weak_ptr(key: NamedImplKey, types: &Types, explicit_impl: Option<&Impl
     let link_upgrade = format!("{}upgrade", prefix);
     let link_drop = format!("{}drop", prefix);
 
-    let (impl_generics, ty_generics) = generics::split_for_impl(explicit_impl, resolve);
+    let (impl_generics, ty_generics) = generics::split_for_impl(key, explicit_impl, resolve);
 
     let begin_span =
         explicit_impl.map_or_else(Span::call_site, |explicit| explicit.impl_token.span);
@@ -1505,7 +1505,7 @@ fn expand_cxx_vector(
     let link_unique_ptr_release = format!("{}release", unique_ptr_prefix);
     let link_unique_ptr_drop = format!("{}drop", unique_ptr_prefix);
 
-    let (impl_generics, ty_generics) = generics::split_for_impl(explicit_impl, resolve);
+    let (impl_generics, ty_generics) = generics::split_for_impl(key, explicit_impl, resolve);
 
     let begin_span =
         explicit_impl.map_or_else(Span::call_site, |explicit| explicit.impl_token.span);

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1,7 +1,7 @@
 use crate::syntax::atom::Atom::*;
 use crate::syntax::attrs::{self, OtherAttrs};
 use crate::syntax::file::Module;
-use crate::syntax::instantiate::ImplKey;
+use crate::syntax::instantiate::{ImplKey, NamedImplKey};
 use crate::syntax::qualified::QualifiedName;
 use crate::syntax::report::Errors;
 use crate::syntax::symbol::Symbol;
@@ -85,7 +85,7 @@ fn expand(ffi: Module, doc: Doc, attrs: OtherAttrs, apis: &[Api], types: &Types)
     }
 
     for (impl_key, &explicit_impl) in &types.impls {
-        match impl_key {
+        match *impl_key {
             ImplKey::RustBox(ident) => {
                 hidden.extend(expand_rust_box(ident, types, explicit_impl));
             }
@@ -1125,7 +1125,8 @@ fn type_id(name: &Pair) -> TokenStream {
     crate::type_id::expand(Crate::Cxx, qualified)
 }
 
-fn expand_rust_box(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>) -> TokenStream {
+fn expand_rust_box(key: NamedImplKey, types: &Types, explicit_impl: Option<&Impl>) -> TokenStream {
+    let ident = key.rust;
     let resolve = types.resolve(ident);
     let link_prefix = format!("cxxbridge1$box${}$", resolve.name.to_symbol());
     let link_alloc = format!("{}alloc", link_prefix);
@@ -1165,7 +1166,8 @@ fn expand_rust_box(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>) -
     }
 }
 
-fn expand_rust_vec(elem: &Ident, types: &Types, explicit_impl: Option<&Impl>) -> TokenStream {
+fn expand_rust_vec(key: NamedImplKey, types: &Types, explicit_impl: Option<&Impl>) -> TokenStream {
+    let elem = key.rust;
     let resolve = types.resolve(elem);
     let link_prefix = format!("cxxbridge1$rust_vec${}$", resolve.name.to_symbol());
     let link_new = format!("{}new", link_prefix);
@@ -1233,7 +1235,12 @@ fn expand_rust_vec(elem: &Ident, types: &Types, explicit_impl: Option<&Impl>) ->
     }
 }
 
-fn expand_unique_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>) -> TokenStream {
+fn expand_unique_ptr(
+    key: NamedImplKey,
+    types: &Types,
+    explicit_impl: Option<&Impl>,
+) -> TokenStream {
+    let ident = key.rust;
     let name = ident.to_string();
     let resolve = types.resolve(ident);
     let prefix = format!("cxxbridge1$unique_ptr${}$", resolve.name.to_symbol());
@@ -1326,7 +1333,12 @@ fn expand_unique_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>)
     }
 }
 
-fn expand_shared_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>) -> TokenStream {
+fn expand_shared_ptr(
+    key: NamedImplKey,
+    types: &Types,
+    explicit_impl: Option<&Impl>,
+) -> TokenStream {
+    let ident = key.rust;
     let name = ident.to_string();
     let resolve = types.resolve(ident);
     let prefix = format!("cxxbridge1$shared_ptr${}$", resolve.name.to_symbol());
@@ -1404,7 +1416,8 @@ fn expand_shared_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>)
     }
 }
 
-fn expand_weak_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>) -> TokenStream {
+fn expand_weak_ptr(key: NamedImplKey, types: &Types, explicit_impl: Option<&Impl>) -> TokenStream {
+    let ident = key.rust;
     let name = ident.to_string();
     let resolve = types.resolve(ident);
     let prefix = format!("cxxbridge1$weak_ptr${}$", resolve.name.to_symbol());
@@ -1471,7 +1484,12 @@ fn expand_weak_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>) -
     }
 }
 
-fn expand_cxx_vector(elem: &Ident, explicit_impl: Option<&Impl>, types: &Types) -> TokenStream {
+fn expand_cxx_vector(
+    key: NamedImplKey,
+    explicit_impl: Option<&Impl>,
+    types: &Types,
+) -> TokenStream {
+    let elem = key.rust;
     let name = elem.to_string();
     let resolve = types.resolve(elem);
     let prefix = format!("cxxbridge1$std$vector${}$", resolve.name.to_symbol());

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1,4 +1,3 @@
-use crate::derive;
 use crate::syntax::atom::Atom::*;
 use crate::syntax::attrs::{self, OtherAttrs};
 use crate::syntax::file::Module;
@@ -11,6 +10,7 @@ use crate::syntax::{
     Struct, Trait, Type, TypeAlias, Types,
 };
 use crate::type_id::Crate;
+use crate::{derive, generics};
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote, quote_spanned, ToTokens};
 use std::mem;
@@ -1137,11 +1137,7 @@ fn expand_rust_box(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>) -
     let local_dealloc = format_ident!("{}dealloc", local_prefix);
     let local_drop = format_ident!("{}drop", local_prefix);
 
-    let (impl_generics, ty_generics) = if let Some(imp) = explicit_impl {
-        (&imp.impl_generics, &imp.ty_generics)
-    } else {
-        (resolve.generics, resolve.generics)
-    };
+    let (impl_generics, ty_generics) = generics::split_for_impl(explicit_impl, resolve);
 
     let begin_span =
         explicit_impl.map_or_else(Span::call_site, |explicit| explicit.impl_token.span);
@@ -1189,11 +1185,7 @@ fn expand_rust_vec(elem: &Ident, types: &Types, explicit_impl: Option<&Impl>) ->
     let local_reserve_total = format_ident!("{}reserve_total", local_prefix);
     let local_set_len = format_ident!("{}set_len", local_prefix);
 
-    let (impl_generics, ty_generics) = if let Some(imp) = explicit_impl {
-        (&imp.impl_generics, &imp.ty_generics)
-    } else {
-        (resolve.generics, resolve.generics)
-    };
+    let (impl_generics, ty_generics) = generics::split_for_impl(explicit_impl, resolve);
 
     let begin_span =
         explicit_impl.map_or_else(Span::call_site, |explicit| explicit.impl_token.span);
@@ -1252,11 +1244,7 @@ fn expand_unique_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>)
     let link_release = format!("{}release", prefix);
     let link_drop = format!("{}drop", prefix);
 
-    let (impl_generics, ty_generics) = if let Some(imp) = explicit_impl {
-        (&imp.impl_generics, &imp.ty_generics)
-    } else {
-        (resolve.generics, resolve.generics)
-    };
+    let (impl_generics, ty_generics) = generics::split_for_impl(explicit_impl, resolve);
 
     let can_construct_from_value = types.structs.contains_key(ident)
         || types.enums.contains_key(ident)
@@ -1348,11 +1336,7 @@ fn expand_shared_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>)
     let link_get = format!("{}get", prefix);
     let link_drop = format!("{}drop", prefix);
 
-    let (impl_generics, ty_generics) = if let Some(imp) = explicit_impl {
-        (&imp.impl_generics, &imp.ty_generics)
-    } else {
-        (resolve.generics, resolve.generics)
-    };
+    let (impl_generics, ty_generics) = generics::split_for_impl(explicit_impl, resolve);
 
     let can_construct_from_value = types.structs.contains_key(ident)
         || types.enums.contains_key(ident)
@@ -1430,11 +1414,7 @@ fn expand_weak_ptr(ident: &Ident, types: &Types, explicit_impl: Option<&Impl>) -
     let link_upgrade = format!("{}upgrade", prefix);
     let link_drop = format!("{}drop", prefix);
 
-    let (impl_generics, ty_generics) = if let Some(imp) = explicit_impl {
-        (&imp.impl_generics, &imp.ty_generics)
-    } else {
-        (resolve.generics, resolve.generics)
-    };
+    let (impl_generics, ty_generics) = generics::split_for_impl(explicit_impl, resolve);
 
     let begin_span =
         explicit_impl.map_or_else(Span::call_site, |explicit| explicit.impl_token.span);
@@ -1507,11 +1487,7 @@ fn expand_cxx_vector(elem: &Ident, explicit_impl: Option<&Impl>, types: &Types) 
     let link_unique_ptr_release = format!("{}release", unique_ptr_prefix);
     let link_unique_ptr_drop = format!("{}drop", unique_ptr_prefix);
 
-    let (impl_generics, ty_generics) = if let Some(imp) = explicit_impl {
-        (&imp.impl_generics, &imp.ty_generics)
-    } else {
-        (resolve.generics, resolve.generics)
-    };
+    let (impl_generics, ty_generics) = generics::split_for_impl(explicit_impl, resolve);
 
     let begin_span =
         explicit_impl.map_or_else(Span::call_site, |explicit| explicit.impl_token.span);

--- a/macro/src/generics.rs
+++ b/macro/src/generics.rs
@@ -1,3 +1,4 @@
+use crate::syntax::instantiate::NamedImplKey;
 use crate::syntax::resolve::Resolution;
 use crate::syntax::Impl;
 use proc_macro2::TokenStream;
@@ -9,11 +10,13 @@ pub struct ImplGenerics<'a> {
 }
 
 pub struct TyGenerics<'a> {
+    key: NamedImplKey<'a>,
     explicit_impl: Option<&'a Impl>,
     resolve: Resolution<'a>,
 }
 
 pub fn split_for_impl<'a>(
+    key: NamedImplKey<'a>,
     explicit_impl: Option<&'a Impl>,
     resolve: Resolution<'a>,
 ) -> (ImplGenerics<'a>, TyGenerics<'a>) {
@@ -22,6 +25,7 @@ pub fn split_for_impl<'a>(
         resolve,
     };
     let ty_generics = TyGenerics {
+        key,
         explicit_impl,
         resolve,
     };
@@ -43,7 +47,9 @@ impl<'a> ToTokens for TyGenerics<'a> {
         if let Some(imp) = self.explicit_impl {
             imp.ty_generics.to_tokens(tokens);
         } else {
-            self.resolve.generics.to_tokens(tokens);
+            self.key.lt_token.to_tokens(tokens);
+            self.resolve.generics.lifetimes.to_tokens(tokens);
+            self.key.gt_token.to_tokens(tokens);
         }
     }
 }

--- a/macro/src/generics.rs
+++ b/macro/src/generics.rs
@@ -1,0 +1,49 @@
+use crate::syntax::resolve::Resolution;
+use crate::syntax::Impl;
+use proc_macro2::TokenStream;
+use quote::ToTokens;
+
+pub struct ImplGenerics<'a> {
+    explicit_impl: Option<&'a Impl>,
+    resolve: Resolution<'a>,
+}
+
+pub struct TyGenerics<'a> {
+    explicit_impl: Option<&'a Impl>,
+    resolve: Resolution<'a>,
+}
+
+pub fn split_for_impl<'a>(
+    explicit_impl: Option<&'a Impl>,
+    resolve: Resolution<'a>,
+) -> (ImplGenerics<'a>, TyGenerics<'a>) {
+    let impl_generics = ImplGenerics {
+        explicit_impl,
+        resolve,
+    };
+    let ty_generics = TyGenerics {
+        explicit_impl,
+        resolve,
+    };
+    (impl_generics, ty_generics)
+}
+
+impl<'a> ToTokens for ImplGenerics<'a> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        if let Some(imp) = self.explicit_impl {
+            imp.impl_generics.to_tokens(tokens);
+        } else {
+            self.resolve.generics.to_tokens(tokens);
+        }
+    }
+}
+
+impl<'a> ToTokens for TyGenerics<'a> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        if let Some(imp) = self.explicit_impl {
+            imp.ty_generics.to_tokens(tokens);
+        } else {
+            self.resolve.generics.to_tokens(tokens);
+        }
+    }
+}

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -32,6 +32,7 @@ extern crate proc_macro;
 
 mod derive;
 mod expand;
+mod generics;
 mod syntax;
 mod type_id;
 

--- a/syntax/instantiate.rs
+++ b/syntax/instantiate.rs
@@ -1,43 +1,76 @@
-use crate::syntax::Type;
+use crate::syntax::{NamedType, Type};
 use proc_macro2::Ident;
+use std::hash::{Hash, Hasher};
+use syn::Token;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum ImplKey<'a> {
-    RustBox(&'a Ident),
-    RustVec(&'a Ident),
-    UniquePtr(&'a Ident),
-    SharedPtr(&'a Ident),
-    WeakPtr(&'a Ident),
-    CxxVector(&'a Ident),
+    RustBox(NamedImplKey<'a>),
+    RustVec(NamedImplKey<'a>),
+    UniquePtr(NamedImplKey<'a>),
+    SharedPtr(NamedImplKey<'a>),
+    WeakPtr(NamedImplKey<'a>),
+    CxxVector(NamedImplKey<'a>),
+}
+
+#[derive(Copy, Clone)]
+pub struct NamedImplKey<'a> {
+    pub rust: &'a Ident,
+    pub lt_token: Option<Token![<]>,
+    pub gt_token: Option<Token![>]>,
 }
 
 impl Type {
     pub(crate) fn impl_key(&self) -> Option<ImplKey> {
         if let Type::RustBox(ty) = self {
             if let Type::Ident(ident) = &ty.inner {
-                return Some(ImplKey::RustBox(&ident.rust));
+                return Some(ImplKey::RustBox(NamedImplKey::from(ident)));
             }
         } else if let Type::RustVec(ty) = self {
             if let Type::Ident(ident) = &ty.inner {
-                return Some(ImplKey::RustVec(&ident.rust));
+                return Some(ImplKey::RustVec(NamedImplKey::from(ident)));
             }
         } else if let Type::UniquePtr(ty) = self {
             if let Type::Ident(ident) = &ty.inner {
-                return Some(ImplKey::UniquePtr(&ident.rust));
+                return Some(ImplKey::UniquePtr(NamedImplKey::from(ident)));
             }
         } else if let Type::SharedPtr(ty) = self {
             if let Type::Ident(ident) = &ty.inner {
-                return Some(ImplKey::SharedPtr(&ident.rust));
+                return Some(ImplKey::SharedPtr(NamedImplKey::from(ident)));
             }
         } else if let Type::WeakPtr(ty) = self {
             if let Type::Ident(ident) = &ty.inner {
-                return Some(ImplKey::WeakPtr(&ident.rust));
+                return Some(ImplKey::WeakPtr(NamedImplKey::from(ident)));
             }
         } else if let Type::CxxVector(ty) = self {
             if let Type::Ident(ident) = &ty.inner {
-                return Some(ImplKey::CxxVector(&ident.rust));
+                return Some(ImplKey::CxxVector(NamedImplKey::from(ident)));
             }
         }
         None
+    }
+}
+
+impl<'a> PartialEq for NamedImplKey<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        PartialEq::eq(self.rust, other.rust)
+    }
+}
+
+impl<'a> Eq for NamedImplKey<'a> {}
+
+impl<'a> Hash for NamedImplKey<'a> {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        self.rust.hash(hasher);
+    }
+}
+
+impl<'a> From<&'a NamedType> for NamedImplKey<'a> {
+    fn from(ty: &'a NamedType) -> Self {
+        NamedImplKey {
+            rust: &ty.rust,
+            lt_token: ty.generics.lt_token,
+            gt_token: ty.generics.gt_token,
+        }
     }
 }

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -20,7 +20,7 @@ mod parse;
 mod pod;
 pub mod qualified;
 pub mod report;
-mod resolve;
+pub mod resolve;
 pub mod set;
 pub mod symbol;
 mod tokens;

--- a/syntax/resolve.rs
+++ b/syntax/resolve.rs
@@ -1,3 +1,4 @@
+use crate::syntax::instantiate::NamedImplKey;
 use crate::syntax::{Lifetimes, NamedType, Pair, Types};
 use proc_macro2::Ident;
 
@@ -29,5 +30,11 @@ impl UnresolvedName for Ident {
 impl UnresolvedName for NamedType {
     fn ident(&self) -> &Ident {
         &self.rust
+    }
+}
+
+impl<'a> UnresolvedName for NamedImplKey<'a> {
+    fn ident(&self) -> &Ident {
+        self.rust
     }
 }

--- a/syntax/types.rs
+++ b/syntax/types.rs
@@ -171,7 +171,7 @@ impl<'a> Types<'a> {
                 | ImplKey::SharedPtr(ident)
                 | ImplKey::WeakPtr(ident)
                 | ImplKey::CxxVector(ident) => {
-                    Atom::from(ident).is_none() && !aliases.contains_key(ident)
+                    Atom::from(ident.rust).is_none() && !aliases.contains_key(ident.rust)
                 }
             };
             if implicit_impl && !impls.contains_key(&impl_key) {

--- a/tests/ui/nonlocal_rust_type.rs
+++ b/tests/ui/nonlocal_rust_type.rs
@@ -1,0 +1,18 @@
+pub struct MyBuilder<'a> {
+    _s: &'a str,
+}
+
+type OptBuilder<'a> = Option<MyBuilder<'a>>;
+
+#[cxx::bridge]
+mod ffi {
+    extern "Rust" {
+        type OptBuilder<'a>;
+    }
+
+    struct MyBuilder<'a> {
+        rs: Box<OptBuilder<'a>>,
+    }
+}
+
+fn main() {}

--- a/tests/ui/nonlocal_rust_type.stderr
+++ b/tests/ui/nonlocal_rust_type.stderr
@@ -1,0 +1,27 @@
+error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
+  --> $DIR/nonlocal_rust_type.rs:10:9
+   |
+10 |         type OptBuilder<'a>;
+   |         ^^^^^--------------
+   |         |    |
+   |         |    `Option` is not defined in the current crate
+   |         impl doesn't use only types from inside the current crate
+   |
+   = note: define and implement a trait or new type instead
+
+error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
+  --> $DIR/nonlocal_rust_type.rs:7:1
+   |
+7  |   #[cxx::bridge]
+   |   ^^^^^^^^^^^^^^ impl doesn't use only types from inside the current crate
+...
+10 |           type OptBuilder<'a>;
+   |  ___________________________-
+11 | |     }
+12 | |
+13 | |     struct MyBuilder<'a> {
+14 | |         rs: Box<OptBuilder<'a>>,
+   | |__________________________- `Option` is not defined in the current crate
+   |
+   = note: define and implement a trait or new type instead
+   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/nonlocal_rust_type.stderr
+++ b/tests/ui/nonlocal_rust_type.stderr
@@ -10,13 +10,12 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
-  --> $DIR/nonlocal_rust_type.rs:7:1
+  --> $DIR/nonlocal_rust_type.rs:14:13
    |
-7  | #[cxx::bridge]
-   | ^^^^^^^^^^^^^^ impl doesn't use only types from inside the current crate
-...
 14 |         rs: Box<OptBuilder<'a>>,
-   |                 --------------- `Option` is not defined in the current crate
+   |             ^^^^---------------
+   |             |   |
+   |             |   `Option` is not defined in the current crate
+   |             impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
-   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/nonlocal_rust_type.stderr
+++ b/tests/ui/nonlocal_rust_type.stderr
@@ -12,16 +12,11 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
   --> $DIR/nonlocal_rust_type.rs:7:1
    |
-7  |   #[cxx::bridge]
-   |   ^^^^^^^^^^^^^^ impl doesn't use only types from inside the current crate
+7  | #[cxx::bridge]
+   | ^^^^^^^^^^^^^^ impl doesn't use only types from inside the current crate
 ...
-10 |           type OptBuilder<'a>;
-   |  ___________________________-
-11 | |     }
-12 | |
-13 | |     struct MyBuilder<'a> {
-14 | |         rs: Box<OptBuilder<'a>>,
-   | |__________________________- `Option` is not defined in the current crate
+14 |         rs: Box<OptBuilder<'a>>,
+   |                 --------------- `Option` is not defined in the current crate
    |
    = note: define and implement a trait or new type instead
    = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
#### Repro:

```rust
pub struct MyBuilder<'a> {
    _s: &'a str,
}

type OptBuilder<'a> = Option<MyBuilder<'a>>;

#[cxx::bridge]
mod ffi {
    extern "Rust" {
        type OptBuilder<'a>;
    }

    struct MyBuilder<'a> {
        rs: Box<OptBuilder<'a>>,
    }
}
```

#### Diagnostic before:

Arrows everywhere, completely confused spans.

```console
error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
  --> $DIR/nonlocal_rust_type.rs:7:1
   |
7  |   #[cxx::bridge]
   |   ^^^^^^^^^^^^^^ impl doesn't use only types from inside the current crate
...
10 |           type OptBuilder<'a>;
   |  ___________________________-
11 | |     }
12 | |
13 | |     struct MyBuilder<'a> {
14 | |         rs: Box<OptBuilder<'a>>,
   | |__________________________- `Option` is not defined in the current crate
   |
   = note: define and implement a trait or new type instead
   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

#### Diagnostic after

```console
error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
  --> $DIR/nonlocal_rust_type.rs:14:13
   |
14 |         rs: Box<OptBuilder<'a>>,
   |             ^^^^---------------
   |             |   |
   |             |   `Option` is not defined in the current crate
   |             impl doesn't use only types from inside the current crate
   |
   = note: define and implement a trait or new type instead
```