### PR TITLE
Add crt-static feature for msvc

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(feature = "crt-static")']
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ default = ["cxxbridge-flags/default"] # c++11
 "c++14" = ["cxxbridge-flags/c++14"]
 "c++17" = ["cxxbridge-flags/c++17"]
 "c++20" = ["cxxbridge-flags/c++20"]
+"crt-static" = []
 
 [dependencies]
 cxxbridge-macro = { version = "=1.0.54", path = "macro" }

--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,7 @@ fn main() {
         .file("src/cxx.cc")
         .cpp(true)
         .cpp_link_stdlib(None) // linked via link-cplusplus crate
+        .static_crt(cfg!(feature = "crt-static"))
         .flag_if_supported(cxxbridge_flags::STD)
         .warnings_into_errors(cfg!(deny_warnings))
         .compile("cxxbridge1");


### PR DESCRIPTION
I have some static C++ libraries I'd like to link against on Windows with MSVC, and they are built with the `/MT` flag for the static CRT. If there's a mismatch with any statically linked libraries, the link fails. I can tweak the `cc::Build` for my own files built with `cxx` by adding `static_crt(true)`, but there's currently no way to configure the flags for `cxx.cc` which is built from `cxx` as part of its own `build.rs` script.

In my project, I also have a .cargo/config.toml file with this option, which makes the Rust object files link against the static CRT as well:

```toml
[target.x86_64-pc-windows-msvc]
rustflags = ["-C", "target-feature=+crt-static"]
```

I added that to this change in `cxx`, but gated on `cfg(feature = "crt-static")` instead of the triplet, so it can still link the Rust objects with the C++ objects anytime this feature is enabled. Consumers may still need to enable that in their own crates separately, I don't think they'll automatically pick this setting up from the `cxx` `config.toml`. But that should only impact consumers who are opting into this feature already.