### PR TITLE
Add Vec clear

### DIFF
--- a/book/src/binding/vec.md
+++ b/book/src/binding/vec.md
@@ -45,6 +45,7 @@ public:
   void reserve(size_t new_cap);
   void push_back(const T &value);
   void push_back(T &&value);
+  void clear();
   template <typename... Args>
   void emplace_back(Args &&...args);
 

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1590,6 +1590,7 @@ fn write_rust_vec_impl(out: &mut OutFile, key: NamedImplKey) {
         instance,
     );
     writeln!(out, "}}");
+    writeln!(out, "template <>");
     begin_function_definition(out);
     writeln!(
         out,

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1475,6 +1475,11 @@ fn write_rust_vec_extern(out: &mut OutFile, key: NamedImplKey) {
         "void cxxbridge1$rust_vec${}$set_len(::rust::Vec<{}> *ptr, ::std::size_t len) noexcept;",
         instance, inner,
     );
+    writeln!(
+        out,
+        "void cxxbridge1$rust_vec${}$clear(::rust::Vec<{}> *ptr) noexcept;",
+        instance, inner,
+    );
 }
 
 fn write_rust_box_impl(out: &mut OutFile, key: NamedImplKey) {
@@ -1582,6 +1587,18 @@ fn write_rust_vec_impl(out: &mut OutFile, key: NamedImplKey) {
     writeln!(
         out,
         "  return cxxbridge1$rust_vec${}$set_len(this, len);",
+        instance,
+    );
+    writeln!(out, "}}");
+    begin_function_definition(out);
+    writeln!(
+        out,
+        "void Vec<{}>::clear() noexcept {{",
+        inner,
+    );
+    writeln!(
+        out,
+        "  return cxxbridge1$rust_vec${}$clear(this);",
         instance,
     );
     writeln!(out, "}}");

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -318,11 +318,11 @@ public:
   T &at(std::size_t n);
   T &front() noexcept;
   T &back() noexcept;
+  void clear() noexcept;
 
   void reserve(std::size_t new_cap);
   void push_back(const T &value);
   void push_back(T &&value);
-  void clear();
   template <typename... Args>
   void emplace_back(Args &&...args);
 
@@ -932,11 +932,6 @@ void Vec<T>::push_back(const T &value) {
 template <typename T>
 void Vec<T>::push_back(T &&value) {
   this->emplace_back(std::move(value));
-}
-
-template <typename T>
-void Vec<T>::clear() {
-  this->set_len(0);
 }
 
 template <typename T>

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -322,6 +322,7 @@ public:
   void reserve(std::size_t new_cap);
   void push_back(const T &value);
   void push_back(T &&value);
+  void clear();
   template <typename... Args>
   void emplace_back(Args &&...args);
 
@@ -931,6 +932,11 @@ void Vec<T>::push_back(const T &value) {
 template <typename T>
 void Vec<T>::push_back(T &&value) {
   this->emplace_back(std::move(value));
+}
+
+template <typename T>
+void Vec<T>::clear() {
+  this->set_len(0);
 }
 
 template <typename T>

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1255,6 +1255,7 @@ fn expand_rust_vec(key: NamedImplKey, types: &Types, explicit_impl: Option<&Impl
     let link_data = format!("{}data", link_prefix);
     let link_reserve_total = format!("{}reserve_total", link_prefix);
     let link_set_len = format!("{}set_len", link_prefix);
+    let link_clear = format!("{}clear", link_prefix);
 
     let local_prefix = format_ident!("{}__vec_", elem);
     let local_new = format_ident!("{}new", local_prefix);
@@ -1264,6 +1265,7 @@ fn expand_rust_vec(key: NamedImplKey, types: &Types, explicit_impl: Option<&Impl
     let local_data = format_ident!("{}data", local_prefix);
     let local_reserve_total = format_ident!("{}reserve_total", local_prefix);
     let local_set_len = format_ident!("{}set_len", local_prefix);
+    let local_clear = format_ident!("{}clear", local_prefix);
 
     let (impl_generics, ty_generics) = generics::split_for_impl(key, explicit_impl, resolve);
 
@@ -1308,6 +1310,11 @@ fn expand_rust_vec(key: NamedImplKey, types: &Types, explicit_impl: Option<&Impl
         #[export_name = #link_set_len]
         unsafe extern "C" fn #local_set_len #impl_generics(this: *mut ::cxx::private::RustVec<#elem #ty_generics>, len: usize) {
             (*this).set_len(len);
+        }
+        #[doc(hidden)]
+        #[export_name = #link_clear]
+        unsafe extern "C" fn #local_clear #impl_generics(this: *mut ::cxx::private::RustVec<#elem #ty_generics>) {
+            (*this).clear();
         }
     }
 }

--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -567,6 +567,8 @@ static_assert(sizeof(std::string) <= kMaxExpectedWordsInString * sizeof(void *),
       const rust::Vec<CXX_TYPE> *ptr) noexcept;                                \
   void cxxbridge1$rust_vec$##RUST_TYPE##$reserve_total(                        \
       rust::Vec<CXX_TYPE> *ptr, std::size_t new_cap) noexcept;                 \
+  void cxxbridge1$rust_vec$##RUST_TYPE##$clear(                                \
+      rust::Vec<CXX_TYPE> *ptr) noexcept;                                      \
   void cxxbridge1$rust_vec$##RUST_TYPE##$set_len(rust::Vec<CXX_TYPE> *ptr,     \
                                                  std::size_t len) noexcept;
 
