### PR TITLE
Update to proc-macro2 with lex error spans

### DIFF
--- a/gen/build/Cargo.toml
+++ b/gen/build/Cargo.toml
@@ -18,10 +18,10 @@ parallel = ["cc/parallel"]
 cc = "1.0.49"
 codespan-reporting = "0.11"
 lazy_static = "1.4"
-proc-macro2 = { version = "1.0.17", default-features = false, features = ["span-locations"] }
+proc-macro2 = { version = "1.0.26", default-features = false, features = ["span-locations"] }
 quote = { version = "1.0", default-features = false }
 scratch = "1.0"
-syn = { version = "1.0.57", default-features = false, features = ["parsing", "printing", "clone-impls", "full"] }
+syn = { version = "1.0.68", default-features = false, features = ["parsing", "printing", "clone-impls", "full"] }
 
 [dev-dependencies]
 cxx-gen = { version = "0.7", path = "../lib" }

--- a/gen/cmd/Cargo.toml
+++ b/gen/cmd/Cargo.toml
@@ -18,9 +18,9 @@ path = "src/main.rs"
 [dependencies]
 clap = "2.33"
 codespan-reporting = "0.11"
-proc-macro2 = { version = "1.0.17", default-features = false, features = ["span-locations"] }
+proc-macro2 = { version = "1.0.26", default-features = false, features = ["span-locations"] }
 quote = { version = "1.0", default-features = false }
-syn = { version = "1.0.57", default-features = false, features = ["parsing", "printing", "clone-impls", "full"] }
+syn = { version = "1.0.68", default-features = false, features = ["parsing", "printing", "clone-impls", "full"] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/gen/lib/Cargo.toml
+++ b/gen/lib/Cargo.toml
@@ -13,9 +13,9 @@ categories = ["development-tools::ffi"]
 [dependencies]
 cc = "1.0.49"
 codespan-reporting = "0.11"
-proc-macro2 = { version = "1.0.17", default-features = false, features = ["span-locations"] }
+proc-macro2 = { version = "1.0.26", default-features = false, features = ["span-locations"] }
 quote = { version = "1.0", default-features = false }
-syn = { version = "1.0.57", default-features = false, features = ["parsing", "printing", "clone-impls", "full"] }
+syn = { version = "1.0.68", default-features = false, features = ["parsing", "printing", "clone-impls", "full"] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0.4"
-syn = { version = "1.0.57", features = ["full"] }
+syn = { version = "1.0.68", features = ["full"] }
 
 [dev-dependencies]
 cxx = { version = "1.0", path = ".." }

--- a/third-party/BUCK
+++ b/third-party/BUCK
@@ -41,7 +41,7 @@ rust_library(
 
 rust_library(
     name = "proc-macro2",
-    srcs = glob(["vendor/proc-macro2-1.0.24/src/**"]),
+    srcs = glob(["vendor/proc-macro2-1.0.26/src/**"]),
     visibility = ["PUBLIC"],
     features = [
         "proc-macro",
@@ -72,7 +72,7 @@ rust_library(
 
 rust_library(
     name = "syn",
-    srcs = glob(["vendor/syn-1.0.67/src/**"]),
+    srcs = glob(["vendor/syn-1.0.68/src/**"]),
     visibility = ["PUBLIC"],
     features = [
         "clone-impls",

--- a/third-party/BUILD
+++ b/third-party/BUILD
@@ -45,7 +45,7 @@ rust_library(
 
 rust_library(
     name = "proc-macro2",
-    srcs = glob(["vendor/proc-macro2-1.0.24/src/**"]),
+    srcs = glob(["vendor/proc-macro2-1.0.26/src/**"]),
     crate_features = [
         "proc-macro",
         "span-locations",
@@ -76,7 +76,7 @@ rust_library(
 
 rust_library(
     name = "syn",
-    srcs = glob(["vendor/syn-1.0.67/src/**"]),
+    srcs = glob(["vendor/syn-1.0.68/src/**"]),
     crate_features = [
         "clone-impls",
         "derive",

--- a/third-party/Cargo.lock
+++ b/third-party/Cargo.lock
@@ -210,9 +210,9 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 dependencies = [
  "unicode-xid",
 ]
@@ -283,9 +283,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6498a9efc342871f91cc2d0d694c674368b4ceb40f62b65a7a08c3792935e702"
+checksum = "3ce15dd3ed8aa2f8eeac4716d6ef5ab58b6b9256db41d7e1a0224c2788e8fd87"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Pulls in https://github.com/dtolnay/syn/pull/1006 + https://github.com/alexcrichton/proc-macro2/pull/283.

<br>

### Before

```console
  error[cxxbridge]: lex error
    ┌─ src/main.rs:1:1
    │
  1 │ //! this file contains a lex error... where?
    │ ^ lex error
```

### After

```console
  error[cxxbridge]: lex error
     ┌─ src/main.rs:46:12
     │
  46 │ fn main() {)
     │            ^ lex error
```