### PR TITLE
Mark feature-gated APIs in rendered rustdoc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = ["demo", "flags", "gen/build", "gen/cmd", "gen/lib", "macro", "tests/f
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "doc_cfg"]
 
 [patch.crates-io]
 cxx = { path = "." }

--- a/src/cxx_string.rs
+++ b/src/cxx_string.rs
@@ -148,6 +148,7 @@ impl CxxString {
     ///
     /// [replacement character]: https://doc.rust-lang.org/std/char/constant.REPLACEMENT_CHARACTER.html
     #[cfg(feature = "alloc")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
     pub fn to_string_lossy(&self) -> Cow<str> {
         String::from_utf8_lossy(self.as_bytes())
     }
@@ -207,6 +208,7 @@ impl CxxString {
 }
 
 #[cfg(feature = "alloc")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 impl Display for CxxString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         Display::fmt(self.to_string_lossy().as_ref(), f)
@@ -214,6 +216,7 @@ impl Display for CxxString {
 }
 
 #[cfg(feature = "alloc")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 impl Debug for CxxString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         Debug::fmt(self.to_string_lossy().as_ref(), f)

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -4,6 +4,7 @@ use alloc::boxed::Box;
 use core::fmt::{self, Display};
 
 /// Exception thrown from an `extern "C++"` function.
+#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 #[derive(Debug)]
 pub struct Exception {
     pub(crate) what: Box<str>,
@@ -16,6 +17,7 @@ impl Display for Exception {
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
 impl std::error::Error for Exception {}
 
 impl Exception {

--- a/src/extern_type.rs
+++ b/src/extern_type.rs
@@ -187,8 +187,9 @@ pub fn verify_extern_type<T: ExternType<Id = Id>, Id>() {}
 pub fn verify_extern_kind<T: ExternType<Kind = Kind>, Kind: self::Kind>() {}
 
 macro_rules! impl_extern_type {
-    ($([$kind:ident] $($ty:path = $cxxpath:literal)*)*) => {
+    ($([$kind:ident] $($(#[$($attr:tt)*])* $ty:path = $cxxpath:literal)*)*) => {
         $($(
+            $(#[$($attr)*])*
             unsafe impl ExternType for $ty {
                 #[doc(hidden)]
                 type Id = crate::type_id!($cxxpath);
@@ -214,12 +215,10 @@ impl_extern_type! {
     f32 = "float"
     f64 = "double"
 
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
+    String = "rust::String"
+
     [Opaque]
     CxxString = "std::string"
-}
-
-#[cfg(feature = "alloc")]
-impl_extern_type! {
-    [Trivial]
-    String = "rust::String"
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,6 +368,7 @@
 #![deny(improper_ctypes, improper_ctypes_definitions, missing_docs)]
 #![cfg_attr(not(no_unsafe_op_in_unsafe_fn_lint), deny(unsafe_op_in_unsafe_fn))]
 #![cfg_attr(no_unsafe_op_in_unsafe_fn_lint, allow(unused_unsafe))]
+#![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![allow(non_camel_case_types)]
 #![allow(
     clippy::cognitive_complexity,


### PR DESCRIPTION
![Screenshot from 2021-12-08 22-47-27](https://user-images.githubusercontent.com/1940490/145347690-4a33ca0c-bb91-4a2a-860c-254e616069ac.png)
---
![Screenshot from 2021-12-08 22-47-44](https://user-images.githubusercontent.com/1940490/145347697-641e6cc9-571d-480c-b3e7-ec59ae383154.png)
---
![Screenshot from 2021-12-08 22-48-18](https://user-images.githubusercontent.com/1940490/145347706-6b8dde05-62cd-4c36-9b46-e5db2eb99c2b.png)
