### PR TITLE
Include <stdexcept> for std::out_of_range type

### DIFF
--- a/gen/src/builtin.rs
+++ b/gen/src/builtin.rs
@@ -71,6 +71,7 @@ pub(super) fn write(out: &mut OutFile) {
         include.initializer_list = true;
         include.iterator = true;
         include.new = true;
+        include.stdexcept = true;
         include.type_traits = true;
         include.utility = true;
         builtin.panic = true;
@@ -84,6 +85,7 @@ pub(super) fn write(out: &mut OutFile) {
         include.cstddef = true;
         include.cstdint = true;
         include.iterator = true;
+        include.stdexcept = true;
         include.type_traits = true;
         builtin.friend_impl = true;
         builtin.layout = true;

--- a/gen/src/include.rs
+++ b/gen/src/include.rs
@@ -33,6 +33,7 @@ pub struct Includes<'a> {
     pub iterator: bool,
     pub memory: bool,
     pub new: bool,
+    pub stdexcept: bool,
     pub string: bool,
     pub type_traits: bool,
     pub utility: bool,
@@ -93,6 +94,7 @@ pub(super) fn write(out: &mut OutFile) {
         iterator,
         memory,
         new,
+        stdexcept,
         string,
         type_traits,
         utility,
@@ -137,6 +139,9 @@ pub(super) fn write(out: &mut OutFile) {
     }
     if new && !cxx_header {
         writeln!(out, "#include <new>");
+    }
+    if stdexcept && !cxx_header {
+        writeln!(out, "#include <stdexcept>");
     }
     if string && !cxx_header {
         writeln!(out, "#include <string>");


### PR DESCRIPTION
This exception type is used for checked indexing of rust::Slice and rust::Vec, for example the following. it is provided by the `stdexcept` header.

https://github.com/dtolnay/cxx/blob/9b8ed98c33f11a8545b022641620f0de86c51b4c/include/cxx.h#L543-L549

https://en.cppreference.com/w/cpp/error/out_of_range