### PR TITLE
Add support for `#[repr(align(x))]` on bridge structs

### DIFF
--- a/book/src/shared.md
+++ b/book/src/shared.md
@@ -244,3 +244,18 @@ C++ data type:
 - `PartialOrd` produces `operator<`, `operator<=`, `operator>`, `operator>=`
 
 [hash]: https://en.cppreference.com/w/cpp/utility/hash
+
+## Alignment
+
+Enforcing minimum alignment for structs using `repr(align(x))` is supported within the
+CXX bridge module. The alignment value must be a power of two from 1 up to 2<sup>29</sup>.
+
+```rust,noplayground
+#[cxx::bridge]
+mod ffi {
+    #[repr(align(4))]
+    struct ExampleStruct {
+        b: [u8; 4],
+    }
+}
+```

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -9,7 +9,7 @@ use crate::syntax::set::UnorderedSet;
 use crate::syntax::symbol::Symbol;
 use crate::syntax::trivial::{self, TrivialReason};
 use crate::syntax::{
-    derive, mangle, Api, Doc, Enum, EnumRepr, ExternFn, ExternType, Pair, Signature, Struct, Trait,
+    derive, mangle, Alignment, Api, Doc, Enum, EnumRepr, ExternFn, ExternType, Pair, Signature, Struct, Trait,
     Type, TypeAlias, Types, Var,
 };
 use proc_macro2::Ident;
@@ -238,7 +238,12 @@ fn write_struct<'a>(out: &mut OutFile<'a>, strct: &'a Struct, methods: &[&Extern
     for line in strct.doc.to_string().lines() {
         writeln!(out, "//{}", line);
     }
