### PR TITLE
Add String::lossy constructors to C++ API

### DIFF
--- a/book/src/binding/string.md
+++ b/book/src/binding/string.md
@@ -18,14 +18,23 @@ public:
   String(String &&) noexcept;
   ~String() noexcept;
 
-  // Throws std::invalid_argument if not utf-8.
+  // Throws std::invalid_argument if not UTF-8.
   String(const std::string &);
   String(const char *);
   String(const char *, size_t);
 
-  // Throws std::invalid_argument if not utf-16.
+  // Replaces invalid UTF-8 data with the replacement character (U+FFFD).
+  static String lossy(const std::string &) noexcept;
+  static String lossy(const char *) noexcept;
+  static String lossy(const char *, std::size_t) noexcept;
+
+  // Throws std::invalid_argument if not UTF-16.
   String(const char16_t *);
   String(const char16_t *, size_t);
+
+  // Replaces invalid UTF-16 data with the replacement character (U+FFFD).
+  static String lossy(const char16_t *) noexcept;
+  static String lossy(const char16_t *, std::size_t) noexcept;
 
   String &operator=(const String &) noexcept;
   String &operator=(String &&) noexcept;

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -24,6 +24,7 @@ namespace rust {
 inline namespace cxxbridge1 {
 
 struct unsafe_bitcopy_t;
+struct lossy_t;
 
 namespace {
 template <typename T>
@@ -45,6 +46,13 @@ public:
   String(const char *, std::size_t);
   String(const char16_t *);
   String(const char16_t *, std::size_t);
+
+  // Replace invalid Unicode data with the replacement character (U+FFFD).
+  static String lossy(const std::string &) noexcept;
+  static String lossy(const char *) noexcept;
+  static String lossy(const char *, std::size_t) noexcept;
+  static String lossy(const char16_t *) noexcept;
+  static String lossy(const char16_t *, std::size_t) noexcept;
 
   String &operator=(const String &) &noexcept;
   String &operator=(String &&) &noexcept;
@@ -85,6 +93,8 @@ public:
   String(unsafe_bitcopy_t, const String &) noexcept;
 
 private:
+  String(lossy_t, const char *, std::size_t) noexcept;
+  String(lossy_t, const char16_t *, std::size_t) noexcept;
   friend void swap(String &lhs, String &rhs) noexcept { lhs.swap(rhs); }
 
   // Size and alignment statically verified by rust_string.rs.

--- a/src/symbols/rust_string.rs
+++ b/src/symbols/rust_string.rs
@@ -39,6 +39,18 @@ unsafe extern "C" fn string_from_utf8(
     }
 }
 
+#[export_name = "cxxbridge1$string$from_utf8_lossy"]
+unsafe extern "C" fn string_from_utf8_lossy(
+    this: &mut MaybeUninit<String>,
+    ptr: *const u8,
+    len: usize,
+) {
+    let slice = unsafe { slice::from_raw_parts(ptr, len) };
+    let owned = String::from_utf8_lossy(slice).into_owned();
+    let this = this.as_mut_ptr();
+    unsafe { ptr::write(this, owned) }
+}
+
 #[export_name = "cxxbridge1$string$from_utf16"]
 unsafe extern "C" fn string_from_utf16(
     this: &mut MaybeUninit<String>,
@@ -54,6 +66,18 @@ unsafe extern "C" fn string_from_utf16(
         }
         Err(_) => false,
     }
+}
+
+#[export_name = "cxxbridge1$string$from_utf16_lossy"]
+unsafe extern "C" fn string_from_utf16_lossy(
+    this: &mut MaybeUninit<String>,
+    ptr: *const u16,
+    len: usize,
+) {
+    let slice = unsafe { slice::from_raw_parts(ptr, len) };
+    let owned = String::from_utf16_lossy(slice);
+    let this = this.as_mut_ptr();
+    unsafe { ptr::write(this, owned) }
 }
 
 #[export_name = "cxxbridge1$string$drop"]

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -103,6 +103,7 @@ pub mod ffi {
         fn c_return_slice_char(shared: &Shared) -> &[c_char];
         fn c_return_mutsliceu8(slice: &mut [u8]) -> &mut [u8];
         fn c_return_rust_string() -> String;
+        fn c_return_rust_string_lossy() -> String;
         fn c_return_unique_ptr_string() -> UniquePtr<CxxString>;
         fn c_return_unique_ptr_vector_u8() -> UniquePtr<CxxVector<u8>>;
         fn c_return_unique_ptr_vector_f64() -> UniquePtr<CxxVector<f64>>;

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -110,6 +110,10 @@ rust::Slice<uint8_t> c_return_mutsliceu8(rust::Slice<uint8_t> slice) {
 
 rust::String c_return_rust_string() { return "2020"; }
 
+rust::String c_return_rust_string_lossy() {
+  return rust::String::lossy("Hello \xf0\x90\x80World");
+}
+
 std::unique_ptr<std::string> c_return_unique_ptr_string() {
   return std::unique_ptr<std::string>(new std::string("2020"));
 }
@@ -859,6 +863,12 @@ extern "C" const char *cxx_run_test() noexcept {
   rust::String utf8_rstring = utf8_literal;
   rust::String utf16_rstring = utf16_literal;
   ASSERT(utf8_rstring == utf16_rstring);
+
+  const char *bad_utf8_literal = "test\x80";
+  const char16_t *bad_utf16_literal = u"test\xDD1E";
+  rust::String bad_utf8_rstring = rust::String::lossy(bad_utf8_literal);
+  rust::String bad_utf16_rstring = rust::String::lossy(bad_utf16_literal);
+  ASSERT(bad_utf8_rstring == bad_utf16_rstring);
 
   rust::Vec<int> vec1{1, 2};
   rust::Vec<int> vec2{3, 4};

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -100,6 +100,7 @@ rust::Str c_return_str(const Shared &shared);
 rust::Slice<const char> c_return_slice_char(const Shared &shared);
 rust::Slice<uint8_t> c_return_mutsliceu8(rust::Slice<uint8_t> slice);
 rust::String c_return_rust_string();
+rust::String c_return_rust_string_lossy();
 std::unique_ptr<std::string> c_return_unique_ptr_string();
 std::unique_ptr<std::vector<uint8_t>> c_return_unique_ptr_vector_u8();
 std::unique_ptr<std::vector<double>> c_return_unique_ptr_vector_f64();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -51,6 +51,7 @@ fn test_c_return() {
         cast::c_char_to_unsigned(ffi::c_return_slice_char(&shared)),
     );
     assert_eq!("2020", ffi::c_return_rust_string());
+    assert_eq!("Hello �World", ffi::c_return_rust_string_lossy());
     assert_eq!("2020", ffi::c_return_unique_ptr_string().to_str().unwrap());
     assert_eq!(4, ffi::c_return_unique_ptr_vector_u8().len());
     assert_eq!(


### PR DESCRIPTION
This constructor maps to `String::from_utf8_lossy` or
`String::from_utf16_lossy`. It's useful in situations where producing a
slightly garbled string on invalid Unicode data is preferable to
crashing the process, e.g. when passing error messages from C++ to Rust.