### PR TITLE
Prevent emitting const const on C++ codegen when using a Slice with a reference

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1207,17 +1207,15 @@ fn write_type(out: &mut OutFile, ty: &Type) {
             if slice.mutability.is_none() {
                 match slice.inner {
                     Type::Ref(_) => {
-                        write_type(out, &slice.inner);
-                        write!(out, "const");
+                        write!(out, "");
                     }
                     _ => {
                         write!(out, "const ");
                         write_type(out, &slice.inner);
                     }
                 }
-            } else {
-                write_type(out, &slice.inner);
             }
+            write_type(out, &slice.inner);
             write!(out, ">");
         }
         Type::Fn(f) => {

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1208,7 +1208,7 @@ fn write_type(out: &mut OutFile, ty: &Type) {
                 match slice.inner {
                     Type::Ref(_) => {
                         write_type(out, &slice.inner);
-                        write!(out, "const")
+                        write!(out, "const");
                     }
                     _ => {
                         write!(out, "const ");

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1205,7 +1205,14 @@ fn write_type(out: &mut OutFile, ty: &Type) {
         Type::SliceRef(slice) => {
             write!(out, "::rust::Slice<");
             if slice.mutability.is_none() {
-                write!(out, "const ");
+                match slice.inner {
+                    Type::Ref(_) => {
+                        write!(out, "");
+                    }
+                    _ => {
+                        write!(out, "const ");
+                    }
+                }
             }
             write_type(out, &slice.inner);
             write!(out, ">");

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1207,14 +1207,17 @@ fn write_type(out: &mut OutFile, ty: &Type) {
             if slice.mutability.is_none() {
                 match slice.inner {
                     Type::Ref(_) => {
-                        write!(out, "");
+                        write_type(out, &slice.inner);
+                        write!(out, "const")
                     }
                     _ => {
                         write!(out, "const ");
+                        write_type(out, &slice.inner);
                     }
                 }
+            } else {
+                write_type(out, &slice.inner);
             }
-            write_type(out, &slice.inner);
             write!(out, ">");
         }
         Type::Fn(f) => {

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -167,7 +167,7 @@ public:
   std::size_t length() const noexcept;
   bool empty() const noexcept;
 
-  T &operator[](std::size_t n) const noexcept;
+  typename std::add_lvalue_reference<T>::type operator[](std::size_t n) const noexcept;
   T &at(std::size_t n) const;
   T &front() const noexcept;
   T &back() const noexcept;


### PR DESCRIPTION
Fixes https://github.com/dtolnay/cxx/issues/830