### PR TITLE
Add optional `serde` `Deserialize` and `Serialize` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cxx"
-version = "1.0.49" # remember to update html_root_url
+version = "1.0.50" # remember to update html_root_url
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 edition = "2018"
 links = "cxxbridge1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,10 @@ default = ["cxxbridge-flags/default"] # c++11
 "c++14" = ["cxxbridge-flags/c++14"]
 "c++17" = ["cxxbridge-flags/c++17"]
 "c++20" = ["cxxbridge-flags/c++20"]
+"serde-derive" = ["cxxbridge-macro/serde-derive"]
 
 [dependencies]
-cxxbridge-macro = { version = "=1.0.49", path = "macro" }
+cxxbridge-macro = { version = "=1.0.50", path = "macro" }
 link-cplusplus = "1.0"
 
 [build-dependencies]

--- a/gen/cmd/Cargo.toml
+++ b/gen/cmd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cxxbridge-cmd"
-version = "1.0.49"
+version = "1.0.50"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/gen/cmd/Cargo.toml
+++ b/gen/cmd/Cargo.toml
@@ -15,12 +15,16 @@ categories = ["development-tools::ffi"]
 name = "cxxbridge"
 path = "src/main.rs"
 
+[features]
+"serde-derive" = ["serde"]
+
 [dependencies]
 clap = "2.33"
 codespan-reporting = "0.11"
 proc-macro2 = { version = "1.0.26", default-features = false, features = ["span-locations"] }
 quote = { version = "1.0", default-features = false }
 syn = { version = "1.0.70", default-features = false, features = ["parsing", "printing", "clone-impls", "full"] }
+serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cxxbridge-macro"
-version = "1.0.49"
+version = "1.0.50"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -16,6 +16,7 @@ proc-macro = true
 
 [features]
 experimental = ["clang-ast", "flate2", "memmap", "serde", "serde_json"]
+"serde-derive" = ["serde"]
 
 [dependencies]
 proc-macro2 = "1.0"

--- a/macro/src/derive.rs
+++ b/macro/src/derive.rs
@@ -16,7 +16,7 @@ pub fn expand_struct(strct: &Struct, actual_derives: &mut Option<TokenStream>) -
             Trait::Debug => expanded.extend(struct_debug(strct, span)),
             Trait::Default => expanded.extend(struct_default(strct, span)),
             #[cfg(feature = "serde-derive")]
-            Trait::Deserialize => traits.push(quote_spanned!(span=> serde::Deserialize)),
+            Trait::Deserialize => traits.push(quote!(serde::Deserialize)),
             Trait::Eq => traits.push(quote_spanned!(span=> ::std::cmp::Eq)),
             Trait::ExternType => unreachable!(),
             Trait::Hash => traits.push(quote_spanned!(span=> ::std::hash::Hash)),
@@ -24,7 +24,7 @@ pub fn expand_struct(strct: &Struct, actual_derives: &mut Option<TokenStream>) -
             Trait::PartialEq => traits.push(quote_spanned!(span=> ::std::cmp::PartialEq)),
             Trait::PartialOrd => expanded.extend(struct_partial_ord(strct, span)),
             #[cfg(feature = "serde-derive")]
-            Trait::Serialize => traits.push(quote_spanned!(span=> serde::Serialize))
+            Trait::Serialize => traits.push(quote!(serde::Serialize))
         }
     }
 

--- a/macro/src/derive.rs
+++ b/macro/src/derive.rs
@@ -15,12 +15,16 @@ pub fn expand_struct(strct: &Struct, actual_derives: &mut Option<TokenStream>) -
             Trait::Clone => expanded.extend(struct_clone(strct, span)),
             Trait::Debug => expanded.extend(struct_debug(strct, span)),
             Trait::Default => expanded.extend(struct_default(strct, span)),
+            #[cfg(feature = "serde-derive")]
+            Trait::Deserialize => traits.push(quote_spanned!(span=> serde::Deserialize)),
             Trait::Eq => traits.push(quote_spanned!(span=> ::std::cmp::Eq)),
             Trait::ExternType => unreachable!(),
             Trait::Hash => traits.push(quote_spanned!(span=> ::std::hash::Hash)),
             Trait::Ord => expanded.extend(struct_ord(strct, span)),
             Trait::PartialEq => traits.push(quote_spanned!(span=> ::std::cmp::PartialEq)),
             Trait::PartialOrd => expanded.extend(struct_partial_ord(strct, span)),