-    writeln!(out, "struct {} final {{", strct.name.cxx);
+    let alignment = if let Some(Alignment::Align(x)) = strct.alignment {
+        format!("alignas({}) ", x)
+    } else {
+        String::from("")
+    };
+    writeln!(out, "struct {}{} final {{", alignment, strct.name.cxx);
 
     for field in &strct.fields {
         for line in field.doc.to_string().lines() {

--- a/syntax/attrs.rs
+++ b/syntax/attrs.rs
@@ -1,11 +1,11 @@
 use crate::syntax::namespace::Namespace;
 use crate::syntax::report::Errors;
-use crate::syntax::Atom::{self, *};
+use crate::syntax::repr::Repr;
 use crate::syntax::{Derive, Doc, ForeignName};
 use proc_macro2::{Ident, TokenStream};
 use quote::ToTokens;
 use syn::parse::{Nothing, Parse, ParseStream, Parser as _};
-use syn::{Attribute, Error, LitStr, Path, Result, Token};
+use syn::{Attribute, LitStr, Path, Result, Token};
 
 // Intended usage:
 //
@@ -29,7 +29,7 @@ use syn::{Attribute, Error, LitStr, Path, Result, Token};
 pub struct Parser<'a> {
     pub doc: Option<&'a mut Doc>,
     pub derives: Option<&'a mut Vec<Derive>>,
-    pub repr: Option<&'a mut Option<Atom>>,
+    pub repr: Option<&'a mut Option<Repr>>,
     pub namespace: Option<&'a mut Namespace>,
     pub cxx_name: Option<&'a mut Option<ForeignName>>,
     pub rust_name: Option<&'a mut Option<Ident>>,
@@ -178,21 +178,8 @@ fn parse_derive_attribute(cx: &mut Errors, input: ParseStream) -> Result<Vec<Der
     Ok(derives)
 }
 
-fn parse_repr_attribute(input: ParseStream) -> Result<Atom> {
-    let begin = input.cursor();
-    let ident: Ident = input.parse()?;
-    if let Some(atom) = Atom::from(&ident) {
-        match atom {
-            U8 | U16 | U32 | U64 | Usize | I8 | I16 | I32 | I64 | Isize if input.is_empty() => {
-                return Ok(atom);
-            }
-            _ => {}
-        }
-    }
-    Err(Error::new_spanned(
-        begin.token_stream(),
-        "unrecognized repr",
-    ))
+fn parse_repr_attribute(input: ParseStream) -> Result<Repr> {
+    input.parse::<Repr>()
 }
 
 fn parse_namespace_attribute(input: ParseStream) -> Result<Namespace> {

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -20,6 +20,7 @@ mod parse;
 mod pod;
 pub mod qualified;
 pub mod report;
+pub mod repr;
 pub mod resolve;
 pub mod set;
 pub mod symbol;
@@ -45,6 +46,10 @@ pub use self::doc::Doc;
 pub use self::names::ForeignName;
 pub use self::parse::parse_items;
 pub use self::types::Types;
+
+pub enum Alignment {
+    Align(u32),
+}
 
 pub enum Api {
     Include(Include),
@@ -92,6 +97,7 @@ pub struct ExternType {
 pub struct Struct {
     pub doc: Doc,
     pub derives: Vec<Derive>,
+    pub alignment: Option<Alignment>,
     pub attrs: OtherAttrs,
     pub visibility: Token![pub],
     pub struct_token: Token![struct],

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -200,7 +200,7 @@ fn parse_enum(cx: &mut Errors, item: ItemEnum, namespace: &Namespace) -> Api {
     let mut variants_from_header = None;
     let attrs = attrs::parse(
         cx,
-        item.attrs,
+        item.attrs.clone(),
         attrs::Parser {
             doc: Some(&mut doc),
             derives: Some(&mut derives),
@@ -224,10 +224,13 @@ fn parse_enum(cx: &mut Errors, item: ItemEnum, namespace: &Namespace) -> Api {
         cx.error(where_clause, "enum with where-clause is not supported");
     }
 
-    let repr = if let Some(Repr::Atom(atom)) = repr {
-        Some(atom)
-    } else {
-        None
+    let repr = match repr {
+        Some(Repr::Atom(atom)) => Some(atom),
+        Some(Repr::Align(_)) => {
+            cx.error(&item, "repr(align) on enums is not supported");
+            None
+        },
+        None => None,
     };
 
     let mut variants = Vec::new();

--- a/syntax/repr.rs
+++ b/syntax/repr.rs
@@ -1,0 +1,45 @@
+use crate::syntax::Atom::{self, *};
+use syn::parse::{Error, Parse, ParseStream, Result};
+use syn::{Ident, LitInt};
+
+#[derive(Copy, Clone, PartialEq)]
+pub enum Repr {
+    Align(u32),
+    Atom(Atom),
+}
+
+impl Parse for Repr {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let begin = input.cursor();
+        let ident: Ident = input.parse()?;
+        if let Some(atom) = Atom::from(&ident) {
+            match atom {
+                U8 | U16 | U32 | U64 | Usize | I8 | I16 | I32 | I64 | Isize if input.is_empty() => {
+                    return Ok(Repr::Atom(atom));
+                }
+                _ => {}
+            }
+        } else if ident == "align" {
+            let content;
+            syn::parenthesized!(content in input);
+            let alignment: u32 = content.parse::<LitInt>()?.base10_parse()?;
+            if !alignment.is_power_of_two() {
+                return Err(Error::new_spanned(
+                    begin.token_stream(),
+                    "invalid `repr(align)` attribute: not a power of two",
+                ));
+            }
+            if alignment > 2u32.pow(29) {
+                return Err(Error::new_spanned(
+                    begin.token_stream(),
+                    "invalid `repr(align)` attribute: larger than 2^29",
+                ));
+            }
+            return Ok(Repr::Align(alignment));
+        }
+        Err(Error::new_spanned(
+            begin.token_stream(),
+            "unrecognized repr",
+        ))
+    }
+}

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -82,6 +82,11 @@ pub mod ffi {
         a: [i32; 4],
     }
 
+    #[repr(align(4))]
+    pub struct StructWithAlignment4 {
+        b: [u8; 4],
+    }
+
     #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
     pub struct StructWithLifetime<'a> {
         s: &'a str,

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -15,6 +15,8 @@ extern "C" bool cxx_test_suite_r_is_correct(const tests::R *) noexcept;
 
 namespace tests {
 
+static_assert(4 == alignof(StructWithAlignment4), "expected 4 byte alignment");
+
 static constexpr char SLICE_DATA[] = "2020";
 
 C::C(size_t n) : n(n) {}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -291,6 +291,11 @@ fn test_enum_representations() {
 }
 
 #[test]
+fn test_struct_align_repr() {
+    assert_eq!(4, std::mem::align_of::<ffi::StructWithAlignment4>());
+}
+
+#[test]
 fn test_debug() {
     assert_eq!("Shared { z: 1 }", format!("{:?}", ffi::Shared { z: 1 }));
     assert_eq!("BVal", format!("{:?}", ffi::Enum::BVal));

--- a/tests/ui/enum_align_unsupported.rs
+++ b/tests/ui/enum_align_unsupported.rs
@@ -1,0 +1,9 @@
+#[cxx::bridge]
+mod ffi {
+    #[repr(align(2))]
+    enum Bad {
+        A,
+    }
+}
+
+fn main() {}

--- a/tests/ui/enum_align_unsupported.stderr
+++ b/tests/ui/enum_align_unsupported.stderr
@@ -1,0 +1,8 @@
+error: repr(align) on enums is not supported
+ --> $DIR/enum_align_unsupported.rs:3:5
+  |
+3 | /     #[repr(align(2))]
+4 | |     enum Bad {
+5 | |         A,
+6 | |     }
+  | |_____^

--- a/tests/ui/struct_align.rs
+++ b/tests/ui/struct_align.rs
@@ -1,0 +1,20 @@
+#[cxx::bridge]
+mod ffi {
+    #[repr(align(3))]
+    struct SharedA {
+        b: [u8; 4],
+    }
+
+    // 1073741824 = 2^30
+    #[repr(align(1073741824))]
+    struct SharedB {
+        b: [u8; 4],
+    }
+
+    #[repr(align(-2))]
+    struct SharedC {
+        b: [u8; 4],
+    }
+}
+
+fn main() {}

--- a/tests/ui/struct_align.stderr
+++ b/tests/ui/struct_align.stderr
@@ -1,0 +1,17 @@
+error: invalid `repr(align)` attribute: not a power of two
+ --> $DIR/struct_align.rs:3:12
+  |
+3 |     #[repr(align(3))]
+  |            ^^^^^^^^
+
+error: invalid `repr(align)` attribute: larger than 2^29
+ --> $DIR/struct_align.rs:9:12
+  |
+9 |     #[repr(align(1073741824))]
+  |            ^^^^^^^^^^^^^^^^^
+
+error: invalid digit found in string
+  --> $DIR/struct_align.rs:14:18
+   |
+14 |     #[repr(align(-2))]
+   |                  ^


### PR DESCRIPTION
Add support for `#[repr(align(x))]` on bridge structs, closing #835. For the example code: 
```rust 
#[cxx::bridge]
mod ffi {
    #[repr(align(4))]
    struct S {
        b: [u8; 4],
    }
}
```
the following output was obtained using the cxx code generators:
```rust 
// -- snip 
#[repr(C)]
#[repr(align(4))]
pub struct S {
    pub b: [u8; 4],
}
// -- snip
```
```cpp
#include <array>
#include <cstdint>
#include <type_traits>

struct S;

#ifndef CXXBRIDGE1_STRUCT_S
#define CXXBRIDGE1_STRUCT_S
struct alignas(4) S final {
  ::std::array<::std::uint8_t, 4> b;

  using IsRelocatable = ::std::true_type;
};
#endif // CXXBRIDGE1_STRUCT_S
```
I believe it would be straightforward to extend this implementation for `#[repr(packed)]` as well. 

I was wondering whether to add support for enums but decided against it for now and made it an "unsupported" error for the time being. `enum alignas(X)` is accepted by all the C++ compilers I tried, but I also found a defect report from 2017 (2534) that removes the ability to apply `alignas` to enums: https://wg21.cmeerw.net/cwg/issue2354.



