### PR TITLE
Bazel: build and execute proc-macro2 build script

### DIFF
--- a/third-party/BUILD
+++ b/third-party/BUILD
@@ -1,5 +1,6 @@
 load(
     "//tools/bazel:rust.bzl",
+    cargo_build_script = "third_party_cargo_build_script",
     glob = "third_party_glob",
     rust_library = "third_party_rust_library",
 )
@@ -50,13 +51,21 @@ rust_library(
         "proc-macro",
         "span-locations",
     ],
-    rustc_flags = [
-        "--cfg=span_locations",
-        "--cfg=use_proc_macro",
-        "--cfg=wrap_proc_macro",
-    ],
     visibility = ["//visibility:public"],
-    deps = [":unicode-xid"],
+    deps = [
+        ":proc-macro2@build",
+        ":unicode-xid",
+    ],
+)
+
+cargo_build_script(
+    name = "proc-macro2@build",
+    srcs = ["vendor/proc-macro2-1.0.28/build.rs"],
+    crate_features = [
+        "proc-macro",
+        "span-locations",
+    ],
+    crate_name = "build",
 )
 
 rust_library(

--- a/tools/bazel/rust.bzl
+++ b/tools/bazel/rust.bzl
@@ -1,6 +1,10 @@
 """A module wrapping the core rules of `rules_rust`"""
 
 load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    _cargo_build_script = "cargo_build_script",
+)
+load(
     "@rules_rust//rust:rust.bzl",
     _rust_binary = "rust_binary",
     _rust_library = "rust_library",
@@ -10,6 +14,13 @@ load("@third-party//:vendor.bzl", "vendored")
 
 def third_party_glob(include):
     return vendored and native.glob(include)
+
+def cargo_build_script(edition = "2018", **kwargs):
+    _cargo_build_script(edition = edition, **kwargs)
+
+def third_party_cargo_build_script(rustc_flags = [], **kwargs):
+    rustc_flags = rustc_flags + ["--cap-lints=allow"]
+    cargo_build_script(rustc_flags = rustc_flags, **kwargs)
 
 def rust_binary(edition = "2018", **kwargs):
     _rust_binary(edition = edition, **kwargs)


### PR DESCRIPTION
This uses the `cargo_build_script` rule introduced by https://github.com/bazelbuild/rules_rust/pull/320.