### PR TITLE
Hide extern "Rust" types' RustType impl from rustdoc

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -755,6 +755,7 @@ fn expand_rust_type_impl(ety: &ExternType) -> TokenStream {
     let unsafe_impl = quote_spanned!(ety.type_token.span=> unsafe impl);
 
     let mut impls = quote_spanned! {span=>
+        #[doc(hidden)]
         #unsafe_impl #generics ::cxx::private::RustType for #ident #generics {}
     };
 


### PR DESCRIPTION
This is a purely internal thing for cxx and doesn't need to be featured as a user-facing API on the type's rendered rustdoc page.