### PR TITLE
Add CxxVector::pop in Rust

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1833,6 +1833,7 @@ fn write_cxx_vector(out: &mut OutFile, key: NamedImplKey) {
     );
     writeln!(out, "  return s.size();");
     writeln!(out, "}}");
+
     writeln!(
         out,
         "{} *cxxbridge1$std$vector${}$get_unchecked(::std::vector<{}> *s, ::std::size_t pos) noexcept {{",
@@ -1840,6 +1841,7 @@ fn write_cxx_vector(out: &mut OutFile, key: NamedImplKey) {
     );
     writeln!(out, "  return &(*s)[pos];");
     writeln!(out, "}}");
+
     if out.types.is_maybe_trivial(element) {
         writeln!(
             out,
@@ -1848,6 +1850,15 @@ fn write_cxx_vector(out: &mut OutFile, key: NamedImplKey) {
         );
         writeln!(out, "  v->push_back(::std::move(*value));");
         writeln!(out, "  ::rust::destroy(value);");
+        writeln!(out, "}}");
+
+        writeln!(
+            out,
+            "void cxxbridge1$std$vector${}$pop_back(::std::vector<{}> *v, {} *out) noexcept {{",
+            instance, inner, inner,
+        );
+        writeln!(out, "  ::new (out) {}(::std::move(v->back()));", inner);
+        writeln!(out, "  v->pop_back();");
         writeln!(out, "}}");
     }
 

--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -503,6 +503,11 @@ static_assert(sizeof(std::string) <= kMaxExpectedWordsInString * sizeof(void *),
       std::vector<CXX_TYPE> *v, CXX_TYPE *value) noexcept {                    \
     v->push_back(std::move(*value));                                           \
     destroy(value);                                                            \
+  }                                                                            \
+  void cxxbridge1$std$vector$##RUST_TYPE##$pop_back(std::vector<CXX_TYPE> *v,  \
+                                                    CXX_TYPE *out) noexcept {  \
+    new (out) CXX_TYPE(std::move(v->back()));                                  \
+    v->pop_back();                                                             \
   }
 
 #define RUST_VEC_EXTERNS(RUST_TYPE, CXX_TYPE)                                  \

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -336,7 +336,7 @@ void c_take_unique_ptr_string(std::unique_ptr<std::string> s) {
 }
 
 void c_take_unique_ptr_vector_u8(std::unique_ptr<std::vector<uint8_t>> v) {
-  if (v->size() == 4) {
+  if (v->size() == 3) {
     cxx_test_suite_set_correct();
   }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -150,9 +150,9 @@ fn test_c_take() {
     check!(ffi::c_take_unique_ptr_string(
         ffi::c_return_unique_ptr_string()
     ));
-    check!(ffi::c_take_unique_ptr_vector_u8(
-        ffi::c_return_unique_ptr_vector_u8()
-    ));
+    let mut vector = ffi::c_return_unique_ptr_vector_u8();
+    assert_eq!(vector.pin_mut().pop(), Some(9));
+    check!(ffi::c_take_unique_ptr_vector_u8(vector));
     let mut vector = ffi::c_return_unique_ptr_vector_f64();
     vector.pin_mut().push(9.0);
     check!(ffi::c_take_unique_ptr_vector_f64(vector));


### PR DESCRIPTION
Closes #838 (originally #778). 