### PR TITLE
Add let_cxx_vector to construct CxxVector on stack

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1854,6 +1854,43 @@ fn write_cxx_vector(out: &mut OutFile, key: NamedImplKey) {
     writeln!(out, "  return &(*s)[pos];");
     writeln!(out, "}}");
 
+    writeln!(
+        out,
+        "  static_assert(alignof(std::vector<{}>) <= alignof(void *),",
+        inner
+    );
+    writeln!(
+        out,
+        "    \"unexpectedly large std::vector<{}> alignment\");",
+        inner
+    );
+    writeln!(
+        out,
+        "  static_assert(sizeof(std::vector<{}>) <= 8 * sizeof(void *),",
+        inner
+    );
+    writeln!(
+        out,
+        "    \"unexpectedly large std::vector<{}> size\");",
+        inner
+    );
+
+    writeln!(
+        out,
+        "void cxxbridge1$std$vector${}$init(::std::vector<{}> *s) noexcept {{",
+        instance, inner,
+    );
+    writeln!(out, "  new (s) ::std::vector<{}>;", inner);
+    writeln!(out, "}}");
+
+    writeln!(
+        out,
+        "void cxxbridge1$std$vector${}$destroy(::std::vector<{}> *s) noexcept {{",
+        instance, inner,
+    );
+    writeln!(out, "  s->~vector();");
+    writeln!(out, "}}");
+
     if out.types.is_maybe_trivial(element) {
         writeln!(
             out,

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1565,6 +1565,8 @@ fn expand_cxx_vector(
     let link_get_unchecked = format!("{}get_unchecked", prefix);
     let link_push_back = format!("{}push_back", prefix);
     let link_pop_back = format!("{}pop_back", prefix);
+    let link_init = format!("{}init", prefix);
+    let link_destroy = format!("{}destroy", prefix);
     let unique_ptr_prefix = format!(
         "cxxbridge1$unique_ptr$std$vector${}$",
         resolve.name.to_symbol(),
@@ -1686,6 +1688,22 @@ fn expand_cxx_vector(
                     fn __unique_ptr_drop(this: *mut ::std::mem::MaybeUninit<*mut ::std::ffi::c_void>);
                 }
                 __unique_ptr_drop(&mut repr);
+            }
+            #[doc(hidden)]
+            unsafe fn __init(this: &mut ::std::mem::MaybeUninit<::cxx::CxxVector<Self>>) {
+                extern "C" {
+                    #[link_name = #link_init]
+                    fn __init(this: &mut ::std::mem::MaybeUninit<::cxx::CxxVector<#elem #ty_generics>>);
+                }
+                __init(this);
+            }
+            #[doc(hidden)]
+            unsafe fn __destroy(this: &mut ::std::mem::MaybeUninit<::cxx::CxxVector<Self>>) {
+                extern "C" {
+                    #[link_name = #link_destroy]
+                    fn __destroy(this: &mut ::std::mem::MaybeUninit<::cxx::CxxVector<#elem #ty_generics>>);
+                }
+                __destroy(this);
             }
         }
     }

--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -521,7 +521,19 @@ static_assert(sizeof(std::string) <= kMaxExpectedWordsInString * sizeof(void *),
   void cxxbridge1$unique_ptr$std$vector$##RUST_TYPE##$drop(                    \
       std::unique_ptr<std::vector<CXX_TYPE>> *ptr) noexcept {                  \
     ptr->~unique_ptr();                                                        \
-  }
+  }                                                                            \
+  void cxxbridge1$std$vector$##RUST_TYPE##$init(                               \
+      std::vector<CXX_TYPE>* s) noexcept {                                     \
+    new (s) std::vector<CXX_TYPE>;                                             \
+  }                                                                            \
+  void cxxbridge1$std$vector$##RUST_TYPE##$destroy(                            \
+      std::vector<CXX_TYPE>* s) noexcept {                                     \
+    s->~vector();                                                              \
+  }                                                                            \
+  static_assert(alignof(std::vector<CXX_TYPE>) <= alignof(void *),             \
+                "unexpectedly large std::vector alignment");                   \
+  static_assert(sizeof(std::vector<CXX_TYPE>) <= 8 * sizeof(void *),           \
+                "unexpectedly large std::vector size");
 
 #define STD_VECTOR_TRIVIAL_OPS(RUST_TYPE, CXX_TYPE)                            \
   void cxxbridge1$std$vector$##RUST_TYPE##$push_back(                          \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,6 +449,7 @@ pub type Vector<T> = CxxVector<T>;
 // Not public API.
 #[doc(hidden)]
 pub mod private {
+    pub use crate::cxx_vector::StackVector;
     pub use crate::cxx_vector::VectorElement;
     pub use crate::extern_type::{verify_extern_kind, verify_extern_type};
     pub use crate::function::FatFunction;

--- a/tests/cxx_vector.rs
+++ b/tests/cxx_vector.rs
@@ -1,7 +1,17 @@
 use cxx::{let_cxx_vector, CxxVector};
 
 #[test]
-fn test_cxx_vector() {
+fn test_cxx_vector_infer() {
+    let_cxx_vector!(v);
+
+    v.as_mut().push(12usize);
+    v.as_mut().push(13);
+
+    assert_eq!(v.len(), 2);
+}
+
+#[test]
+fn test_cxx_vector_ascribed() {
     let_cxx_vector!(v: CxxVector<i32>);
 
     v.as_mut().push(12);
@@ -11,11 +21,15 @@ fn test_cxx_vector() {
 }
 
 #[test]
-fn test_cxx_vector_infer() {
-    let_cxx_vector!(v);
+fn test_cxx_vector_lit() {
+    let_cxx_vector!(v = [1, 2, 3,]);
 
-    v.as_mut().push(12usize);
-    v.as_mut().push(13);
+    assert_eq!(v.len(), 3);
+}
 
-    assert_eq!(v.len(), 2);
+#[test]
+fn test_cxx_vector_lit_ascribed() {
+    let_cxx_vector!(v: CxxVector<usize> = [1, 2, 3, 4, 5,]);
+
+    assert_eq!(v.iter().sum::<usize>(), 15);
 }

--- a/tests/cxx_vector.rs
+++ b/tests/cxx_vector.rs
@@ -1,0 +1,21 @@
+use cxx::{let_cxx_vector, CxxVector};
+
+#[test]
+fn test_cxx_vector() {
+    let_cxx_vector!(v: CxxVector<i32>);
+
+    v.as_mut().push(12);
+    v.as_mut().push(13);
+
+    assert_eq!(v.len(), 2);
+}
+
+#[test]
+fn test_cxx_vector_infer() {
+    let_cxx_vector!(v);
+
+    v.as_mut().push(12usize);
+    v.as_mut().push(13);
+
+    assert_eq!(v.len(), 2);
+}


### PR DESCRIPTION
Implement `let_cxx_vector` macro, very similarly to `let_cxx_string`, to enable constructing a `CxxVector<T>` on the stack. 

Helps with calling methods that take `std::vector` as an out variable.