### PR TITLE
Deny improper_ctypes_definitions in generated code

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -131,7 +131,7 @@ fn expand(ffi: Module, doc: Doc, attrs: OtherAttrs, apis: &[Api], types: &Types)
     quote! {
         #doc
         #attrs
-        #[deny(improper_ctypes)]
+        #[deny(improper_ctypes, improper_ctypes_definitions)]
         #[allow(non_camel_case_types, non_snake_case, clippy::upper_case_acronyms)]
         #vis #mod_token #ident #expanded
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,7 +365,7 @@
 
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/cxx/1.0.42")]
-#![deny(improper_ctypes)]
+#![deny(improper_ctypes, improper_ctypes_definitions)]
 #![allow(non_camel_case_types)]
 #![allow(
     clippy::cognitive_complexity,


### PR DESCRIPTION
This warning is mostly equivalent to `improper_ctypes` but applies to function definitions as opposed to declarations.

```rust
extern "C" {
    // improper_ctypes
    pub fn c(_s: &str);
}

// improper_ctypes_definitions
pub extern "C" fn r(_s: &str) {}
```

```console
warning: `extern` block uses type `str`, which is not FFI-safe
 --> src/lib.rs:3:18
  |
3 |     pub fn c(_s: &str);
  |                  ^^^^ not FFI-safe
  |
  = note: `#[warn(improper_ctypes)]` on by default
  = help: consider using `*const u8` and a length instead
  = note: string slices have no C equivalent

warning: `extern` fn uses type `str`, which is not FFI-safe
 --> src/lib.rs:7:25
  |
7 | pub extern "C" fn r(_s: &str) {}
  |                         ^^^^ not FFI-safe
  |
  = note: `#[warn(improper_ctypes_definitions)]` on by default
  = help: consider using `*const u8` and a length instead
  = note: string slices have no C equivalent
```