### PR TITLE
Recognize mutable slice in return position of a safe function

### DIFF
--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -514,6 +514,7 @@ fn check_mut_return_restriction(cx: &mut Check, efn: &ExternFn) {
 
     match &efn.ret {
         Some(Type::Ref(ty)) if ty.mutable => {}
+        Some(Type::SliceRef(slice)) if slice.mutable => {}
         _ => return,
     }
 

--- a/tests/ui/mut_return.rs
+++ b/tests/ui/mut_return.rs
@@ -11,6 +11,7 @@ mod ffi {
         unsafe fn g(t: &Thing) -> Pin<&mut CxxString>;
         fn h(t: Box<Mut>) -> Pin<&mut CxxString>;
         fn i<'a>(t: Box<Mut<'a>>) -> Pin<&'a mut CxxString>;
+        fn j(t: &Thing) -> &mut [u8];
     }
 }
 

--- a/tests/ui/mut_return.stderr
+++ b/tests/ui/mut_return.stderr
@@ -3,3 +3,9 @@ error: &mut return type is not allowed unless there is a &mut argument
    |
 10 |         fn f(t: &Thing) -> Pin<&mut CxxString>;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: &mut return type is not allowed unless there is a &mut argument
+  --> $DIR/mut_return.rs:14:9
+   |
+14 |         fn j(t: &Thing) -> &mut [u8];
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes #766.

See https://github.com/novifinancial/rust-plasma/pull/3 and https://github.com/MWATelescope/Birli/pull/1 for two examples of the type of unsound signature that this catches.