### PR TITLE
Diagnostic for invalid use of 'static as a lifetime parameter name

### DIFF
--- a/gen/src/check.rs
+++ b/gen/src/check.rs
@@ -4,7 +4,7 @@ use crate::syntax::{error, Api};
 use quote::{quote, quote_spanned};
 use std::path::{Component, Path};
 
-pub(super) use crate::syntax::check::typecheck;
+pub(super) use crate::syntax::check::{typecheck, Generator};
 
 pub(super) fn precheck(cx: &mut Errors, apis: &[Api], opt: &Opt) {
     if !opt.allow_dot_includes {

--- a/gen/src/mod.rs
+++ b/gen/src/mod.rs
@@ -130,7 +130,8 @@ pub(super) fn generate(syntax: File, opt: &Opt) -> Result<GeneratedCode> {
     let ref types = Types::collect(errors, apis);
     check::precheck(errors, apis, opt);
     errors.propagate()?;
-    check::typecheck(errors, apis, types);
+    let generator = check::Generator::Build;
+    check::typecheck(errors, apis, types, generator);
     errors.propagate()?;
 
     // Some callers may wish to generate both header and implementation from the

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -35,7 +35,8 @@ pub fn bridge(mut ffi: Module) -> Result<TokenStream> {
     let ref apis = syntax::parse_items(errors, content, trusted, namespace);
     let ref types = Types::collect(errors, apis);
     errors.propagate()?;
-    check::typecheck(errors, apis, types);
+    let generator = check::Generator::Macro;
+    check::typecheck(errors, apis, types, generator);
     errors.propagate()?;
 
     Ok(expand(ffi, doc, attrs, apis, types))

--- a/syntax/error.rs
+++ b/syntax/error.rs
@@ -21,6 +21,7 @@ pub static ERRORS: &[Error] = &[
     DISCRIMINANT_OVERFLOW,
     DOT_INCLUDE,
     DOUBLE_UNDERSCORE,
+    RESERVED_LIFETIME,
     RUST_TYPE_BY_VALUE,
     UNSUPPORTED_TYPE,
     USE_NOT_ALLOWED,
@@ -66,6 +67,12 @@ pub static DOUBLE_UNDERSCORE: Error = Error {
     msg: "identifiers containing double underscore are reserved in C++",
     label: Some("reserved identifier"),
     note: Some("identifiers containing double underscore are reserved in C++"),
+};
+
+pub static RESERVED_LIFETIME: Error = Error {
+    msg: "invalid lifetime parameter name: `'static`",
+    label: Some("'static is a reserved lifetime name"),
+    note: None,
 };
 
 pub static RUST_TYPE_BY_VALUE: Error = Error {

--- a/tests/ui/reserved_lifetime.rs
+++ b/tests/ui/reserved_lifetime.rs
@@ -1,0 +1,10 @@
+#[cxx::bridge]
+mod ffi {
+    unsafe extern "C++" {
+        type Logger;
+
+        fn logger<'static>() -> Pin<&'static Logger>;
+    }
+}
+
+fn main() {}

--- a/tests/ui/reserved_lifetime.stderr
+++ b/tests/ui/reserved_lifetime.stderr
@@ -1,0 +1,5 @@
+error[E0262]: invalid lifetime parameter name: `'static`
+ --> $DIR/reserved_lifetime.rs:6:19
+  |
+6 |         fn logger<'static>() -> Pin<&'static Logger>;
+  |                   ^^^^^^^ 'static is a reserved lifetime name


### PR DESCRIPTION
Closes #811.