### PR TITLE
Adopt unsafe_op_in_unsafe_fn style

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,6 +28,12 @@ fn main() {
                 rustc.version,
             );
         }
+
+        if rustc.minor < 52 {
+            // #![deny(unsafe_op_in_unsafe_fn)].
+            // https://github.com/rust-lang/rust/issues/71668
+            println!("cargo:rustc-cfg=no_unsafe_op_in_unsafe_fn_lint");
+        }
     }
 }
 

--- a/src/cxx_string.rs
+++ b/src/cxx_string.rs
@@ -240,9 +240,11 @@ impl StackString {
 
     pub unsafe fn init(&mut self, value: impl AsRef<[u8]>) -> Pin<&mut CxxString> {
         let value = value.as_ref();
-        let this = &mut *self.space.as_mut_ptr().cast::<MaybeUninit<CxxString>>();
-        string_init(this, value.as_ptr(), value.len());
-        Pin::new_unchecked(&mut *this.as_mut_ptr())
+        unsafe {
+            let this = &mut *self.space.as_mut_ptr().cast::<MaybeUninit<CxxString>>();
+            string_init(this, value.as_ptr(), value.len());
+            Pin::new_unchecked(&mut *this.as_mut_ptr())
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,6 +366,8 @@
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/cxx/1.0.53")]
 #![deny(improper_ctypes, improper_ctypes_definitions, missing_docs)]
+#![cfg_attr(not(no_unsafe_op_in_unsafe_fn_lint), deny(unsafe_op_in_unsafe_fn))]
+#![cfg_attr(no_unsafe_op_in_unsafe_fn_lint, allow(unused_unsafe))]
 #![allow(non_camel_case_types)]
 #![allow(
     clippy::cognitive_complexity,

--- a/src/rust_slice.rs
+++ b/src/rust_slice.rs
@@ -26,13 +26,13 @@ impl RustSlice {
     pub unsafe fn as_slice<'a, T>(self) -> &'a [T] {
         let ptr = self.as_non_null_ptr().as_ptr();
         let len = self.len();
-        slice::from_raw_parts(ptr, len)
+        unsafe { slice::from_raw_parts(ptr, len) }
     }
 
     pub unsafe fn as_mut_slice<'a, T>(self) -> &'a mut [T] {
         let ptr = self.as_non_null_ptr().as_ptr();
         let len = self.len();
-        slice::from_raw_parts_mut(ptr, len)
+        unsafe { slice::from_raw_parts_mut(ptr, len) }
     }
 
     pub(crate) fn from_raw_parts<T>(ptr: NonNull<T>, len: usize) -> Self {

--- a/src/rust_str.rs
+++ b/src/rust_str.rs
@@ -17,8 +17,10 @@ impl RustStr {
     }
 
     pub unsafe fn as_str<'a>(self) -> &'a str {
-        let repr = mem::transmute::<RustStr, NonNull<str>>(self);
-        &*repr.as_ptr()
+        unsafe {
+            let repr = mem::transmute::<RustStr, NonNull<str>>(self);
+            &*repr.as_ptr()
+        }
     }
 }
 

--- a/src/rust_vec.rs
+++ b/src/rust_vec.rs
@@ -65,7 +65,7 @@ impl<T> RustVec<T> {
     }
 
     pub unsafe fn set_len(&mut self, len: usize) {
-        self.as_mut_vec().set_len(len);
+        unsafe { self.as_mut_vec().set_len(len) }
     }
 }
 

--- a/src/shared_ptr.rs
+++ b/src/shared_ptr.rs
@@ -216,7 +216,7 @@ macro_rules! impl_shared_ptr_target {
                         fn __null(new: *mut c_void);
                     }
                 }
-                __null(new);
+                unsafe { __null(new) }
             }
             #[doc(hidden)]
             unsafe fn __new(value: Self, new: *mut c_void) {
@@ -226,7 +226,7 @@ macro_rules! impl_shared_ptr_target {
                         fn __uninit(new: *mut c_void) -> *mut c_void;
                     }
                 }
-                __uninit(new).cast::<$ty>().write(value);
+                unsafe { __uninit(new).cast::<$ty>().write(value) }
             }
             #[doc(hidden)]
             unsafe fn __clone(this: *const c_void, new: *mut c_void) {
@@ -236,7 +236,7 @@ macro_rules! impl_shared_ptr_target {
                         fn __clone(this: *const c_void, new: *mut c_void);
                     }
                 }
