### PR TITLE
Expose reserve on CxxString

### DIFF
--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -24,6 +24,11 @@ std::size_t cxxbridge1$cxx_string$length(const std::string &s) noexcept {
 
 void cxxbridge1$cxx_string$clear(std::string &s) noexcept { s.clear(); }
 
+void cxxbridge1$cxx_string$reserve_total(std::string &s,
+                                         size_t new_cap) noexcept {
+  s.reserve(new_cap);
+}
+
 void cxxbridge1$cxx_string$push(std::string &s, const std::uint8_t *ptr,
                                 std::size_t len) noexcept {
   s.append(reinterpret_cast<const char *>(ptr), len);


### PR DESCRIPTION
This has come up as necessary in APIs that connect `bytes`-based code in Rust to `std::string`-based code in C++.

```rust
use bytes::Buf;
use cxx::let_cxx_string;

fn thing(buf: &mut dyn Buf) {
    let_cxx_string!(string = "");

    // handled by helper:
    string.as_mut().reserve(buf.remaining());
    while buf.remaining() > 0 {
        let chunk = buf.chunk();
        string.as_mut().push_bytes(chunk);
        buf.advance(chunk.len());
    }

    ffi::thing(string);
}

// ffi::thing:
// void thing(std::string& s) {
//   WriteMessage msg{std::move(s)};
//   ...
// }
```