### PR TITLE
Avoid warning on unknown upper_case_acronyms lint on old clippys

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -132,6 +132,7 @@ fn expand(ffi: Module, doc: Doc, attrs: OtherAttrs, apis: &[Api], types: &Types)
         #doc
         #attrs
         #[deny(improper_ctypes, improper_ctypes_definitions)]
+        #[allow(clippy::unknown_clippy_lints)]
         #[allow(non_camel_case_types, non_snake_case, clippy::upper_case_acronyms)]
         #vis #mod_token #ident #expanded
     }


### PR DESCRIPTION
The `clippy::upper_case_acronyms` lint is newly introduced in the Clippy that shipped with rustc 1.51.0. When building CXX-generated Rust code with a toolchain older than 1.51.0, this PR avoids a `clippy::unknown_clippy_lints` warning in the generated code.

```console
warning: unknown clippy lint: clippy::upper_case_acronyms
 --> path/to/bridge.rs:7:1
  |
7 | #[cxx::bridge]
  | ^^^^^^^^^^^^^^
  |
  = note: `#[warn(clippy::unknown_clippy_lints)]` on by default
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unknown_clippy_lints
  = note: this warning originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
```