### PR TITLE
deny(missing_docs) at crate root

### DIFF
--- a/src/cxx_string.rs
+++ b/src/cxx_string.rs
@@ -213,6 +213,7 @@ pub struct StackString {
     space: MaybeUninit<[usize; 8]>,
 }
 
+#[allow(missing_docs)]
 impl StackString {
     pub fn new() -> Self {
         StackString {

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -16,6 +16,7 @@ impl Display for Exception {
 impl std::error::Error for Exception {}
 
 impl Exception {
+    #[allow(missing_docs)]
     pub fn what(&self) -> &str {
         &self.what
     }

--- a/src/extern_type.rs
+++ b/src/extern_type.rs
@@ -167,6 +167,7 @@ pub mod kind {
     /// indirection.
     pub enum Trivial {}
 
+    #[allow(missing_docs)]
     pub trait Kind: private::Sealed {}
     impl Kind for Opaque {}
     impl Kind for Trivial {}

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use core::ffi::c_void;
 
 #[repr(C)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,7 +365,7 @@
 
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/cxx/1.0.45")]
-#![deny(improper_ctypes, improper_ctypes_definitions)]
+#![deny(improper_ctypes, improper_ctypes_definitions, missing_docs)]
 #![allow(non_camel_case_types)]
 #![allow(
     clippy::cognitive_complexity,

--- a/src/opaque.rs
+++ b/src/opaque.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use core::marker::{PhantomData, PhantomPinned};
 use core::mem;
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use crate::exception::Exception;
 use alloc::boxed::Box;
 use alloc::string::{String, ToString};

--- a/src/rust_slice.rs
+++ b/src/rust_slice.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use core::mem::{self, MaybeUninit};
 use core::ptr::{self, NonNull};
 use core::slice;

--- a/src/rust_str.rs
+++ b/src/rust_str.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use core::mem::{self, MaybeUninit};
 use core::ptr::NonNull;
 use core::str;

--- a/src/rust_string.rs
+++ b/src/rust_string.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use alloc::string::String;
 use core::mem::{self, MaybeUninit};
 use core::ptr;

--- a/src/rust_type.rs
+++ b/src/rust_type.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 pub unsafe trait RustType {}
 pub unsafe trait ImplBox {}
 pub unsafe trait ImplVec {}

--- a/src/rust_vec.rs
+++ b/src/rust_vec.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use crate::rust_string::RustString;
 use alloc::string::String;
 use alloc::vec::Vec;

--- a/src/unwind.rs
+++ b/src/unwind.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use std::io::{self, Write};
 use std::panic::{self, AssertUnwindSafe};
 use std::process;

--- a/src/weak_ptr.rs
+++ b/src/weak_ptr.rs
@@ -93,6 +93,7 @@ where
 
 // Methods are private; not intended to be implemented outside of cxxbridge
 // codebase.
+#[allow(missing_docs)]
 pub unsafe trait WeakPtrTarget {
     #[doc(hidden)]
     fn __typename(f: &mut fmt::Formatter) -> fmt::Result;


### PR DESCRIPTION
To help flag missing documentation on publicly accessible APIs.