### PR TITLE
Add cxx include directive to blobstore header in middle example

### DIFF
--- a/book/src/tutorial.md
+++ b/book/src/tutorial.md
@@ -332,6 +332,7 @@ pub fn next_chunk(buf: &mut MultiBuf) -> &[u8] {
 // include/blobstore.h
 
 # #pragma once
+#include "rust/cxx.h"
 # #include <memory>
 #
 struct MultiBuf;


### PR DESCRIPTION
I was running through the tutorial today, and found that when I tried to run my code at the end of the [calling a rust function from C++ example](https://cxx.rs/tutorial.html#calling-a-rust-function-from-c), I was met with the following errors.

```
-*- mode: compilation; default-directory: "~/Dev/cxx-demo/" -*-
Compilation started at Mon Jun 14 23:52:53

cargo run
   Compiling cxx-demo v0.1.0 (/Users/brendond/Dev/cxx-demo)
The following warnings were emitted during compilation:

warning: src/blobstore.cc:12:15: error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
warning:   std::string contents;
warning:               ^
warning: /Applications/Xcode_11.2.1_fb.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/iosfwd:210:32: note: template is declared here
warning:     class _LIBCPP_TEMPLATE_VIS basic_string;
warning:                                ^
warning: src/blobstore.cc:21:17: error: call to implicitly-deleted default constructor of 'std::hash<std::string>' (aka 'hash<basic_string<char, char_traits<char>, allocator<char> > >')
warning:   auto blobid = std::hash<std::string>{}(contents);
warning:                 ^                     ~~
warning: /Applications/Xcode_11.2.1_fb.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/utility:1576:36: note: default constructor of 'hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >' is implicitly deleted because base class '__enum_hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >' has a deleted default constructor
warning: struct _LIBCPP_TEMPLATE_VIS hash : public __enum_hash<_Tp>
warning:                                    ^
warning: /Applications/Xcode_11.2.1_fb.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/utility:1570:5: note: '__enum_hash' has been explicitly marked deleted here
warning:     __enum_hash() = delete;
warning:     ^
warning: 2 errors generated.

error: failed to run custom build command for `cxx-demo v0.1.0 (/Users/brendond/Dev/cxx-demo)`

Caused by:
  process didn't exit successfully: `/Users/brendond/Dev/cxx-demo/target/debug/build/cxx-demo-0d444ea0084d0f37/build-script-build` (exit code: 1)
  --- stdout
  cargo:CXXBRIDGE_PREFIX=cxx-demo
  cargo:CXXBRIDGE_DIR0=/Users/brendond/Dev/cxx-demo/target/debug/build/cxx-demo-cc0e0d9756cd5d70/out/cxxbridge/include
  cargo:CXXBRIDGE_DIR1=/Users/brendond/Dev/cxx-demo/target/debug/build/cxx-demo-cc0e0d9756cd5d70/out/cxxbridge/crate
  TARGET = Some("x86_64-apple-darwin")
  OPT_LEVEL = Some("0")
  HOST = Some("x86_64-apple-darwin")
  CXX_x86_64-apple-darwin = None
  CXX_x86_64_apple_darwin = None
  HOST_CXX = None
  CXX = None
  CXXFLAGS_x86_64-apple-darwin = None
  CXXFLAGS_x86_64_apple_darwin = None
  HOST_CXXFLAGS = None
  CXXFLAGS = None
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some("true")
  CARGO_CFG_TARGET_FEATURE = Some("cmpxchg16b,fxsr,sse,sse2,sse3,ssse3")
  CXX_x86_64-apple-darwin = None
  CXX_x86_64_apple_darwin = None
  HOST_CXX = None
  CXX = None
  CXXFLAGS_x86_64-apple-darwin = None
  CXXFLAGS_x86_64_apple_darwin = None
  HOST_CXXFLAGS = None
  CXXFLAGS = None
  CRATE_CC_NO_DEFAULTS = None
  CARGO_CFG_TARGET_FEATURE = Some("cmpxchg16b,fxsr,sse,sse2,sse3,ssse3")
  running: "c++" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-g" "-fno-omit-frame-pointer" "-m64" "-arch" "x86_64" "-I" "/Users/brendond/Dev/cxx-demo/target/debug/build/cxx-demo-cc0e0d9756cd5d70/out/cxxbridge/include" "-I" "/Users/brendond/Dev/cxx-demo/target/debug/build/cxx-demo-cc0e0d9756cd5d70/out/cxxbridge/crate" "-Wall" "-Wextra" "-std=c++14" "-o" "/Users/brendond/Dev/cxx-demo/target/debug/build/cxx-demo-cc0e0d9756cd5d70/out/cxxbridge/sources/cxx-demo/src/main.rs.o" "-c" "/Users/brendond/Dev/cxx-demo/target/debug/build/cxx-demo-cc0e0d9756cd5d70/out/cxxbridge/sources/cxx-demo/src/main.rs.cc"
  exit code: 0
  running: "c++" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-g" "-fno-omit-frame-pointer" "-m64" "-arch" "x86_64" "-I" "/Users/brendond/Dev/cxx-demo/target/debug/build/cxx-demo-cc0e0d9756cd5d70/out/cxxbridge/include" "-I" "/Users/brendond/Dev/cxx-demo/target/debug/build/cxx-demo-cc0e0d9756cd5d70/out/cxxbridge/crate" "-Wall" "-Wextra" "-std=c++14" "-o" "/Users/brendond/Dev/cxx-demo/target/debug/build/cxx-demo-cc0e0d9756cd5d70/out/src/blobstore.o" "-c" "src/blobstore.cc"
  cargo:warning=src/blobstore.cc:12:15: error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
  cargo:warning=  std::string contents;
  cargo:warning=              ^
  cargo:warning=/Applications/Xcode_11.2.1_fb.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/iosfwd:210:32: note: template is declared here
  cargo:warning=    class _LIBCPP_TEMPLATE_VIS basic_string;
  cargo:warning=                               ^
  cargo:warning=src/blobstore.cc:21:17: error: call to implicitly-deleted default constructor of 'std::hash<std::string>' (aka 'hash<basic_string<char, char_traits<char>, allocator<char> > >')
  cargo:warning=  auto blobid = std::hash<std::string>{}(contents);
  cargo:warning=                ^                     ~~
  cargo:warning=/Applications/Xcode_11.2.1_fb.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/utility:1576:36: note: default constructor of 'hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >' is implicitly deleted because base class '__enum_hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >' has a deleted default constructor
  cargo:warning=struct _LIBCPP_TEMPLATE_VIS hash : public __enum_hash<_Tp>
  cargo:warning=                                   ^
  cargo:warning=/Applications/Xcode_11.2.1_fb.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/utility:1570:5: note: '__enum_hash' has been explicitly marked deleted here
  cargo:warning=    __enum_hash() = delete;
  cargo:warning=    ^
  cargo:warning=2 errors generated.
  exit code: 1

  --- stderr

  CXX include path:
    /Users/brendond/Dev/cxx-demo/target/debug/build/cxx-demo-cc0e0d9756cd5d70/out/cxxbridge/include
    /Users/brendond/Dev/cxx-demo/target/debug/build/cxx-demo-cc0e0d9756cd5d70/out/cxxbridge/crate


  error occurred: Command "c++" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-g" "-fno-omit-frame-pointer" "-m64" "-arch" "x86_64" "-I" "/Users/brendond/Dev/cxx-demo/target/debug/build/cxx-demo-cc0e0d9756cd5d70/out/cxxbridge/include" "-I" "/Users/brendond/Dev/cxx-demo/target/debug/build/cxx-demo-cc0e0d9756cd5d70/out/cxxbridge/crate" "-Wall" "-Wextra" "-std=c++14" "-o" "/Users/brendond/Dev/cxx-demo/target/debug/build/cxx-demo-cc0e0d9756cd5d70/out/src/blobstore.o" "-c" "src/blobstore.cc" with args "c++" did not execute successfully (status code exit code: 1).



Compilation exited abnormally with code 1 at Mon Jun 14 23:52:54
```

After some attempts at trying to understand what was going on, I read on a bit, and realized that in the final example, this include directive was added. Thought I'd try to help the next sorry soul and update the docs. I must say though, on the whole, this tutorial was REALLY great!!! So stoked to start using CXX!