### PR TITLE
Add UniquePtr::as_mut_ptr

### DIFF
--- a/src/unique_ptr.rs
+++ b/src/unique_ptr.rs
@@ -84,6 +84,30 @@ where
         }
     }
 
+    /// Returns a pointer to the object owned by this UniquePtr
+    /// if any, otherwise the null pointer.
+    pub fn as_ptr(&self) -> *const T {
+        match self.as_ref() {
+            Some(target) => target as *const T,
+            None => std::ptr::null(),
+        }
+    }
+
+    /// Returns a mutable pointer to the object owned by this UniquePtr
+    /// if any, otherwise the null pointer.
+    ///
+    /// # Safety
+    ///
+    /// This funtion is unsafe because improper modification of the
+    /// resultant raw pointer may invalidate the UniquePtr (for example,
+    /// freeing the underlying pointer.)
+    pub unsafe fn as_mut_ptr(&mut self) -> *mut T {
+        match self.as_mut() {
+            Some(target) => target.get_unchecked_mut(),
+            None => std::ptr::null_mut(),
+        }
+    }
+
     /// Consumes the UniquePtr, releasing its ownership of the heap-allocated T.
     ///
     /// Matches the behavior of [std::unique_ptr\<T\>::release](https://en.cppreference.com/w/cpp/memory/unique_ptr/release).

--- a/src/unique_ptr.rs
+++ b/src/unique_ptr.rs
@@ -96,16 +96,12 @@ where
     /// Returns a mutable pointer to the object owned by this UniquePtr
     /// if any, otherwise the null pointer.
     ///
-    /// # Safety
-    ///
-    /// This funtion is unsafe because improper modification of the
-    /// resultant raw pointer may invalidate the UniquePtr (for example,
-    /// freeing the underlying pointer.)
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut T {
-        match self.as_mut() {
-            Some(target) => target.get_unchecked_mut(),
-            None => std::ptr::null_mut(),
-        }
+    /// As with [std::unique_ptr\<T\>::get](https://en.cppreference.com/w/cpp/memory/unique_ptr/get),
+    /// this doesn't require that you hold a mutable reference to the `UniquePtr`.
+    /// This differs from Rust norms, so extra care should be taken in
+    /// the way the pointer is used.
+    pub fn as_mut_ptr(&self) -> *mut T {
+        self.as_ptr() as *mut T
     }
 
     /// Consumes the UniquePtr, releasing its ownership of the heap-allocated T.

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -248,6 +248,8 @@ fn test_c_method_calls() {
     assert_eq!(2021, unique_ptr.get());
     assert_eq!(2021, unique_ptr.get2());
     assert_eq!(2021, *unique_ptr.getRef());
+    assert_eq!(2021, unsafe { unique_ptr.as_mut_ptr().as_ref() }.unwrap().get());
+    assert_eq!(2021, unsafe { unique_ptr.as_ptr().as_ref() }.unwrap().get());
     assert_eq!(2021, *unique_ptr.pin_mut().getMut());
     assert_eq!(2022, unique_ptr.pin_mut().set_succeed(2022).unwrap());
     assert!(unique_ptr.pin_mut().get_fail().is_err());


### PR DESCRIPTION
cxx accepts functions that take *mut T as an argument.
Such functions are of course used under odd niche circumstances;
it would be safer and better to take a &mut Pin<T>.

But in cases where such a function does exist, we'd most commonly
want to provide it a mutable pointer to a T which is safely
and uniquely owned by Rust, within a UniquePtr.

It was previously quite hard to do this:

```rust
    let mut a = /* make UniquePtr to a thing */
    unsafe { ffi::TakeA(std::pin::Pin::<&mut ffi::A>::into_inner_unchecked(a.pin_mut())) };
```

With this extra API, it becomes much more ergonomic:

```rust
    let mut a = /* make UniquePtr to a thing */
    unsafe { ffi::TakeA(a.as_mut_ptr()) }
```

Inspired by https://github.com/google/autocxx/issues/558