### PR TITLE
Pass opaque Rust types to C++ and back

### DIFF
--- a/smessmer/Cargo.toml
+++ b/smessmer/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "smessmer"
+version = "0.0.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+cxx = "1.0"
+
+[build-dependencies]
+cxx-build = "1.0"
+
+[workspace]

--- a/smessmer/build.rs
+++ b/smessmer/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    cxx_build::bridge("src/main.rs")
+        .file("src/roundtrip.cc")
+        .compile("smessmer");
+}

--- a/smessmer/include/roundtrip.h
+++ b/smessmer/include/roundtrip.h
@@ -1,0 +1,5 @@
+#pragma once
+
+struct MyCustomType;
+
+void cppfunc(const MyCustomType& v);

--- a/smessmer/src/main.rs
+++ b/smessmer/src/main.rs
@@ -1,0 +1,24 @@
+#[cxx::bridge]
+mod ffi {
+    unsafe extern "C++" {
+        include!("smessmer/include/roundtrip.h");
+        fn cppfunc(v: &MyCustomType);
+    }
+
+    extern "Rust" {
+        type MyCustomType;
+        fn rustfunc(v: &MyCustomType);
+    }
+}
+
+pub struct MyCustomType {}
+
+fn rustfunc(v: &MyCustomType) {
+    let _ = v;
+    println!("success");
+}
+
+fn main() {
+    let v = MyCustomType {};
+    ffi::cppfunc(&v);
+}

--- a/smessmer/src/roundtrip.cc
+++ b/smessmer/src/roundtrip.cc
@@ -1,0 +1,5 @@
+#include "smessmer/src/main.rs"
+
+void cppfunc(const MyCustomType &v) {
+  rustfunc(v);
+}


### PR DESCRIPTION
#802.

<pre>
<i>cxx</i>$  <b>git fetch origin refs/pull/803/head</b>
<i>cxx</i>$  <b>git checkout FETCH_HEAD</b>
<i>cxx</i>$  <b>cd smessmer/</b>
<i>cxx/smessmer</i>$  <b>cargo run</b>
   Compiling smessmer v0.0.0
    Finished dev [unoptimized + debuginfo] target(s) in 2.06s
     Running `target/debug/smessmer`
success
</pre>