-                __clone(this, new);
+                unsafe { __clone(this, new) }
             }
             #[doc(hidden)]
             unsafe fn __get(this: *const c_void) -> *const Self {
@@ -246,7 +246,7 @@ macro_rules! impl_shared_ptr_target {
                         fn __get(this: *const c_void) -> *const c_void;
                     }
                 }
-                __get(this).cast()
+                unsafe { __get(this) }.cast()
             }
             #[doc(hidden)]
             unsafe fn __drop(this: *mut c_void) {
@@ -256,7 +256,7 @@ macro_rules! impl_shared_ptr_target {
                         fn __drop(this: *mut c_void);
                     }
                 }
-                __drop(this);
+                unsafe { __drop(this) }
             }
         }
     };

--- a/src/symbols/exception.rs
+++ b/src/symbols/exception.rs
@@ -4,7 +4,7 @@ use core::slice;
 
 #[export_name = "cxxbridge1$exception"]
 unsafe extern "C" fn exception(ptr: *const u8, len: usize) -> *const u8 {
-    let slice = slice::from_raw_parts(ptr, len);
+    let slice = unsafe { slice::from_raw_parts(ptr, len) };
     let boxed = String::from_utf8_lossy(slice).into_owned().into_boxed_str();
     Box::leak(boxed).as_ptr()
 }

--- a/src/symbols/rust_slice.rs
+++ b/src/symbols/rust_slice.rs
@@ -4,8 +4,9 @@ use core::ptr::{self, NonNull};
 
 #[export_name = "cxxbridge1$slice$new"]
 unsafe extern "C" fn slice_new(this: &mut MaybeUninit<RustSlice>, ptr: NonNull<()>, len: usize) {
+    let this = this.as_mut_ptr();
     let rust_slice = RustSlice::from_raw_parts(ptr, len);
-    ptr::write(this.as_mut_ptr(), rust_slice);
+    unsafe { ptr::write(this, rust_slice) }
 }
 
 #[export_name = "cxxbridge1$slice$ptr"]

--- a/src/symbols/rust_str.rs
+++ b/src/symbols/rust_str.rs
@@ -6,20 +6,24 @@ use core::str;
 
 #[export_name = "cxxbridge1$str$new"]
 unsafe extern "C" fn str_new(this: &mut MaybeUninit<&str>) {
-    ptr::write(this.as_mut_ptr(), "");
+    let this = this.as_mut_ptr();
+    unsafe { ptr::write(this, "") }
 }
 
 #[export_name = "cxxbridge1$str$ref"]
 unsafe extern "C" fn str_ref<'a>(this: &mut MaybeUninit<&'a str>, string: &'a String) {
