### PR TITLE
Add impls for dropping RustString/RustVec ffi wrappers

### DIFF
--- a/src/rust_string.rs
+++ b/src/rust_string.rs
@@ -1,5 +1,6 @@
 use alloc::string::String;
 use core::mem::{self, MaybeUninit};
+use core::ptr;
 
 // ABI compatible with C++ rust::String (not necessarily alloc::string::String).
 #[repr(C)]
@@ -30,6 +31,12 @@ impl RustString {
 
     pub fn as_mut_string(&mut self) -> &mut String {
         unsafe { &mut *(self as *mut RustString as *mut String) }
+    }
+}
+
+impl Drop for RustString {
+    fn drop(&mut self) {
+        unsafe { ptr::drop_in_place(self.as_mut_string()) }
     }
 }
 

--- a/src/rust_vec.rs
+++ b/src/rust_vec.rs
@@ -4,6 +4,7 @@ use alloc::vec::Vec;
 use core::ffi::c_void;
 use core::marker::PhantomData;
 use core::mem::{self, ManuallyDrop, MaybeUninit};
+use core::ptr;
 
 // ABI compatible with C++ rust::Vec<T> (not necessarily alloc::vec::Vec<T>).
 #[repr(C)]
@@ -97,5 +98,11 @@ impl RustVec<RustString> {
 
     pub fn as_mut_vec_string(&mut self) -> &mut Vec<String> {
         unsafe { &mut *(self as *mut RustVec<RustString> as *mut Vec<String>) }
+    }
+}
+
+impl<T> Drop for RustVec<T> {
+    fn drop(&mut self) {
+        unsafe { ptr::drop_in_place(self.as_mut_vec()) }
     }
 }


### PR DESCRIPTION
This restores the `Drop` behavior prior to #821 for both types. I don't think either of these drops is ever currently invoked, because we only ever manipulate `RustString` / `RustVec` by value from Rust in one of the following forms, neither of which involves running Drop. However this change is likely to prevent future confusion as we extend the API of these types.

```rust
// fn() -> Vec<T>

#[export_name = "..."]
unsafe extern "C" fn __r_return_rust_vec(__return: *mut ::cxx::private::RustVec<u8>) {
    fn __r_return_rust_vec() -> ::std::vec::Vec<u8> {...}
    ::cxx::private::catch_unwind(__fn, move || {
        ::std::ptr::write(
            __return,
            ::cxx::private::RustVec::from(__r_return_rust_vec()),
        )
    })
}
```

```rust
// fn(Vec<T>)

#[export_name = "..."]
unsafe extern "C" fn __r_take_rust_vec(v: *mut ::cxx::private::RustVec<u8>) {
    fn __r_take_rust_vec(v: ::std::vec::Vec<u8>) {...}
    ::cxx::private::catch_unwind(__fn, move || {
        __r_take_rust_vec(::std::mem::take((*v).as_mut_vec()))
    })
}
```