### PR TITLE
Experimental support for enum variant names and discriminant values retrieved from C++

### DIFF
--- a/gen/build/Cargo.toml
+++ b/gen/build/Cargo.toml
@@ -21,7 +21,7 @@ lazy_static = "1.4"
 proc-macro2 = { version = "1.0.26", default-features = false, features = ["span-locations"] }
 quote = { version = "1.0", default-features = false }
 scratch = "1.0"
-syn = { version = "1.0.68", default-features = false, features = ["parsing", "printing", "clone-impls", "full"] }
+syn = { version = "1.0.70", default-features = false, features = ["parsing", "printing", "clone-impls", "full"] }
 
 [dev-dependencies]
 cxx-gen = { version = "0.7", path = "../lib" }

--- a/gen/cmd/Cargo.toml
+++ b/gen/cmd/Cargo.toml
@@ -20,7 +20,7 @@ clap = "2.33"
 codespan-reporting = "0.11"
 proc-macro2 = { version = "1.0.26", default-features = false, features = ["span-locations"] }
 quote = { version = "1.0", default-features = false }
-syn = { version = "1.0.68", default-features = false, features = ["parsing", "printing", "clone-impls", "full"] }
+syn = { version = "1.0.70", default-features = false, features = ["parsing", "printing", "clone-impls", "full"] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/gen/lib/Cargo.toml
+++ b/gen/lib/Cargo.toml
@@ -15,7 +15,7 @@ cc = "1.0.49"
 codespan-reporting = "0.11"
 proc-macro2 = { version = "1.0.26", default-features = false, features = ["span-locations"] }
 quote = { version = "1.0", default-features = false }
-syn = { version = "1.0.68", default-features = false, features = ["parsing", "printing", "clone-impls", "full"] }
+syn = { version = "1.0.70", default-features = false, features = ["parsing", "printing", "clone-impls", "full"] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -9,8 +9,8 @@ use crate::syntax::set::UnorderedSet;
 use crate::syntax::symbol::Symbol;
 use crate::syntax::trivial::{self, TrivialReason};
 use crate::syntax::{
-    derive, mangle, Api, Doc, Enum, ExternFn, ExternType, Pair, Signature, Struct, Trait, Type,
-    TypeAlias, Types, Var,
+    derive, mangle, Api, Doc, Enum, EnumRepr, ExternFn, ExternType, Pair, Signature, Struct, Trait,
+    Type, TypeAlias, Types, Var,
 };
 use proc_macro2::Ident;
 
@@ -317,8 +317,12 @@ fn write_struct_decl(out: &mut OutFile, ident: &Pair) {
 }
 
 fn write_enum_decl(out: &mut OutFile, enm: &Enum) {
+    let repr = match &enm.repr {
+        EnumRepr::Foreign { .. } => return,
+        EnumRepr::Native { atom, .. } => *atom,
+    };
     write!(out, "enum class {} : ", enm.name.cxx);
-    write_atom(out, enm.repr);
+    write_atom(out, repr);
     writeln!(out, ";");
 }
 
@@ -376,6 +380,10 @@ fn write_opaque_type<'a>(out: &mut OutFile<'a>, ety: &'a ExternType, methods: &[
 }
 
 fn write_enum<'a>(out: &mut OutFile<'a>, enm: &'a Enum) {
+    let repr = match &enm.repr {
+        EnumRepr::Foreign { .. } => return,
+        EnumRepr::Native { atom, .. } => *atom,
+    };
     out.set_namespace(&enm.name.namespace);
     let guard = format!("CXXBRIDGE1_ENUM_{}", enm.name.to_symbol());
     writeln!(out, "#ifndef {}", guard);
@@ -384,7 +392,7 @@ fn write_enum<'a>(out: &mut OutFile<'a>, enm: &'a Enum) {
         writeln!(out, "//{}", line);
     }
     write!(out, "enum class {} : ", enm.name.cxx);
