### PR TITLE
Fix rust::Fn call with non-const reference argument

### DIFF
--- a/include/cxx.h
+++ b/include/cxx.h
@@ -475,7 +475,7 @@ void panic [[noreturn]] (const char *msg);
 #define CXXBRIDGE1_RUST_FN
 template <typename Ret, typename... Args>
 Ret Fn<Ret(Args...)>::operator()(Args... args) const noexcept {
-  return (*this->trampoline)(std::move(args)..., this->fn);
+  return (*this->trampoline)(std::forward<Args>(args)..., this->fn);
 }
 
 template <typename Ret, typename... Args>

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -157,6 +157,8 @@ pub mod ffi {
         fn c_take_ref_rust_vec_copy(v: &Vec<u8>);
         fn c_take_ref_shared_string(s: &SharedString) -> &SharedString;
         fn c_take_callback(callback: fn(String) -> usize);
+        fn c_take_callback_ref(callback: fn(&String));
+        fn c_take_callback_mut(callback: fn(&mut String));
         fn c_take_enum(e: Enum);
         fn c_take_ns_enum(e: AEnum);
         fn c_take_nested_ns_enum(e: ABEnum);

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -494,6 +494,16 @@ void c_take_callback(rust::Fn<size_t(rust::String)> callback) {
   callback("2020");
 }
 
+void c_take_callback_ref(rust::Fn<void(const rust::String &)> callback) {
+  const rust::String string = "2020";
+  callback(string);
+}
+
+void c_take_callback_mut(rust::Fn<void(rust::String &)> callback) {
+  rust::String string = "2020";
+  callback(string);
+}
+
 void c_take_enum(Enum e) {
   if (e == Enum::AVal) {
     cxx_test_suite_set_correct();

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -160,6 +160,8 @@ void c_take_ref_rust_vec_index(const rust::Vec<uint8_t> &v);
 void c_take_ref_rust_vec_copy(const rust::Vec<uint8_t> &v);
 const SharedString &c_take_ref_shared_string(const SharedString &s);
 void c_take_callback(rust::Fn<size_t(rust::String)> callback);
+void c_take_callback_ref(rust::Fn<void(const rust::String &)> callback);
+void c_take_callback_mut(rust::Fn<void(rust::String &)> callback);
 void c_take_enum(Enum e);
 void c_take_ns_enum(::A::AEnum e);
 void c_take_nested_ns_enum(::A::B::ABEnum e);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -204,7 +204,21 @@ fn test_c_callback() {
         0
     }
 
+    fn callback_ref(s: &String) {
+        if s == "2020" {
+            cxx_test_suite_set_correct();
+        }
+    }
+
+    fn callback_mut(s: &mut String) {
+        if s == "2020" {
+            cxx_test_suite_set_correct();
+        }
+    }
+
     check!(ffi::c_take_callback(callback));
+    check!(ffi::c_take_callback_ref(callback_ref));
+    check!(ffi::c_take_callback_mut(callback_mut));
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -204,6 +204,7 @@ fn test_c_callback() {
         0
     }
 
+    #[allow(clippy::ptr_arg)]
     fn callback_ref(s: &String) {
         if s == "2020" {
             cxx_test_suite_set_correct();


### PR DESCRIPTION
Fixes #738.