### PR TITLE
Re-enable clippy after upstream crash fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,7 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
-    #if: github.event_name != 'pull_request'
-    if: false  # Clippy crash: https://github.com/rust-lang/rust-clippy/issues/7423
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@clippy

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -51,6 +51,7 @@
     clippy::doc_markdown,
     clippy::drop_copy,
     clippy::enum_glob_use,
+    clippy::if_same_then_else,
     clippy::inherent_to_string,
     clippy::items_after_statements,
     clippy::let_underscore_drop,

--- a/gen/cmd/src/main.rs
+++ b/gen/cmd/src/main.rs
@@ -3,6 +3,7 @@
     clippy::cognitive_complexity,
     clippy::default_trait_access,
     clippy::enum_glob_use,
+    clippy::if_same_then_else,
     clippy::inherent_to_string,
     clippy::items_after_statements,
     clippy::large_enum_variant,

--- a/gen/lib/src/lib.rs
+++ b/gen/lib/src/lib.rs
@@ -12,6 +12,7 @@
     clippy::cast_sign_loss,
     clippy::default_trait_access,
     clippy::enum_glob_use,
+    clippy::if_same_then_else,
     clippy::inherent_to_string,
     clippy::items_after_statements,
     clippy::match_bool,

--- a/macro/src/derive.rs
+++ b/macro/src/derive.rs
@@ -151,6 +151,7 @@ fn struct_default(strct: &Struct, span: Span) -> TokenStream {
     let fields = strct.fields.iter().map(|field| &field.name.rust);
 
     quote_spanned! {span=>
+        #[allow(clippy::derivable_impls)] // different spans than the derived impl
         impl #generics ::std::default::Default for #ident #generics {
             fn default() -> Self {
                 #ident {

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -3,7 +3,6 @@
     clippy::default_trait_access,
     clippy::doc_markdown,
     clippy::enum_glob_use,
-    clippy::filter_map,
     clippy::if_same_then_else,
     clippy::inherent_to_string,
     clippy::items_after_statements,

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -4,6 +4,7 @@
     clippy::doc_markdown,
     clippy::enum_glob_use,
     clippy::filter_map,
+    clippy::if_same_then_else,
     clippy::inherent_to_string,
     clippy::items_after_statements,
     clippy::large_enum_variant,


### PR DESCRIPTION
The Clippy crash that caused us to disable it (https://github.com/rust-lang/rust-clippy/issues/7423) was fixed in https://github.com/rust-lang/rust-clippy/pull/7428 + https://github.com/rust-lang/rust/pull/87152 in nightly-2021-07-16.