### PR TITLE
Don't shadow `pos` in C++ rust::Slice implementation

### DIFF
--- a/include/cxx.h
+++ b/include/cxx.h
@@ -540,8 +540,8 @@ bool Slice<T>::empty() const noexcept {
 template <typename T>
 T &Slice<T>::operator[](std::size_t n) const noexcept {
   assert(n < this->size());
-  auto index = static_cast<char *>(slicePtr(this)) + size_of<T>() * n;
-  return *reinterpret_cast<T *>(index);
+  auto ptr = static_cast<char *>(slicePtr(this)) + size_of<T>() * n;
+  return *reinterpret_cast<T *>(ptr);
 }
 
 template <typename T>
@@ -579,8 +579,8 @@ Slice<T>::iterator::operator->() const noexcept {
 template <typename T>
 typename Slice<T>::iterator::reference Slice<T>::iterator::operator[](
     typename Slice<T>::iterator::difference_type n) const noexcept {
-  auto index = static_cast<char *>(this->pos) + this->stride * n;
-  return *reinterpret_cast<T *>(index);
+  auto ptr = static_cast<char *>(this->pos) + this->stride * n;
+  return *reinterpret_cast<T *>(ptr);
 }
 
 template <typename T>


### PR DESCRIPTION
When linking the generated code into our C++ project, we have these errors since we compile with `-Wshadow`:

```
lib.rs.h:207:8: error: declaration shadows a field of 'rust::cxxbridge1::Slice::iterator' [-Werror,-Wshadow]
  auto pos = static_cast<char *>(this->pos) + this->stride * n;
       ^
lib.rs.h:126:9: note: previous declaration is here
  void *pos;
        ^
1 error generated.
```

This is fixed by a simple rename. 

Thanks for the review, and thanks for the great project!