### PR TITLE
Debug assert that rust::Slice isn't constructed with C++ null ptr

### DIFF
--- a/include/cxx.h
+++ b/include/cxx.h
@@ -505,6 +505,7 @@ Slice<T>::Slice() noexcept {
 
 template <typename T>
 Slice<T>::Slice(T *s, std::size_t count) noexcept {
+  assert(s != nullptr);
   sliceInit(this, const_cast<typename std::remove_const<T>::type *>(s), count);
 }
 


### PR DESCRIPTION
According to https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html#safety:

> `data` must be non-null and aligned even for zero-length slices. One reason for this is that enum layout optimizations may rely on references (including slices of any length) being aligned and non-null to distinguish them from other data.