### PR TITLE
Pass through serde attributes

### DIFF
--- a/syntax/attrs.rs
+++ b/syntax/attrs.rs
@@ -143,6 +143,9 @@ pub fn parse(cx: &mut Errors, attrs: Vec<Attribute>, mut parser: Parser) -> Othe
             // https://doc.rust-lang.org/reference/attributes/diagnostics.html
             passthrough_attrs.push(attr);
             continue;
+        } else if attr.path.is_ident("serde") {
+            passthrough_attrs.push(attr);
+            continue;
         } else if attr.path.segments.len() > 1 {
             let tool = &attr.path.segments.first().unwrap().ident;
             if tool == "rustfmt" {


### PR DESCRIPTION
#941 added support for `derive(Serialize)` and `derive(Deserialize)` on data structures inside the cxx::bridge module, but previously the use of a `serde(...)` inert attribute would still fail to compile:

```rust
#[cxx::bridge]
mod ffi {
    #[derive(Serialize)]
    struct BlobMetadata {
        #[serde(rename = "len")]
        size: usize,
        tags: Vec<String>,
    }

    ...
}
```

```console
error: unsupported attribute
 --> src/main.rs:6:9
  |
6 |         #[serde(rename = "len")]
  |         ^^^^^^^^^^^^^^^^^^^^^^^^
```

This PR accepts and preserves those `serde(...)` attributes so that they can be read by Serde's derives.