### PR TITLE
Fill in angle brackets with appropriate span if elided from impl key

### DIFF
--- a/macro/src/generics.rs
+++ b/macro/src/generics.rs
@@ -3,6 +3,7 @@ use crate::syntax::resolve::Resolution;
 use crate::syntax::Impl;
 use proc_macro2::TokenStream;
 use quote::ToTokens;
+use syn::Token;
 
 pub struct ImplGenerics<'a> {
     explicit_impl: Option<&'a Impl>,
@@ -46,10 +47,17 @@ impl<'a> ToTokens for TyGenerics<'a> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         if let Some(imp) = self.explicit_impl {
             imp.ty_generics.to_tokens(tokens);
-        } else {
-            self.key.lt_token.to_tokens(tokens);
+        } else if !self.resolve.generics.lifetimes.is_empty() {
+            let span = self.key.rust.span();
+            self.key
+                .lt_token
+                .unwrap_or_else(|| Token![<](span))
+                .to_tokens(tokens);
             self.resolve.generics.lifetimes.to_tokens(tokens);
-            self.key.gt_token.to_tokens(tokens);
+            self.key
+                .gt_token
+                .unwrap_or_else(|| Token![>](span))
+                .to_tokens(tokens);
         }
     }
 }

--- a/tests/ui/expected_named.rs
+++ b/tests/ui/expected_named.rs
@@ -1,0 +1,9 @@
+#[cxx::bridge]
+mod ffi {
+    unsafe extern "C++" {
+        type Borrowed<'a>;
+        fn borrowed() -> UniquePtr<Borrowed>;
+    }
+}
+
+fn main() {}

--- a/tests/ui/expected_named.stderr
+++ b/tests/ui/expected_named.stderr
@@ -1,7 +1,11 @@
-error: expected one of `!`, `(`, `+`, `::`, `<`, `where`, or `{`, found `'a`
- --> $DIR/expected_named.rs:4:23
+error[E0106]: missing lifetime specifier
+ --> $DIR/expected_named.rs:5:36
   |
-4 |         type Borrowed<'a>;
-  |                       ^^ unexpected token
 5 |         fn borrowed() -> UniquePtr<Borrowed>;
-  |                                            - expected one of 7 possible tokens
+  |                                    ^^^^^^^^ expected named lifetime parameter
+  |
+  = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
+help: consider using the `'static` lifetime
+  |
+5 |         fn borrowed() -> UniquePtr<Borrowed<'static>>;
+  |                                    ^^^^^^^^^^^^^^^^^

--- a/tests/ui/expected_named.stderr
+++ b/tests/ui/expected_named.stderr
@@ -1,0 +1,7 @@
+error: expected one of `!`, `(`, `+`, `::`, `<`, `where`, or `{`, found `'a`
+ --> $DIR/expected_named.rs:4:23
+  |
+4 |         type Borrowed<'a>;
+  |                       ^^ unexpected token
+5 |         fn borrowed() -> UniquePtr<Borrowed>;
+  |                                            - expected one of 7 possible tokens


### PR DESCRIPTION
Fixes #805.

#### Before:

```console
error: expected one of `!`, `(`, `+`, `::`, `<`, `where`, or `{`, found `'a`
 --> $DIR/expected_named.rs:4:23
  |
4 |         type Borrowed<'a>;
  |                       ^^ unexpected token
5 |         fn borrowed() -> UniquePtr<Borrowed>;
  |                                            - expected one of 7 possible tokens
```

#### After:

```console
error[E0106]: missing lifetime specifier
 --> $DIR/expected_named.rs:5:36
  |
5 |         fn borrowed() -> UniquePtr<Borrowed>;
  |                                    ^^^^^^^^ expected named lifetime parameter
  |
  = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
help: consider using the `'static` lifetime
  |
5 |         fn borrowed() -> UniquePtr<Borrowed<'static>>;
  |                                    ^^^^^^^^^^^^^^^^^

```