-    ptr::write(this.as_mut_ptr(), string.as_str());
+    let this = this.as_mut_ptr();
+    let s = string.as_str();
+    unsafe { ptr::write(this, s) }
 }
 
 #[export_name = "cxxbridge1$str$from"]
 unsafe extern "C" fn str_from(this: &mut MaybeUninit<&str>, ptr: *const u8, len: usize) -> bool {
-    let slice = slice::from_raw_parts(ptr, len);
+    let slice = unsafe { slice::from_raw_parts(ptr, len) };
     match str::from_utf8(slice) {
         Ok(s) => {
-            ptr::write(this.as_mut_ptr(), s);
+            let this = this.as_mut_ptr();
+            unsafe { ptr::write(this, s) }
             true
         }
         Err(_) => false,

--- a/src/symbols/rust_string.rs
+++ b/src/symbols/rust_string.rs
@@ -7,12 +7,16 @@ use core::str;
 
 #[export_name = "cxxbridge1$string$new"]
 unsafe extern "C" fn string_new(this: &mut MaybeUninit<String>) {
-    ptr::write(this.as_mut_ptr(), String::new());
+    let this = this.as_mut_ptr();
+    let new = String::new();
+    unsafe { ptr::write(this, new) }
 }
 
 #[export_name = "cxxbridge1$string$clone"]
 unsafe extern "C" fn string_clone(this: &mut MaybeUninit<String>, other: &String) {
-    ptr::write(this.as_mut_ptr(), other.clone());
+    let this = this.as_mut_ptr();
+    let clone = other.clone();
+    unsafe { ptr::write(this, clone) }
 }
 
 #[export_name = "cxxbridge1$string$from_utf8"]
@@ -21,10 +25,12 @@ unsafe extern "C" fn string_from_utf8(
     ptr: *const u8,
     len: usize,
 ) -> bool {
-    let slice = slice::from_raw_parts(ptr, len);
+    let slice = unsafe { slice::from_raw_parts(ptr, len) };
     match str::from_utf8(slice) {
         Ok(s) => {
-            ptr::write(this.as_mut_ptr(), s.to_owned());
+            let this = this.as_mut_ptr();
+            let owned = s.to_owned();
+            unsafe { ptr::write(this, owned) }
             true
         }
         Err(_) => false,
@@ -37,10 +43,11 @@ unsafe extern "C" fn string_from_utf16(
     ptr: *const u16,
     len: usize,
 ) -> bool {
-    let slice = slice::from_raw_parts(ptr, len);
+    let slice = unsafe { slice::from_raw_parts(ptr, len) };
     match String::from_utf16(slice) {
         Ok(s) => {
-            ptr::write(this.as_mut_ptr(), s);
+            let this = this.as_mut_ptr();
+            unsafe { ptr::write(this, s) }
             true
         }
         Err(_) => false,
@@ -49,7 +56,7 @@ unsafe extern "C" fn string_from_utf16(
 
 #[export_name = "cxxbridge1$string$drop"]
 unsafe extern "C" fn string_drop(this: &mut ManuallyDrop<String>) {
-    ManuallyDrop::drop(this);
+    unsafe { ManuallyDrop::drop(this) }
 }
 
 #[export_name = "cxxbridge1$string$ptr"]

--- a/src/symbols/rust_vec.rs
+++ b/src/symbols/rust_vec.rs
@@ -15,43 +15,43 @@ macro_rules! rust_vec_shims {
             attr! {
                 #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$new")]
                 unsafe extern "C" fn __new(this: *mut RustVec<$ty>) {
-                    ptr::write(this, RustVec::new());
+                    unsafe { ptr::write(this, RustVec::new()) }
                 }
             }
             attr! {
                 #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$drop")]
                 unsafe extern "C" fn __drop(this: *mut RustVec<$ty>) {
-                    ptr::drop_in_place(this);
+                    unsafe { ptr::drop_in_place(this) }
                 }
             }
             attr! {
                 #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$len")]
                 unsafe extern "C" fn __len(this: *const RustVec<$ty>) -> usize {
-                    (*this).len()
+                    unsafe { &*this }.len()
                 }
             }
             attr! {
                 #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$capacity")]
                 unsafe extern "C" fn __capacity(this: *const RustVec<$ty>) -> usize {
-                    (*this).capacity()
+                    unsafe { &*this }.capacity()
                 }
             }
             attr! {
                 #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$data")]
                 unsafe extern "C" fn __data(this: *const RustVec<$ty>) -> *const $ty {
-                    (*this).as_ptr()
+                    unsafe { &*this }.as_ptr()
                 }
             }
             attr! {
                 #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$reserve_total")]
                 unsafe extern "C" fn __reserve_total(this: *mut RustVec<$ty>, new_cap: usize) {
-                    (*this).reserve_total(new_cap);
+                    unsafe { &mut *this }.reserve_total(new_cap);
                 }
             }
             attr! {
                 #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$set_len")]
                 unsafe extern "C" fn __set_len(this: *mut RustVec<$ty>, len: usize) {
-                    (*this).set_len(len);
+                    unsafe { (*this).set_len(len) }
                 }
             }
         };

--- a/src/unique_ptr.rs
+++ b/src/unique_ptr.rs
@@ -103,7 +103,7 @@ where
     /// twice on the same raw pointer.
     pub unsafe fn from_raw(raw: *mut T) -> Self {
         UniquePtr {
-            repr: T::__raw(raw),
+            repr: unsafe { T::__raw(raw) },
             ty: PhantomData,
         }
     }
@@ -256,20 +256,20 @@ unsafe impl UniquePtrTarget for CxxString {
     #[doc(hidden)]
     unsafe fn __raw(raw: *mut Self) -> MaybeUninit<*mut c_void> {
         let mut repr = MaybeUninit::uninit();
-        unique_ptr_std_string_raw(&mut repr, raw);
+        unsafe { unique_ptr_std_string_raw(&mut repr, raw) }
         repr
     }
     #[doc(hidden)]
     unsafe fn __get(repr: MaybeUninit<*mut c_void>) -> *const Self {
-        unique_ptr_std_string_get(&repr)
+        unsafe { unique_ptr_std_string_get(&repr) }
     }
     #[doc(hidden)]
     unsafe fn __release(mut repr: MaybeUninit<*mut c_void>) -> *mut Self {
-        unique_ptr_std_string_release(&mut repr)
+        unsafe { unique_ptr_std_string_release(&mut repr) }
     }
     #[doc(hidden)]
     unsafe fn __drop(mut repr: MaybeUninit<*mut c_void>) {
-        unique_ptr_std_string_drop(&mut repr);
+        unsafe { unique_ptr_std_string_drop(&mut repr) }
     }
 }
 
@@ -287,18 +287,18 @@ where
     }
     #[doc(hidden)]
     unsafe fn __raw(raw: *mut Self) -> MaybeUninit<*mut c_void> {
-        T::__unique_ptr_raw(raw)
+        unsafe { T::__unique_ptr_raw(raw) }
     }
     #[doc(hidden)]
     unsafe fn __get(repr: MaybeUninit<*mut c_void>) -> *const Self {
-        T::__unique_ptr_get(repr)
+        unsafe { T::__unique_ptr_get(repr) }
     }
     #[doc(hidden)]
     unsafe fn __release(repr: MaybeUninit<*mut c_void>) -> *mut Self {
-        T::__unique_ptr_release(repr)
+        unsafe { T::__unique_ptr_release(repr) }
     }
     #[doc(hidden)]
     unsafe fn __drop(repr: MaybeUninit<*mut c_void>) {
-        T::__unique_ptr_drop(repr);
+        unsafe { T::__unique_ptr_drop(repr) }
     }
 }

--- a/src/weak_ptr.rs
+++ b/src/weak_ptr.rs
@@ -126,7 +126,7 @@ macro_rules! impl_weak_ptr_target {
                         fn __null(new: *mut c_void);
                     }
                 }
-                __null(new);
+                unsafe { __null(new) }
             }
             #[doc(hidden)]
             unsafe fn __clone(this: *const c_void, new: *mut c_void) {
@@ -136,7 +136,7 @@ macro_rules! impl_weak_ptr_target {
                         fn __clone(this: *const c_void, new: *mut c_void);
                     }
                 }
-                __clone(this, new);
+                unsafe { __clone(this, new) }
             }
             #[doc(hidden)]
             unsafe fn __downgrade(shared: *const c_void, weak: *mut c_void) {
@@ -146,7 +146,7 @@ macro_rules! impl_weak_ptr_target {
                         fn __downgrade(shared: *const c_void, weak: *mut c_void);
                     }
                 }
-                __downgrade(shared, weak);
+                unsafe { __downgrade(shared, weak) }
             }
             #[doc(hidden)]
             unsafe fn __upgrade(weak: *const c_void, shared: *mut c_void) {
@@ -156,7 +156,7 @@ macro_rules! impl_weak_ptr_target {
                         fn __upgrade(weak: *const c_void, shared: *mut c_void);
                     }
                 }
-                __upgrade(weak, shared);
+                unsafe { __upgrade(weak, shared) }
             }
             #[doc(hidden)]
             unsafe fn __drop(this: *mut c_void) {
@@ -166,7 +166,7 @@ macro_rules! impl_weak_ptr_target {
                         fn __drop(this: *mut c_void);
                     }
                 }
-                __drop(this);
+                unsafe { __drop(this) }
             }
         }
     };


### PR DESCRIPTION
I have found this valuable in https://github.com/dtolnay/semver to identify what subset of the implementation of an unsafe fn is really the unsafe part.

I wouldn't be surprised if this style were default in some future edition.