### PR TITLE
Handle unrecognized type names in checking signature for mutable return type

### DIFF
--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -521,7 +521,10 @@ fn check_mut_return_restriction(cx: &mut Check, efn: &ExternFn) {
         if receiver.mutable {
             return;
         }
-        let resolve = cx.types.resolve(&receiver.ty);
+        let resolve = match cx.types.try_resolve(&receiver.ty) {
+            Some(resolve) => resolve,
+            None => return,
+        };
         if !resolve.generics.lifetimes.is_empty() {
             return;
         }
@@ -536,9 +539,11 @@ fn check_mut_return_restriction(cx: &mut Check, efn: &ExternFn) {
         fn visit_type(&mut self, ty: &'t Type) {
             self.found |= match ty {
                 Type::Ref(ty) => ty.mutable,
-                Type::Ident(ident) => {
-                    let resolve = self.cx.types.resolve(ident);
-                    !resolve.generics.lifetimes.is_empty()
+                Type::Ident(ident) if Atom::from(&ident.rust).is_none() => {
+                    match self.cx.types.try_resolve(ident) {
+                        Some(resolve) => !resolve.generics.lifetimes.is_empty(),
+                        None => true,
+                    }
                 }
                 _ => false,
             };

--- a/syntax/resolve.rs
+++ b/syntax/resolve.rs
@@ -11,10 +11,15 @@ pub struct Resolution<'a> {
 impl<'a> Types<'a> {
     pub fn resolve(&self, ident: &impl UnresolvedName) -> Resolution<'a> {
         let ident = ident.ident();
-        match self.resolutions.get(ident) {
-            Some(resolution) => *resolution,
+        match self.try_resolve(ident) {
+            Some(resolution) => resolution,
             None => panic!("Unable to resolve type `{}`", ident),
         }
+    }
+
+    pub fn try_resolve(&self, ident: &impl UnresolvedName) -> Option<Resolution<'a>> {
+        let ident = ident.ident();
+        self.resolutions.get(ident).copied()
     }
 }
 


### PR DESCRIPTION
The previous implementation contained calls to `Types::resolve` which could fail if the signature contained any unrecognized type name, such as a typo. `Types::resolve` is really only safe to call *after* all type checking has been completed, such as in gen/src/write.rs and macro/src/expand.rs.

This indicates maybe we should separate out a second "tier" of checks which only run after all names are known to successfully resolve.