### PR TITLE
Make demo crate's Cargo dependencies copy/pasteable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,7 @@ members = ["demo", "flags", "gen/build", "gen/cmd", "gen/lib", "macro", "tests/f
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[patch.crates-io]
+cxx = { path = "." }
+cxx-build = { path = "gen/build" }

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-cxx = { version = "1.0", path = ".." }
+cxx = "1.0"
 
 [build-dependencies]
-cxx-build = { version = "1.0", path = "../gen/build" }
+cxx-build = "1.0"


### PR DESCRIPTION
By using a `patch` at the workspace root rather than path dependencies in the demo crate, the demo crate's dependencies can now match exactly what is shown/discussed in https://cxx.rs/tutorial.html and can be copied directly into the reader's project.