### PR TITLE
Allow slice null ptr safely if slice is empty

### DIFF
--- a/include/cxx.h
+++ b/include/cxx.h
@@ -505,8 +505,12 @@ Slice<T>::Slice() noexcept {
 
 template <typename T>
 Slice<T>::Slice(T *s, std::size_t count) noexcept {
-  assert(s != nullptr);
-  sliceInit(this, const_cast<typename std::remove_const<T>::type *>(s), count);
+  assert(s != nullptr || count == 0);
+  sliceInit(this,
+            s == nullptr && count == 0
+                ? reinterpret_cast<void *>(align_of<T>())
+                : const_cast<typename std::remove_const<T>::type *>(s),
+            count);
 }
 
 template <typename T>


### PR DESCRIPTION
Followup / relaxation of #788. This matches what we do for rust::String and rust::Str construction from ptr/len.

https://github.com/dtolnay/cxx/blob/72b8b7e5a2cde8378dcbbb7cecadf8fcd18f16c7/src/cxx.cc#L96-L101
https://github.com/dtolnay/cxx/blob/72b8b7e5a2cde8378dcbbb7cecadf8fcd18f16c7/src/cxx.cc#L214-L219