@@ -598,7 +600,11 @@ static_assert(sizeof(std::string) <= kMaxExpectedWordsInString * sizeof(void *),
   template <>                                                                  \
   void Vec<CXX_TYPE>::set_len(std::size_t len) noexcept {                      \
     cxxbridge1$rust_vec$##RUST_TYPE##$set_len(this, len);                      \
-  }
+  }                                                                            \
+  template <>                                                                  \
+  void Vec<CXX_TYPE>::clear() noexcept {                                       \
+    cxxbridge1$rust_vec$##RUST_TYPE##$clear(this);                             \
+  }   
 
 #define SHARED_PTR_OPS(RUST_TYPE, CXX_TYPE)                                    \
   static_assert(sizeof(std::shared_ptr<CXX_TYPE>) == 2 * sizeof(void *), "");  \

--- a/src/rust_vec.rs
+++ b/src/rust_vec.rs
@@ -67,6 +67,10 @@ impl<T> RustVec<T> {
     pub unsafe fn set_len(&mut self, len: usize) {
         unsafe { self.as_mut_vec().set_len(len) }
     }
+
+    pub fn clear(&mut self) {
+        self.as_mut_vec().clear()
+    }
 }
 
 impl RustVec<RustString> {

--- a/src/symbols/rust_vec.rs
+++ b/src/symbols/rust_vec.rs
@@ -54,6 +54,12 @@ macro_rules! rust_vec_shims {
                     unsafe { (*this).set_len(len) }
                 }
             }
+            attr! {
+                #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$clear")]
+                unsafe extern "C" fn __clear(this: *mut RustVec<$ty>) {
+                    unsafe { (*this).clear() }
+                }
+            }
         };
     };
 }

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -149,6 +149,7 @@ pub mod ffi {
         fn c_take_rust_vec_index(v: Vec<u8>);
         fn c_take_rust_vec_shared_index(v: Vec<Shared>);
         fn c_take_rust_vec_shared_push(v: Vec<Shared>);
+        fn c_take_rust_vec_shared_clear(v: Vec<Shared>);
         fn c_take_rust_vec_shared_forward_iterator(v: Vec<Shared>);
         fn c_take_rust_vec_shared_sort(v: Vec<Shared>);
         fn c_take_ref_rust_vec(v: &Vec<u8>);

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -452,6 +452,13 @@ void c_take_rust_vec_shared_push(rust::Vec<Shared> v) {
   }
 }
 
+void c_take_rust_vec_shared_clear(rust::Vec<Shared> v) {
+  v.clear();
+  if (v.size() == 0) {
+    cxx_test_suite_set_correct();
+  }
+}
+
 void c_take_ref_rust_vec(const rust::Vec<uint8_t> &v) {
   uint8_t sum = std::accumulate(v.begin(), v.end(), 0);
   if (sum == 200) {

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -152,6 +152,7 @@ void c_take_rust_vec_nested_ns_shared(rust::Vec<::A::B::ABShared> v);
 void c_take_rust_vec_string(rust::Vec<rust::String> v);
 void c_take_rust_vec_shared_index(rust::Vec<Shared> v);
 void c_take_rust_vec_shared_push(rust::Vec<Shared> v);
+void c_take_rust_vec_shared_clear(rust::Vec<Shared> v);
 void c_take_rust_vec_shared_forward_iterator(rust::Vec<Shared> v);
 void c_take_rust_vec_shared_sort(rust::Vec<Shared> v);
 void c_take_ref_rust_vec(const rust::Vec<uint8_t> &v);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -167,6 +167,7 @@ fn test_c_take() {
     check!(ffi::c_take_rust_vec_shared(shared_test_vec.clone()));
     check!(ffi::c_take_rust_vec_shared_index(shared_test_vec.clone()));
     check!(ffi::c_take_rust_vec_shared_push(shared_test_vec.clone()));
+    check!(ffi::c_take_rust_vec_shared_clear(shared_test_vec.clone()));
     check!(ffi::c_take_rust_vec_shared_forward_iterator(
         shared_test_vec,
     ));


### PR DESCRIPTION
Added a `clear` method to rust::Vec to address https://github.com/dtolnay/cxx/issues/950.

Closes #950.