+            #[cfg(feature = "serde-derive")]
+            Trait::Serialize => traits.push(quote_spanned!(span=> serde::Serialize))
         }
     }
 
@@ -54,6 +58,8 @@ pub fn expand_enum(enm: &Enum, actual_derives: &mut Option<TokenStream>) -> Toke
             }
             Trait::Debug => expanded.extend(enum_debug(enm, span)),
             Trait::Default => unreachable!(),
+            #[cfg(feature = "serde-derive")]
+            Trait::Deserialize => traits.push(quote_spanned!(span=> serde::Deserialize)),
             Trait::Eq => {
                 traits.push(quote_spanned!(span=> ::std::cmp::Eq));
                 has_eq = true;
@@ -66,6 +72,8 @@ pub fn expand_enum(enm: &Enum, actual_derives: &mut Option<TokenStream>) -> Toke
                 has_partial_eq = true;
             }
             Trait::PartialOrd => expanded.extend(enum_partial_ord(enm, span)),
+            #[cfg(feature = "serde-derive")]
+            Trait::Serialize => traits.push(quote_spanned!(span=> serde::Serialize))
         }
     }
 

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -57,10 +57,6 @@ fn expand(ffi: Module, doc: Doc, attrs: OtherAttrs, apis: &[Api], types: &Types)
         }
     }
 
-    if cfg!(feature = "serde-derive") {
-        expanded.extend()
-    }
-
     for api in apis {
         match api {
             Api::Include(_) | Api::Impl(_) => {}

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -57,6 +57,10 @@ fn expand(ffi: Module, doc: Doc, attrs: OtherAttrs, apis: &[Api], types: &Types)
         }
     }
 
+    if cfg!(feature = "serde-derive") {
+        expanded.extend()
+    }
+
     for api in apis {
         match api {
             Api::Include(_) | Api::Impl(_) => {}

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -28,6 +28,8 @@
     clippy::wrong_self_convention
 )]
 
+#[cfg(feature = "serde-derive")]
+extern crate serde;
 extern crate proc_macro;
 
 mod derive;
@@ -40,6 +42,7 @@ mod type_id;
 mod clang;
 #[cfg(feature = "experimental")]
 mod load;
+
 
 use crate::syntax::file::Module;
 use crate::syntax::namespace::Namespace;

--- a/syntax/derive.rs
+++ b/syntax/derive.rs
@@ -13,12 +13,16 @@ pub enum Trait {
     Copy,
     Debug,
     Default,
+    #[cfg(feature = "serde-derive")]
+    Deserialize,
     Eq,
     ExternType,
     Hash,
     Ord,
     PartialEq,
     PartialOrd,
+    #[cfg(feature = "serde-derive")]
+    Serialize
 }
 
 impl Derive {
@@ -28,12 +32,16 @@ impl Derive {
             "Copy" => Trait::Copy,
             "Debug" => Trait::Debug,
             "Default" => Trait::Default,
+            #[cfg(feature = "serde-derive")]
+            "Deserialize" => Trait::Deserialize,
             "Eq" => Trait::Eq,
             "ExternType" => Trait::ExternType,
             "Hash" => Trait::Hash,
             "Ord" => Trait::Ord,
             "PartialEq" => Trait::PartialEq,
             "PartialOrd" => Trait::PartialOrd,
+            #[cfg(feature = "serde-derive")]
+            "Serialize" => Trait::Serialize,
             _ => return None,
         };
         let span = ident.span();
@@ -54,12 +62,16 @@ impl AsRef<str> for Trait {
             Trait::Copy => "Copy",
             Trait::Debug => "Debug",
             Trait::Default => "Default",
+            #[cfg(feature = "serde-derive")]
+            Trait::Deserialize => "Deserialize",
             Trait::Eq => "Eq",
             Trait::ExternType => "ExternType",
             Trait::Hash => "Hash",
             Trait::Ord => "Ord",
             Trait::PartialEq => "PartialEq",
             Trait::PartialOrd => "PartialOrd",
+            #[cfg(feature = "serde-derive")]
+            Trait::Serialize => "Serialize",
         }
     }
 }


### PR DESCRIPTION
My project relies a lot on both `cxx` and `serde`. Not being able to derive `Deserialize` inside of `bridge.rs` is a deal breaker. This PR is a dirty fix to keep the `#[derive(serde::Deserialize, serde::Serialize)]` inside the generated code.

A further feature would be to make an `extern "C"` function to call serialize and deserialize from `C/C++`.