### PR TITLE
Update ui test suite to nightly-2021-08-12

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1127,9 +1127,11 @@ fn expand_rust_function_shim_super(
             Some(ret) => quote!(#ret),
             None => quote!(()),
         };
-        let impl_trait = quote_spanned!(result.span=> impl);
-        let display = quote_spanned!(rangle.span=> ::std::fmt::Display);
-        quote!(-> ::std::result::Result<#ok, #impl_trait #display>)
+        // Set spans that result in the `Result<...>` written by the user being
+        // highlighted as the cause if their error type has no Display impl.
+        let result_begin = quote_spanned!(result.span=> ::std::result::Result<#ok, impl);
+        let result_end = quote_spanned!(rangle.span=> ::std::fmt::Display>);
+        quote!(-> #result_begin #result_end)
     } else {
         expand_return_type(&sig.ret)
     };

--- a/tests/ui/array_len_suffix.stderr
+++ b/tests/ui/array_len_suffix.stderr
@@ -7,4 +7,4 @@ error[E0308]: mismatched types
 help: change the type of the numeric literal from `u16` to `usize`
   |
 4 |         fn array() -> [String; 12usize];
-  |                                ^^^^^^^
+  |                                ~~~~~~~

--- a/tests/ui/expected_named.stderr
+++ b/tests/ui/expected_named.stderr
@@ -8,4 +8,4 @@ error[E0106]: missing lifetime specifier
 help: consider using the `'static` lifetime
   |
 5 |         fn borrowed() -> UniquePtr<Borrowed<'static>>;
-  |                                    ^^^^^^^^^^^^^^^^^
+  |                                    ~~~~~~~~~~~~~~~~~

--- a/tests/ui/result_no_display.stderr
+++ b/tests/ui/result_no_display.stderr
@@ -1,9 +1,8 @@
 error[E0277]: `NonError` doesn't implement `std::fmt::Display`
- --> $DIR/result_no_display.rs:1:1
+ --> $DIR/result_no_display.rs:4:19
   |
-1 | #[cxx::bridge]
-  | ^^^^^^^^^^^^^^ `NonError` cannot be formatted with the default formatter
+4 |         fn f() -> Result<()>;
+  |                   ^^^^^^^^^^ `NonError` cannot be formatted with the default formatter
   |
   = help: the trait `std::fmt::Display` is not implemented for `NonError`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-  = note: this error originates in the attribute macro `cxx::bridge` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/result_no_display.stderr
+++ b/tests/ui/result_no_display.stderr
@@ -1,8 +1,9 @@
 error[E0277]: `NonError` doesn't implement `std::fmt::Display`
- --> $DIR/result_no_display.rs:4:19
+ --> $DIR/result_no_display.rs:1:1
   |
-4 |         fn f() -> Result<()>;
-  |                   ^^^^^^^^^^ `NonError` cannot be formatted with the default formatter
+1 | #[cxx::bridge]
+  | ^^^^^^^^^^^^^^ `NonError` cannot be formatted with the default formatter
   |
   = help: the trait `std::fmt::Display` is not implemented for `NonError`
   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+  = note: this error originates in the attribute macro `cxx::bridge` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/unsupported_elided.stderr
+++ b/tests/ui/unsupported_elided.stderr
@@ -16,4 +16,4 @@ error[E0106]: missing lifetime specifier
 help: consider introducing a named lifetime parameter
   |
 8 |         fn f<'a>(t: &'a T) -> &'a str;
-  |             ^^^^    ^^^^^     ^^^
+  |             ++++    ~~~~~     ~~~


### PR DESCRIPTION
Updates the span of the tokens around `impl ::std::fmt::Display` in the expansion of fallible extern Rust functions to account for some diagnostic changes from https://github.com/rust-lang/rust/pull/86532.