### PR TITLE
Consistently use new_cap in signatures of reserve_total

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1467,7 +1467,7 @@ fn write_rust_vec_extern(out: &mut OutFile, key: NamedImplKey) {
     );
     writeln!(
         out,
-        "void cxxbridge1$rust_vec${}$reserve_total(::rust::Vec<{}> *ptr, ::std::size_t cap) noexcept;",
+        "void cxxbridge1$rust_vec${}$reserve_total(::rust::Vec<{}> *ptr, ::std::size_t new_cap) noexcept;",
         instance, inner,
     );
     writeln!(
@@ -1562,12 +1562,12 @@ fn write_rust_vec_impl(out: &mut OutFile, key: NamedImplKey) {
     begin_function_definition(out);
     writeln!(
         out,
-        "void Vec<{}>::reserve_total(::std::size_t cap) noexcept {{",
+        "void Vec<{}>::reserve_total(::std::size_t new_cap) noexcept {{",
         inner,
     );
     writeln!(
         out,
-        "  return cxxbridge1$rust_vec${}$reserve_total(this, cap);",
+        "  return cxxbridge1$rust_vec${}$reserve_total(this, new_cap);",
         instance,
     );
     writeln!(out, "}}");

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -338,7 +338,7 @@ public:
   Vec(unsafe_bitcopy_t, const Vec &) noexcept;
 
 private:
-  void reserve_total(std::size_t cap) noexcept;
+  void reserve_total(std::size_t new_cap) noexcept;
   void set_len(std::size_t len) noexcept;
   void drop() noexcept;
 

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1301,8 +1301,8 @@ fn expand_rust_vec(key: NamedImplKey, types: &Types, explicit_impl: Option<&Impl
         }
         #[doc(hidden)]
         #[export_name = #link_reserve_total]
-        unsafe extern "C" fn #local_reserve_total #impl_generics(this: *mut ::cxx::private::RustVec<#elem #ty_generics>, cap: usize) {
-            (*this).reserve_total(cap);
+        unsafe extern "C" fn #local_reserve_total #impl_generics(this: *mut ::cxx::private::RustVec<#elem #ty_generics>, new_cap: usize) {
+            (*this).reserve_total(new_cap);
         }
         #[doc(hidden)]
         #[export_name = #link_set_len]

--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -550,7 +550,7 @@ static_assert(sizeof(std::string) <= kMaxExpectedWordsInString * sizeof(void *),
   const CXX_TYPE *cxxbridge1$rust_vec$##RUST_TYPE##$data(                      \
       const rust::Vec<CXX_TYPE> *ptr) noexcept;                                \
   void cxxbridge1$rust_vec$##RUST_TYPE##$reserve_total(                        \
-      rust::Vec<CXX_TYPE> *ptr, std::size_t cap) noexcept;                     \
+      rust::Vec<CXX_TYPE> *ptr, std::size_t new_cap) noexcept;                 \
   void cxxbridge1$rust_vec$##RUST_TYPE##$set_len(rust::Vec<CXX_TYPE> *ptr,     \
                                                  std::size_t len) noexcept;
 
@@ -576,8 +576,8 @@ static_assert(sizeof(std::string) <= kMaxExpectedWordsInString * sizeof(void *),
     return cxxbridge1$rust_vec$##RUST_TYPE##$data(this);                       \
   }                                                                            \
   template <>                                                                  \
-  void Vec<CXX_TYPE>::reserve_total(std::size_t cap) noexcept {                \
-    cxxbridge1$rust_vec$##RUST_TYPE##$reserve_total(this, cap);                \
+  void Vec<CXX_TYPE>::reserve_total(std::size_t new_cap) noexcept {            \
+    cxxbridge1$rust_vec$##RUST_TYPE##$reserve_total(this, new_cap);            \
   }                                                                            \
   template <>                                                                  \
   void Vec<CXX_TYPE>::set_len(std::size_t len) noexcept {                      \

--- a/src/rust_vec.rs
+++ b/src/rust_vec.rs
@@ -56,11 +56,11 @@ impl<T> RustVec<T> {
         self.as_vec().as_ptr()
     }
 
-    pub fn reserve_total(&mut self, cap: usize) {
+    pub fn reserve_total(&mut self, new_cap: usize) {
         let vec = self.as_mut_vec();
         let len = vec.len();
-        if cap > len {
-            vec.reserve(cap - len);
+        if new_cap > len {
+            vec.reserve(new_cap - len);
         }
     }
 

--- a/src/symbols/rust_vec.rs
+++ b/src/symbols/rust_vec.rs
@@ -44,8 +44,8 @@ macro_rules! rust_vec_shims {
             }
             attr! {
                 #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$reserve_total")]
-                unsafe extern "C" fn __reserve_total(this: *mut RustVec<$ty>, cap: usize) {
-                    (*this).reserve_total(cap);
+                unsafe extern "C" fn __reserve_total(this: *mut RustVec<$ty>, new_cap: usize) {
+                    (*this).reserve_total(new_cap);
                 }
             }
             attr! {


### PR DESCRIPTION
This is the argument name given in https://en.cppreference.com/w/cpp/string/basic_string/reserve and https://en.cppreference.com/w/cpp/container/vector/reserve.

https://github.com/cplusplus/draft/blob/f66f72a92c5c9ce108f8b7ceadcafc4c70adae83/source/strings.tex#L871 uses `res_arg`, and https://github.com/cplusplus/draft/blob/f66f72a92c5c9ce108f8b7ceadcafc4c70adae83/source/containers.tex#L5741 uses `n`, but new_cap is the clearest of the three.