### PR TITLE
Fix over-reserve in rust::String::c_str

### DIFF
--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -40,7 +40,8 @@ bool cxxbridge1$string$from_utf16(rust::String *self, const char16_t *ptr,
 void cxxbridge1$string$drop(rust::String *self) noexcept;
 const char *cxxbridge1$string$ptr(const rust::String *self) noexcept;
 std::size_t cxxbridge1$string$len(const rust::String *self) noexcept;
-void cxxbridge1$string$reserve_total(rust::String *self, size_t cap) noexcept;
+void cxxbridge1$string$reserve_additional(rust::String *self,
+                                          size_t additional) noexcept;
 
 // rust::Str
 void cxxbridge1$str$new(rust::Str *self) noexcept;
@@ -158,7 +159,7 @@ bool String::empty() const noexcept { return this->size() == 0; }
 
 const char *String::c_str() noexcept {
   auto len = this->length();
-  cxxbridge1$string$reserve_total(this, len + 1);
+  cxxbridge1$string$reserve_additional(this, 1);
   auto ptr = this->data();
   const_cast<char *>(ptr)[len] = '\0';
   return ptr;

--- a/src/symbols/rust_string.rs
+++ b/src/symbols/rust_string.rs
@@ -62,7 +62,7 @@ unsafe extern "C" fn string_len(this: &String) -> usize {
     this.len()
 }
 
-#[export_name = "cxxbridge1$string$reserve_total"]
-unsafe extern "C" fn string_reserve_total(this: &mut String, cap: usize) {
-    this.reserve(cap);
+#[export_name = "cxxbridge1$string$reserve_additional"]
+unsafe extern "C" fn string_reserve_additional(this: &mut String, additional: usize) {
+    this.reserve(additional);
 }


### PR DESCRIPTION
`reserve` in C++ means reserve total (ensures `this->capacity() >= new_cap`, see https://en.cppreference.com/w/cpp/string/basic_string/reserve) whereas `reserve` in Rust means reserve additional (ensures `self.capacity() >= self.length() + additional`, see https://doc.rust-lang.org/std/string/struct.String.html#method.reserve).

Previously `rust::String::c_str` was reserving too much capacity by passing `len + 1` to Rust's `reserve`, which is safe, but will almost always reallocate on the first `c_str` call even when not necessary.