### PR TITLE
bazel: don't use cargo in $PATH, make the build hermetic.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,7 +1,6 @@
 workspace(name = "cxx.rs")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("//tools/bazel:vendor.bzl", "vendor")
 
 http_archive(
     name = "rules_rust",
@@ -15,12 +14,17 @@ http_archive(
 
 load("@rules_rust//rust:repositories.bzl", "rust_repositories")
 
+RUST_VERSION = "1.51.0"
+
 rust_repositories(
     edition = "2018",
-    version = "1.51.0",
+    version = RUST_VERSION,
 )
+
+load("//tools/bazel:vendor.bzl", "vendor")
 
 vendor(
     name = "third-party",
     lockfile = "//third-party:Cargo.lock",
+    cargo_version = RUST_VERSION,
 )


### PR DESCRIPTION
Background:
tools/bazel/vendor is just running 'cargo', hoping to find it somewhere
in $PATH.

Problem:
rules_rust try to be hermetic, and not use the cargo of the system, but
the cargo of the toolchain installed.
This means that if the cargo on the system is different from the cargo
used by cxx.rs, or the system does not have a cargo at all, bad things
will happen when using cxx.rs.

In this change:
use the recommended way to find/install the tool. Thanks to Andre in the