### PR TITLE
Rename catch_unwind -> prevent_unwind

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -753,14 +753,14 @@ fn expand_function_pointer_trampoline(
     let c_trampoline = mangle::c_trampoline(efn, var, types);
     let r_trampoline = mangle::r_trampoline(efn, var, types);
     let local_name = parse_quote!(__);
-    let catch_unwind_label = format!("::{}::{}", efn.name.rust, var.rust);
+    let prevent_unwind_label = format!("::{}::{}", efn.name.rust, var.rust);
     let body_span = efn.semi_token.span;
     let shim = expand_rust_function_shim_impl(
         sig,
         types,
         &r_trampoline,
         local_name,
-        catch_unwind_label,
+        prevent_unwind_label,
         None,
         Some(&efn.generics),
         body_span,
@@ -891,7 +891,7 @@ fn expand_rust_function_shim(efn: &ExternFn, types: &Types) -> TokenStream {
         None => format_ident!("__{}", efn.name.rust),
         Some(receiver) => format_ident!("__{}__{}", receiver.ty.rust, efn.name.rust),
     };
-    let catch_unwind_label = match &efn.receiver {
+    let prevent_unwind_label = match &efn.receiver {
         None => format!("::{}", efn.name.rust),
         Some(receiver) => format!("::{}::{}", receiver.ty.rust, efn.name.rust),
     };
@@ -902,7 +902,7 @@ fn expand_rust_function_shim(efn: &ExternFn, types: &Types) -> TokenStream {
         types,
         &link_name,
         local_name,
-        catch_unwind_label,
+        prevent_unwind_label,
         invoke,
         None,
         body_span,
@@ -914,7 +914,7 @@ fn expand_rust_function_shim_impl(
     types: &Types,
     link_name: &Symbol,
     local_name: Ident,
-    catch_unwind_label: String,
+    prevent_unwind_label: String,
     invoke: Option<&Ident>,
     outer_generics: Option<&Generics>,
     body_span: Span,
@@ -1077,7 +1077,7 @@ fn expand_rust_function_shim_impl(
         quote!(#local_name)
     };
 
-    expr = quote_spanned!(span=> ::cxx::private::catch_unwind(__fn, #closure));
+    expr = quote_spanned!(span=> ::cxx::private::prevent_unwind(__fn, #closure));
 
     let ret = if sig.throws {
         quote!(-> ::cxx::private::Result)
@@ -1094,7 +1094,7 @@ fn expand_rust_function_shim_impl(
         #[doc(hidden)]
         #[export_name = #link_name]
         unsafe extern "C" fn #local_name #generics(#(#all_args,)* #outparam #pointer) #ret {
-            let __fn = concat!(module_path!(), #catch_unwind_label);
+            let __fn = concat!(module_path!(), #prevent_unwind_label);
             #wrap_super
             #expr
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -504,7 +504,7 @@ pub mod private {
     pub use crate::shared_ptr::SharedPtrTarget;
     pub use crate::string::StackString;
     pub use crate::unique_ptr::UniquePtrTarget;
-    pub use crate::unwind::catch_unwind;
+    pub use crate::unwind::prevent_unwind;
     pub use crate::weak_ptr::WeakPtrTarget;
     pub use cxxbridge_macro::type_id;
 }

--- a/src/unwind.rs
+++ b/src/unwind.rs
@@ -2,7 +2,7 @@
 
 use core::mem;
 
-pub fn catch_unwind<F, R>(label: &'static str, foreign_call: F) -> R
+pub fn prevent_unwind<F, R>(label: &'static str, foreign_call: F) -> R
 where
     F: FnOnce() -> R,
 {


### PR DESCRIPTION
This describes its purpose in the context of cxx better. We are blocking the unwind from propagating across the extern "C" signature by aborting, not continuing the program like in the case of std::panic::catch_unwind.