-    write_atom(out, enm.repr);
+    write_atom(out, repr);
     writeln!(out, " {{");
     for variant in &enm.variants {
         for line in variant.doc.to_string().lines() {
@@ -397,6 +405,10 @@ fn write_enum<'a>(out: &mut OutFile<'a>, enm: &'a Enum) {
 }
 
 fn check_enum<'a>(out: &mut OutFile<'a>, enm: &'a Enum) {
+    let repr = match &enm.repr {
+        EnumRepr::Foreign { .. } => return,
+        EnumRepr::Native { atom, .. } => *atom,
+    };
     out.set_namespace(&enm.name.namespace);
     out.include.type_traits = true;
     writeln!(
@@ -405,11 +417,11 @@ fn check_enum<'a>(out: &mut OutFile<'a>, enm: &'a Enum) {
         enm.name.cxx,
     );
     write!(out, "static_assert(sizeof({}) == sizeof(", enm.name.cxx);
-    write_atom(out, enm.repr);
+    write_atom(out, repr);
     writeln!(out, "), \"incorrect size\");");
     for variant in &enm.variants {
         write!(out, "static_assert(static_cast<");
-        write_atom(out, enm.repr);
+        write_atom(out, repr);
         writeln!(
             out,
             ">({}::{}) == {}, \"disagrees with the value in #[cxx::bridge]\");",

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -101,10 +101,10 @@ fn write_data_structures<'a>(out: &mut OutFile<'a>, apis: &'a [Api]) {
             }
             Api::Enum(enm) => {
                 out.next_section();
-                if out.types.cxx.contains(&enm.name.rust) {
-                    check_enum(out, enm);
-                } else {
+                if !out.types.cxx.contains(&enm.name.rust) {
                     write_enum(out, enm);
+                } else if !enm.variants_from_header {
+                    check_enum(out, enm);
                 }
             }
             Api::RustType(ety) => {

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -20,7 +20,7 @@ experimental = ["clang-ast", "serde", "serde_json"]
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0.4"
-syn = { version = "1.0.68", features = ["full"] }
+syn = { version = "1.0.70", features = ["full"] }
 
 # optional dependencies
 clang-ast = { version = "0.1", optional = true }

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -14,10 +14,18 @@ categories = ["development-tools::ffi"]
 [lib]
 proc-macro = true
 
+[features]
+experimental = ["clang-ast", "serde", "serde_json"]
+
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0.4"
 syn = { version = "1.0.68", features = ["full"] }
+
+# optional dependencies
+clang-ast = { version = "0.1", optional = true }
+serde = { version = "1.0", optional = true, features = ["derive"] }
+serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
 cxx = { version = "1.0", path = ".." }

--- a/macro/src/clang.rs
+++ b/macro/src/clang.rs
@@ -79,6 +79,19 @@ pub fn load(cx: &mut Errors, apis: &mut [Api]) {
 
     let ref mut namespace = Vec::new();
     traverse(root, namespace, variants_from_header, None);
+
+    for enm in variants_from_header {
+        if enm.variants.is_empty() {
+            let span = &enm.variants_from_header_attr;
+            let mut msg = "failed to find any C++ definition of enum ".to_owned();
+            for name in &enm.name.namespace {
+                msg += &name.to_string();
+                msg += "::";
+            }
+            msg += &enm.name.cxx.to_string();
+            cx.error(span, msg);
+        }
+    }
 }
 
 fn traverse<'a>(

--- a/macro/src/clang.rs
+++ b/macro/src/clang.rs
@@ -10,7 +10,19 @@ enum Clang {
 }
 
 pub fn load(cx: &mut Errors, apis: &mut [Api]) {
+    let mut variants_from_header = Vec::new();
+    for api in apis {
+        if let Api::Enum(enm) = api {
+            if enm.variants_from_header {
+                variants_from_header.push(enm);
+            }
+        }
+    }
+
+    if variants_from_header.is_empty() {
+        return;
+    }
+
     let _ = cx;
-    let _ = apis;
     unimplemented!()
 }

--- a/macro/src/clang.rs
+++ b/macro/src/clang.rs
@@ -1,6 +1,11 @@
 use crate::syntax::report::Errors;
 use crate::syntax::Api;
 use serde::Deserialize;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+const CXX_CLANG_AST: &str = "CXX_CLANG_AST";
 
 type Node = clang_ast::Node<Clang>;
 
@@ -19,10 +24,37 @@ pub fn load(cx: &mut Errors, apis: &mut [Api]) {
         }
     }
 
-    if variants_from_header.is_empty() {
-        return;
-    }
+    let span = match variants_from_header.get(0) {
+        None => return,
+        Some(enm) => enm.variants_from_header_attr.clone().unwrap(),
+    };
 
-    let _ = cx;
+    let ast_dump_path = match env::var_os(CXX_CLANG_AST) {
+        Some(ast_dump_path) => PathBuf::from(ast_dump_path),
+        None => {
+            let msg = format!(
+                "environment variable ${} has not been provided",
+                CXX_CLANG_AST,
+            );
+            return cx.error(span, msg);
+        }
+    };
+
+    let ast_dump_bytes = match fs::read(&ast_dump_path) {
+        Ok(ast_dump_bytes) => ast_dump_bytes,
+        Err(error) => {
+            let msg = format!("failed to read {}: {}", ast_dump_path.display(), error);
+            return cx.error(span, msg);
+        }
+    };
+
+    let root: Node = match serde_json::from_slice(&ast_dump_bytes) {
+        Ok(root) => root,
+        Err(error) => {
+            let msg = format!("failed to read {}: {}", ast_dump_path.display(), error);
+            return cx.error(span, msg);
+        }
+    };
+
     unimplemented!()
 }

--- a/macro/src/clang.rs
+++ b/macro/src/clang.rs
@@ -1,0 +1,16 @@
+use crate::syntax::report::Errors;
+use crate::syntax::Api;
+use serde::Deserialize;
+
+type Node = clang_ast::Node<Clang>;
+
+#[derive(Deserialize)]
+enum Clang {
+    Unknown,
+}
+
+pub fn load(cx: &mut Errors, apis: &mut [Api]) {
+    let _ = cx;
+    let _ = apis;
+    unimplemented!()
+}

--- a/macro/src/clang.rs
+++ b/macro/src/clang.rs
@@ -136,8 +136,20 @@ fn traverse<'a>(
             idx = None;
             for (i, enm) in variants_from_header.iter().enumerate() {
                 if enm.name.cxx == **name && enm.name.namespace.iter().eq(&*namespace) {
-                    idx = Some(i);
-                    break;
+                    if enm.variants.is_empty() {
+                        idx = Some(i);
+                        break;
+                    } else {
+                        let span = &enm.variants_from_header_attr;
+                        let mut msg = "found multiple C++ definitions of enum ".to_owned();
+                        for name in &enm.name.namespace {
+                            msg += &name.to_string();
+                            msg += "::";
+                        }
+                        msg += &enm.name.cxx.to_string();
+                        cx.error(span, msg);
+                        return;
+                    }
                 }
             }
             if idx.is_none() {

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -32,9 +32,12 @@ pub fn bridge(mut ffi: Module) -> Result<TokenStream> {
     let content = mem::take(&mut ffi.content);
     let trusted = ffi.unsafety.is_some();
     let namespace = &ffi.namespace;
-    let ref apis = syntax::parse_items(errors, content, trusted, namespace);
+    let ref mut apis = syntax::parse_items(errors, content, trusted, namespace);
+    #[cfg(feature = "experimental")]
+    crate::clang::load(errors, apis);
     let ref types = Types::collect(errors, apis);
     errors.propagate()?;
+
     let generator = check::Generator::Macro;
     check::typecheck(errors, apis, types, generator);
     errors.propagate()?;

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -293,7 +293,7 @@ fn expand_enum(enm: &Enum) -> TokenStream {
     let ident = &enm.name.rust;
     let doc = &enm.doc;
     let attrs = &enm.attrs;
-    let repr = enm.repr;
+    let repr = &enm.repr;
     let type_id = type_id(&enm.name);
     let variants = enm.variants.iter().map(|variant| {
         let doc = &variant.doc;

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -36,6 +36,9 @@ mod generics;
 mod syntax;
 mod type_id;
 
+#[cfg(feature = "experimental")]
+mod clang;
+
 use crate::syntax::file::Module;
 use crate::syntax::namespace::Namespace;
 use crate::syntax::qualified::QualifiedName;

--- a/syntax/attrs.rs
+++ b/syntax/attrs.rs
@@ -5,7 +5,7 @@ use crate::syntax::{Derive, Doc, ForeignName};
 use proc_macro2::{Ident, TokenStream};
 use quote::ToTokens;
 use syn::parse::{Nothing, Parse, ParseStream, Parser as _};
-use syn::{AttrStyle, Attribute, Error, LitStr, Path, Result, Token};
+use syn::{Attribute, Error, LitStr, Path, Result, Token};
 
 // Intended usage:
 //
@@ -122,10 +122,7 @@ pub fn parse(cx: &mut Errors, attrs: Vec<Attribute>, mut parser: Parser) -> Othe
                     break;
                 }
             }
-        } else if attr.path.is_ident("variants_from_header")
-            && matches!(attr.style, AttrStyle::Inner(_))
-            && cfg!(feature = "experimental")
-        {
+        } else if attr.path.is_ident("variants_from_header") && cfg!(feature = "experimental") {
             if let Err(err) = Nothing::parse.parse2(attr.tokens.clone()) {
                 cx.push(err);
             }

--- a/syntax/attrs.rs
+++ b/syntax/attrs.rs
@@ -33,7 +33,7 @@ pub struct Parser<'a> {
     pub namespace: Option<&'a mut Namespace>,
     pub cxx_name: Option<&'a mut Option<ForeignName>>,
     pub rust_name: Option<&'a mut Option<Ident>>,
-    pub variants_from_header: Option<&'a mut bool>,
+    pub variants_from_header: Option<&'a mut Option<Attribute>>,
 
     // Suppress clippy needless_update lint ("struct update has no effect, all
     // the fields in the struct have already been specified") when preemptively
@@ -130,7 +130,7 @@ pub fn parse(cx: &mut Errors, attrs: Vec<Attribute>, mut parser: Parser) -> Othe
                 cx.push(err);
             }
             if let Some(variants_from_header) = &mut parser.variants_from_header {
-                **variants_from_header = true;
+                **variants_from_header = Some(attr);
                 continue;
             }
         } else if attr.path.is_ident("allow")

--- a/syntax/attrs.rs
+++ b/syntax/attrs.rs
@@ -4,8 +4,8 @@ use crate::syntax::Atom::{self, *};
 use crate::syntax::{Derive, Doc, ForeignName};
 use proc_macro2::{Ident, TokenStream};
 use quote::ToTokens;
-use syn::parse::{ParseStream, Parser as _};
-use syn::{Attribute, Error, LitStr, Path, Result, Token};
+use syn::parse::{Nothing, Parse, ParseStream, Parser as _};
+use syn::{AttrStyle, Attribute, Error, LitStr, Path, Result, Token};
 
 // Intended usage:
 //
@@ -33,6 +33,7 @@ pub struct Parser<'a> {
     pub namespace: Option<&'a mut Namespace>,
     pub cxx_name: Option<&'a mut Option<ForeignName>>,
     pub rust_name: Option<&'a mut Option<Ident>>,
+    pub variants_from_header: Option<&'a mut bool>,
 
     // Suppress clippy needless_update lint ("struct update has no effect, all
     // the fields in the struct have already been specified") when preemptively
@@ -120,6 +121,17 @@ pub fn parse(cx: &mut Errors, attrs: Vec<Attribute>, mut parser: Parser) -> Othe
                     cx.push(err);
                     break;
                 }
+            }
+        } else if attr.path.is_ident("variants_from_header")
+            && matches!(attr.style, AttrStyle::Inner(_))
+            && cfg!(feature = "experimental")
+        {
+            if let Err(err) = Nothing::parse.parse2(attr.tokens.clone()) {
+                cx.push(err);
+            }
+            if let Some(variants_from_header) = &mut parser.variants_from_header {
+                **variants_from_header = true;
+                continue;
             }
         } else if attr.path.is_ident("allow")
             || attr.path.is_ident("warn")

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -349,11 +349,19 @@ fn check_api_enum(cx: &mut Check, enm: &Enum) {
     check_reserved_name(cx, &enm.name.rust);
     check_lifetimes(cx, &enm.generics);
 
-    if enm.variants.is_empty() && !enm.explicit_repr {
+    if enm.variants.is_empty() && !enm.explicit_repr && !enm.variants_from_header {
         let span = span_for_enum_error(enm);
         cx.error(
             span,
             "explicit #[repr(...)] is required for enum without any variants",
+        );
+    }
+
+    if enm.variants_from_header && !enm.variants.is_empty() {
+        let span = span_for_enum_error(enm);
+        cx.error(
+            span,
+            "enum with #![variants_from_header] must be written with no explicit variants",
         );
     }
 

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -357,14 +357,6 @@ fn check_api_enum(cx: &mut Check, enm: &Enum) {
         );
     }
 
-    if enm.variants_from_header && !enm.variants.is_empty() {
-        let span = span_for_enum_error(enm);
-        cx.error(
-            span,
-            "enum with #![variants_from_header] must be written with no explicit variants",
-        );
-    }
-
     for derive in &enm.derives {
         if derive.what == Trait::Default || derive.what == Trait::ExternType {
             let msg = format!("derive({}) on shared enum is not supported", derive);

--- a/syntax/discriminant.rs
+++ b/syntax/discriminant.rs
@@ -150,7 +150,7 @@ fn insert(set: &mut DiscriminantSet, discriminant: Discriminant) -> Result<Discr
 }
 
 impl Discriminant {
-    const fn zero() -> Self {
+    pub const fn zero() -> Self {
         Discriminant {
             sign: Sign::Positive,
             magnitude: 0,
@@ -177,6 +177,28 @@ impl Discriminant {
             // produces 1<<63 too which happens to be the correct unsigned
             // magnitude.
             magnitude: i.wrapping_abs() as u64,
+        }
+    }
+
+    pub const fn checked_succ(self) -> Option<Self> {
+        match self.sign {
+            Sign::Negative => {
+                if self.magnitude == 1 {
+                    Some(Discriminant::zero())
+                } else {
+                    Some(Discriminant {
+                        sign: Sign::Negative,
+                        magnitude: self.magnitude - 1,
+                    })
+                }
+            }
+            Sign::Positive => match self.magnitude.checked_add(1) {
+                Some(magnitude) => Some(Discriminant {
+                    sign: Sign::Positive,
+                    magnitude,
+                }),
+                None => None,
+            },
         }
     }
 }

--- a/syntax/file.rs
+++ b/syntax/file.rs
@@ -91,17 +91,32 @@ impl Parse for Item {
 
         let item = input.parse()?;
         match item {
-            RustItem::Struct(item) => Ok(Item::Struct(ItemStruct { attrs, ..item })),
-            RustItem::Enum(item) => Ok(Item::Enum(ItemEnum { attrs, ..item })),
-            RustItem::ForeignMod(item) => Ok(Item::ForeignMod(ItemForeignMod {
-                attrs,
-                unsafety,
-                abi: item.abi,
-                brace_token: item.brace_token,
-                items: item.items,
-            })),
-            RustItem::Impl(item) => Ok(Item::Impl(ItemImpl { attrs, ..item })),
-            RustItem::Use(item) => Ok(Item::Use(ItemUse { attrs, ..item })),
+            RustItem::Struct(mut item) => {
+                item.attrs.splice(..0, attrs);
+                Ok(Item::Struct(item))
+            }
+            RustItem::Enum(mut item) => {
+                item.attrs.splice(..0, attrs);
+                Ok(Item::Enum(item))
+            }
+            RustItem::ForeignMod(mut item) => {
+                item.attrs.splice(..0, attrs);
+                Ok(Item::ForeignMod(ItemForeignMod {
+                    attrs: item.attrs,
+                    unsafety,
+                    abi: item.abi,
+                    brace_token: item.brace_token,
+                    items: item.items,
+                }))
+            }
+            RustItem::Impl(mut item) => {
+                item.attrs.splice(..0, attrs);
+                Ok(Item::Impl(item))
+            }
+            RustItem::Use(mut item) => {
+                item.attrs.splice(..0, attrs);
+                Ok(Item::Use(item))
+            }
             other => Ok(Item::Other(other)),
         }
     }

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -36,7 +36,7 @@ use self::symbol::Symbol;
 use proc_macro2::{Ident, Span};
 use syn::punctuated::Punctuated;
 use syn::token::{Brace, Bracket, Paren};
-use syn::{Attribute, Expr, Generics, Lifetime, LitInt, Token, Type as RustType};
+use syn::{Attribute, Expr, Generics, Lifetime, LitInt, Path, Token, Type as RustType};
 
 pub use self::atom::Atom;
 pub use self::derive::{Derive, Trait};
@@ -113,9 +113,13 @@ pub struct Enum {
     pub variants: Vec<Variant>,
     pub variants_from_header: bool,
     pub variants_from_header_attr: Option<Attribute>,
-    pub repr: Atom,
-    pub repr_type: Type,
+    pub repr: EnumRepr,
     pub explicit_repr: bool,
+}
+
+pub enum EnumRepr {
+    Native { atom: Atom, repr_type: Type },
+    Foreign { rust_type: Path },
 }
 
 pub struct ExternFn {

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -111,6 +111,7 @@ pub struct Enum {
     pub generics: Lifetimes,
     pub brace_token: Brace,
     pub variants: Vec<Variant>,
+    pub variants_from_header: bool,
     pub repr: Atom,
     pub repr_type: Type,
     pub explicit_repr: bool,

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -30,7 +30,6 @@ pub mod types;
 mod visit;
 
 use self::attrs::OtherAttrs;
-use self::discriminant::Discriminant;
 use self::namespace::Namespace;
 use self::parse::kw;
 use self::symbol::Symbol;
@@ -41,6 +40,7 @@ use syn::{Attribute, Expr, Generics, Lifetime, LitInt, Token, Type as RustType};
 
 pub use self::atom::Atom;
 pub use self::derive::{Derive, Trait};
+pub use self::discriminant::Discriminant;
 pub use self::doc::Doc;
 pub use self::names::ForeignName;
 pub use self::parse::parse_items;

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -37,7 +37,7 @@ use self::symbol::Symbol;
 use proc_macro2::{Ident, Span};
 use syn::punctuated::Punctuated;
 use syn::token::{Brace, Bracket, Paren};
-use syn::{Expr, Generics, Lifetime, LitInt, Token, Type as RustType};
+use syn::{Attribute, Expr, Generics, Lifetime, LitInt, Token, Type as RustType};
 
 pub use self::atom::Atom;
 pub use self::derive::{Derive, Trait};
@@ -112,6 +112,7 @@ pub struct Enum {
     pub brace_token: Brace,
     pub variants: Vec<Variant>,
     pub variants_from_header: bool,
+    pub variants_from_header_attr: Option<Attribute>,
     pub repr: Atom,
     pub repr_type: Type,
     pub explicit_repr: bool,

--- a/syntax/names.rs
+++ b/syntax/names.rs
@@ -68,3 +68,9 @@ impl Display for ForeignName {
         formatter.write_str(&self.text)
     }
 }
+
+impl PartialEq<str> for ForeignName {
+    fn eq(&self, rhs: &str) -> bool {
+        self.text == rhs
+    }
+}

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -4,9 +4,9 @@ use crate::syntax::file::{Item, ItemForeignMod};
 use crate::syntax::report::Errors;
 use crate::syntax::Atom::*;
 use crate::syntax::{
-    attrs, error, Api, Array, Derive, Doc, Enum, ExternFn, ExternType, ForeignName, Impl, Include,
-    IncludeKind, Lang, Lifetimes, NamedType, Namespace, Pair, Ptr, Receiver, Ref, Signature,
-    SliceRef, Struct, Ty1, Type, TypeAlias, Var, Variant,
+    attrs, error, Api, Array, Derive, Doc, Enum, EnumRepr, ExternFn, ExternType, ForeignName, Impl,
+    Include, IncludeKind, Lang, Lifetimes, NamedType, Namespace, Pair, Ptr, Receiver, Ref,
+    Signature, SliceRef, Struct, Ty1, Type, TypeAlias, Var, Variant,
 };
 use proc_macro2::{Delimiter, Group, Span, TokenStream, TokenTree};
 use quote::{format_ident, quote, quote_spanned};
@@ -241,6 +241,10 @@ fn parse_enum(cx: &mut Errors, item: ItemEnum, namespace: &Namespace) -> Api {
     let name = pair(namespace, &item.ident, cxx_name, rust_name);
     let repr_ident = Ident::new(repr.as_ref(), Span::call_site());
     let repr_type = Type::Ident(NamedType::new(repr_ident));
+    let repr = EnumRepr::Native {
+        atom: repr,
+        repr_type,
+    };
     let generics = Lifetimes {
         lt_token: None,
         lifetimes: Punctuated::new(),
@@ -262,7 +266,6 @@ fn parse_enum(cx: &mut Errors, item: ItemEnum, namespace: &Namespace) -> Api {
         variants_from_header,
         variants_from_header_attr,
         repr,
-        repr_type,
         explicit_repr,
     })
 }

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -187,6 +187,7 @@ fn parse_enum(cx: &mut Errors, item: ItemEnum, namespace: &Namespace) -> Api {
     let mut namespace = namespace.clone();
     let mut cxx_name = None;
     let mut rust_name = None;
+    let mut variants_from_header = false;
     let attrs = attrs::parse(
         cx,
         item.attrs,
@@ -197,6 +198,7 @@ fn parse_enum(cx: &mut Errors, item: ItemEnum, namespace: &Namespace) -> Api {
             namespace: Some(&mut namespace),
             cxx_name: Some(&mut cxx_name),
             rust_name: Some(&mut rust_name),
+            variants_from_header: Some(&mut variants_from_header),
             ..Default::default()
         },
     );
@@ -255,6 +257,7 @@ fn parse_enum(cx: &mut Errors, item: ItemEnum, namespace: &Namespace) -> Api {
         generics,
         brace_token,
         variants,
+        variants_from_header,
         repr,
         repr_type,
         explicit_repr,

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -187,7 +187,7 @@ fn parse_enum(cx: &mut Errors, item: ItemEnum, namespace: &Namespace) -> Api {
     let mut namespace = namespace.clone();
     let mut cxx_name = None;
     let mut rust_name = None;
-    let mut variants_from_header = false;
+    let mut variants_from_header = None;
     let attrs = attrs::parse(
         cx,
         item.attrs,
@@ -246,6 +246,8 @@ fn parse_enum(cx: &mut Errors, item: ItemEnum, namespace: &Namespace) -> Api {
         lifetimes: Punctuated::new(),
         gt_token: None,
     };
+    let variants_from_header_attr = variants_from_header;
+    let variants_from_header = variants_from_header_attr.is_some();
 
     Api::Enum(Enum {
         doc,
@@ -258,6 +260,7 @@ fn parse_enum(cx: &mut Errors, item: ItemEnum, namespace: &Namespace) -> Api {
         brace_token,
         variants,
         variants_from_header,
+        variants_from_header_attr,
         repr,
         repr_type,
         explicit_repr,

--- a/syntax/tokens.rs
+++ b/syntax/tokens.rs
@@ -1,7 +1,7 @@
 use crate::syntax::atom::Atom::*;
 use crate::syntax::{
-    Array, Atom, Derive, Enum, ExternFn, ExternType, Impl, Lifetimes, NamedType, Ptr, Receiver,
-    Ref, Signature, SliceRef, Struct, Ty1, Type, TypeAlias, Var,
+    Array, Atom, Derive, Enum, EnumRepr, ExternFn, ExternType, Impl, Lifetimes, NamedType, Ptr,
+    Receiver, Ref, Signature, SliceRef, Struct, Ty1, Type, TypeAlias, Var,
 };
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote_spanned, ToTokens};
@@ -276,6 +276,15 @@ impl ToTokens for Signature {
             langle.to_tokens(tokens);
             token::Paren(langle.span).surround(tokens, |_| ());
             rangle.to_tokens(tokens);
+        }
+    }
+}
+
+impl ToTokens for EnumRepr {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            EnumRepr::Native { atom, repr_type: _ } => atom.to_tokens(tokens),
+            EnumRepr::Foreign { rust_type } => rust_type.to_tokens(tokens),
         }
     }
 }

--- a/syntax/types.rs
+++ b/syntax/types.rs
@@ -7,7 +7,7 @@ use crate::syntax::set::{OrderedSet, UnorderedSet};
 use crate::syntax::trivial::{self, TrivialReason};
 use crate::syntax::visit::{self, Visit};
 use crate::syntax::{
-    toposort, Api, Atom, Enum, ExternType, Impl, Lifetimes, Pair, Struct, Type, TypeAlias,
+    toposort, Api, Atom, Enum, EnumRepr, ExternType, Impl, Lifetimes, Pair, Struct, Type, TypeAlias,
 };
 use proc_macro2::Ident;
 use quote::ToTokens;
@@ -88,7 +88,12 @@ impl<'a> Types<'a> {
                     add_resolution(&strct.name, &strct.generics);
                 }
                 Api::Enum(enm) => {
-                    all.insert(&enm.repr_type);
+                    match &enm.repr {
+                        EnumRepr::Native { atom: _, repr_type } => {
+                            all.insert(repr_type);
+                        }
+                        EnumRepr::Foreign { rust_type: _ } => {}
+                    }
                     let ident = &enm.name.rust;
                     if !type_names.insert(ident)
                         && (!cxx.contains(ident)

--- a/syntax/types.rs
+++ b/syntax/types.rs
@@ -101,6 +101,11 @@ impl<'a> Types<'a> {
                         duplicate_name(cx, enm, ident);
                     }
                     enums.insert(ident, enm);
+                    if enm.variants_from_header {
+                        // #![variants_from_header] enums are implicitly extern
+                        // C++ type.
+                        cxx.insert(&enm.name.rust);
+                    }
                     add_resolution(&enm.name, &enm.generics);
                 }
                 Api::CxxType(ety) => {

--- a/third-party/BUCK
+++ b/third-party/BUCK
@@ -72,7 +72,7 @@ rust_library(
 
 rust_library(
     name = "syn",
-    srcs = glob(["vendor/syn-1.0.69/src/**"]),
+    srcs = glob(["vendor/syn-1.0.70/src/**"]),
     visibility = ["PUBLIC"],
     features = [
         "clone-impls",

--- a/third-party/BUILD
+++ b/third-party/BUILD
@@ -76,7 +76,7 @@ rust_library(
 
 rust_library(
     name = "syn",
-    srcs = glob(["vendor/syn-1.0.69/src/**"]),
+    srcs = glob(["vendor/syn-1.0.70/src/**"]),
     crate_features = [
         "clone-impls",
         "derive",

--- a/third-party/Cargo.lock
+++ b/third-party/Cargo.lock
@@ -38,6 +38,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-ast"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06a1f20328a0881a6a6198d7320ac202af537cf671542078c6896cd21f1df394"
+dependencies = [
+ "once_cell",
+ "serde",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,9 +141,12 @@ version = "1.0.46"
 name = "cxxbridge-macro"
 version = "1.0.46"
 dependencies = [
+ "clang-ast",
  "cxx",
  "proc-macro2",
  "quote",
+ "serde",
+ "serde_json",
  "syn",
 ]
 
@@ -201,6 +214,12 @@ checksum = "8f1becd27d473556dc610b8afa1636ef90747b574a84553bc11e82371d5ef2d1"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "pkg-config"

--- a/third-party/Cargo.lock
+++ b/third-party/Cargo.lock
@@ -302,9 +302,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fe99c6bd8b1cc636890bcc071842de909d902c81ac7dab53ba33c421ab8ffb"
+checksum = "b9505f307c872bab8eb46f77ae357c8eba1fdacead58ee5a850116b1d7f82883"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
This PR adds an optional feature based on https://github.com/dtolnay/clang-ast to extract information about shared enums (variant names, discriminant values, repr type) from a serialized Clang AST of the associated C++ headers.

The user-facing change is:

```diff
  #[cxx::bridge]
  mod ffi {
      extern "C++" {
          include!("path/to/ServiceManager.h");
      }

      ...

-     #[repr(i32)]
      enum ServiceState {
-         DISABLED = 0,
-         ENABLED = 1,
-         PRODUCTION = 2,
-         QA_SERVICE = 4,
-         IN_REPAIR = 8,
+         #![variants_from_header]
      }
  }
```

Wiring up an AST dump in a Buck-based build looks something like:

```python
def rust_library(
        name,
        env = {},
        cxx_bridge = None,
        cxx_deps = None,
        **kwargs):
    if cxx_bridge:
        rust_cxx_bridge(
            name = "%s@bridge" % name,
            src = cxx_bridge,
            deps = cxx_deps,
        )

        clang_ast(
            name = "%s@ast" % name,
            header = ":%s@bridge=generated.h" % name,
            deps = cpp_deps,
        )

        env["CXX_CLANG_AST"] = "$(location :%s@ast)" % name

    native.rust_library(
        name = name,
        env = env,
        **kwargs,
    )
```

where `clang_ast()` is a simple bzl macro implemented as a genrule that runs `clang++ -Xclang -ast-dump=json -fsyntax-only $(location {header}) -I$(location {deps}) -x c++`, and `rust_cxx_bridge` is like [tools/buck/rust_cxx_bridge.bzl](https://github.com/dtolnay/cxx/blob/2c76dd69623fc5f6d148066e5fee6a69d4fba4c1/tools/buck/rust_cxx_bridge.bzl).

This is experimental for now but opens up some interesting possibilities, such as:

- Rustfix-compatible autofix suggestion if you've written an incompatible signature (i.e. as opposed to a C++ type error later in the generated code)
- Automatically using `type Kind = Trivial` for `extern "C++"` types which have a trivial definition, thereby making them available by value in Rust