### PR TITLE
Make FatFunction private contents into proper ctype

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -773,9 +773,9 @@ fn expand_function_pointer_trampoline(
                     fn trampoline();
                 }
                 #shim
-                trampoline as usize as *const ()
+                trampoline as usize as *const ::std::ffi::c_void
             },
-            ptr: #var as usize as *const (),
+            ptr: #var as usize as *const ::std::ffi::c_void,
         };
     }
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,5 +1,7 @@
+use core::ffi::c_void;
+
 #[repr(C)]
 pub struct FatFunction {
-    pub trampoline: *const (),
-    pub ptr: *const (),
+    pub trampoline: *const c_void,
+    pub ptr: *const c_void,
 }


### PR DESCRIPTION
Part of #744.

Without this, it's possible for the macro-expanded code to trigger improper_ctypes lints.

```console
error: `extern` block uses type `()`, which is not FFI-safe
    --> tests/ffi/lib.rs:2577:44
     |
2577 |             fn __c_take_callback(callback: ::cxx::private::FatFunction);
     |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
     |
note: the lint level is defined here
    --> tests/ffi/lib.rs:1439:8
     |
1439 | #[deny(improper_ctypes, improper_ctypes_definitions)]
     |        ^^^^^^^^^^^^^^^
     = help: consider using a struct instead
     = note: tuples have unspecified layout
```