### PR TITLE
Pass opaque Rust types to C++ and back (separate crates)

### DIFF
--- a/smessmer/Cargo.toml
+++ b/smessmer/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "smessmer"
+version = "0.0.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+cxx = "1.0"
+
+[build-dependencies]
+cxx-build = "1.0"
+
+[workspace]

--- a/smessmer/build.rs
+++ b/smessmer/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    cxx_build::bridges(&["src/lib.rs", "src/main.rs"])
+        .compile("smessmer");
+}

--- a/smessmer/include/roundtrip.h
+++ b/smessmer/include/roundtrip.h
@@ -1,0 +1,6 @@
+#pragma once
+#include "smessmer/src/lib.rs"
+
+inline void cppfunc(const MyCustomType& v) {
+  rustfunc(v);
+}

--- a/smessmer/src/lib.rs
+++ b/smessmer/src/lib.rs
@@ -1,0 +1,16 @@
+#[cxx::bridge]
+pub mod ffi {
+    extern "Rust" {
+        #[derive(ExternType)]
+        type MyCustomType;
+
+        fn rustfunc(v: &MyCustomType);
+    }
+}
+
+pub struct MyCustomType {}
+
+fn rustfunc(v: &MyCustomType) {
+    let _ = v;
+    println!("success");
+}

--- a/smessmer/src/main.rs
+++ b/smessmer/src/main.rs
@@ -1,0 +1,15 @@
+use smessmer::MyCustomType;
+
+#[cxx::bridge]
+mod ffi {
+    unsafe extern "C++" {
+        include!("smessmer/include/roundtrip.h");
+        type MyCustomType = smessmer::MyCustomType;
+        fn cppfunc(v: &MyCustomType);
+    }
+}
+
+fn main() {
+    let v = MyCustomType {};
+    ffi::cppfunc(&v);
+}


### PR DESCRIPTION
#802.

<pre>
<i>cxx</i>$  <b>git fetch origin refs/pull/804/head</b>
<i>cxx</i>$  <b>git checkout FETCH_HEAD</b>
<i>cxx</i>$  <b>cd smessmer/</b>
<i>cxx/smessmer</i>$  <b>cargo run</b>
   Compiling smessmer v0.0.0
    Finished dev [unoptimized + debuginfo] target(s) in 2.06s
     Running `target/debug/smessmer`
success
</pre>