### PR TITLE
Block inadvertent use of items from libstd in no_std mode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -397,7 +397,14 @@ extern crate link_cplusplus;
 
 extern crate alloc;
 extern crate self as cxx;
+
+#[cfg(feature = "std")]
 extern crate std;
+
+// Block inadvertent use of items from libstd, which does not otherwise produce
+// a compile-time error on edition 2018+.
+#[cfg(not(feature = "std"))]
+extern crate core as std;
 
 #[macro_use]
 mod macros;


### PR DESCRIPTION
On edition 2018+, `use std::…` implies an implicit `extern crate std`, even inside of a `#[no_std]` crate. This PR prevents this std dependency being inserted inadvertently.

Part of #933.