### PR TITLE
Add UTF-16 rust::String initialization

### DIFF
--- a/include/cxx.h
+++ b/include/cxx.h
@@ -43,6 +43,8 @@ public:
   String(const std::string &);
   String(const char *);
   String(const char *, std::size_t);
+  String(const char16_t *);
+  String(const char16_t *, std::size_t);
 
   String &operator=(const String &) &noexcept;
   String &operator=(String &&) &noexcept;

--- a/src/symbols/rust_string.rs
+++ b/src/symbols/rust_string.rs
@@ -15,8 +15,8 @@ unsafe extern "C" fn string_clone(this: &mut MaybeUninit<String>, other: &String
     ptr::write(this.as_mut_ptr(), other.clone());
 }
 
-#[export_name = "cxxbridge1$string$from"]
-unsafe extern "C" fn string_from(
+#[export_name = "cxxbridge1$string$from_utf8"]
+unsafe extern "C" fn string_from_utf8(
     this: &mut MaybeUninit<String>,
     ptr: *const u8,
     len: usize,
@@ -25,6 +25,22 @@ unsafe extern "C" fn string_from(
     match str::from_utf8(slice) {
         Ok(s) => {
             ptr::write(this.as_mut_ptr(), s.to_owned());
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+#[export_name = "cxxbridge1$string$from_utf16"]
+unsafe extern "C" fn string_from_utf16(
+    this: &mut MaybeUninit<String>,
+    ptr: *const u16,
+    len: usize,
+) -> bool {
+    let slice = slice::from_raw_parts(ptr, len);
+    match String::from_utf16(slice) {
+        Ok(s) => {
+            ptr::write(this.as_mut_ptr(), s);
             true
         }
         Err(_) => false,

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -841,6 +841,12 @@ extern "C" const char *cxx_run_test() noexcept {
   ASSERT(cstr == "foo");
   ASSERT(other_cstr == "test");
 
+  const char *utf8_literal = u8"Test string";
+  const char16_t *utf16_literal = u"Test string";
+  rust::String utf8_rstring = utf8_literal;
+  rust::String utf16_rstring = utf16_literal;
+  ASSERT(utf8_rstring == utf16_rstring);
+
   rust::Vec<int> vec1{1, 2};
   rust::Vec<int> vec2{3, 4};
   swap(vec1, vec2);


### PR DESCRIPTION
This patch exposes String::from_utf16 to the C++ interface for rust::String.