### PR TITLE
Store parsed cfg attributes into syntax tree

### DIFF
--- a/gen/src/nested.rs
+++ b/gen/src/nested.rs
@@ -52,6 +52,7 @@ fn sort_by_inner_namespace(apis: Vec<&Api>, depth: usize) -> NamespaceEntries {
 mod tests {
     use super::NamespaceEntries;
     use crate::syntax::attrs::OtherAttrs;
+    use crate::syntax::cfg::CfgExpr;
     use crate::syntax::namespace::Namespace;
     use crate::syntax::{Api, Doc, ExternType, ForeignName, Lang, Lifetimes, Pair};
     use proc_macro2::{Ident, Span};
@@ -128,6 +129,7 @@ mod tests {
     fn make_api(ns: Option<&str>, ident: &str) -> Api {
         let ns = ns.map_or(Namespace::ROOT, |ns| syn::parse_str(ns).unwrap());
         Api::CxxType(ExternType {
+            cfg: CfgExpr::Unconditional,
             lang: Lang::Rust,
             doc: Doc::new(),
             derives: Vec::new(),

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1,5 +1,6 @@
 use crate::syntax::atom::Atom::*;
 use crate::syntax::attrs::{self, OtherAttrs};
+use crate::syntax::cfg::CfgExpr;
 use crate::syntax::file::Module;
 use crate::syntax::instantiate::{ImplKey, NamedImplKey};
 use crate::syntax::qualified::QualifiedName;
@@ -19,11 +20,13 @@ use syn::{parse_quote, punctuated, Generics, Lifetime, Result, Token};
 pub fn bridge(mut ffi: Module) -> Result<TokenStream> {
     let ref mut errors = Errors::new();
 
+    let mut cfg = CfgExpr::Unconditional;
     let mut doc = Doc::new();
     let attrs = attrs::parse(
         errors,
         mem::take(&mut ffi.attrs),
         attrs::Parser {
+            cfg: Some(&mut cfg),
             doc: Some(&mut doc),
             ..Default::default()
         },

--- a/syntax/impls.rs
+++ b/syntax/impls.rs
@@ -8,12 +8,14 @@ use std::ops::{Deref, DerefMut};
 impl PartialEq for Include {
     fn eq(&self, other: &Self) -> bool {
         let Include {
+            cfg: _,
             path,
             kind,
             begin_span: _,
             end_span: _,
         } = self;
         let Include {
+            cfg: _,
             path: path2,
             kind: kind2,
             begin_span: _,
@@ -335,6 +337,7 @@ impl PartialEq for Signature {
             && args.len() == args2.len()
             && args.iter().zip(args2).all(|(arg, arg2)| {
                 let Var {
+                    cfg: _,
                     doc: _,
                     attrs: _,
                     visibility: _,
@@ -343,6 +346,7 @@ impl PartialEq for Signature {
                     ty,
                 } = arg;
                 let Var {
+                    cfg: _,
                     doc: _,
                     attrs: _,
                     visibility: _,
@@ -372,6 +376,7 @@ impl Hash for Signature {
         receiver.hash(state);
         for arg in args {
             let Var {
+                cfg: _,
                 doc: _,
                 attrs: _,
                 visibility: _,

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -2,7 +2,7 @@
 
 pub mod atom;
 pub mod attrs;
-mod cfg;
+pub mod cfg;
 pub mod check;
 pub mod derive;
 mod discriminant;
@@ -31,6 +31,7 @@ pub mod types;
 mod visit;
 
 use self::attrs::OtherAttrs;
+use self::cfg::CfgExpr;
 use self::namespace::Namespace;
 use self::parse::kw;
 use self::symbol::Symbol;
@@ -60,6 +61,7 @@ pub enum Api {
 }
 
 pub struct Include {
+    pub cfg: CfgExpr,
     pub path: String,
     pub kind: IncludeKind,
     pub begin_span: Span,
@@ -76,6 +78,7 @@ pub enum IncludeKind {
 }
 
 pub struct ExternType {
+    pub cfg: CfgExpr,
     pub lang: Lang,
     pub doc: Doc,
     pub derives: Vec<Derive>,
@@ -91,6 +94,7 @@ pub struct ExternType {
 }
 
 pub struct Struct {
+    pub cfg: CfgExpr,
     pub doc: Doc,
     pub derives: Vec<Derive>,
     pub attrs: OtherAttrs,
@@ -103,6 +107,7 @@ pub struct Struct {
 }
 
 pub struct Enum {
+    pub cfg: CfgExpr,
     pub doc: Doc,
     pub derives: Vec<Derive>,
     pub attrs: OtherAttrs,
@@ -130,6 +135,7 @@ pub enum EnumRepr {
 }
 
 pub struct ExternFn {
+    pub cfg: CfgExpr,
     pub lang: Lang,
     pub doc: Doc,
     pub attrs: OtherAttrs,
@@ -141,6 +147,7 @@ pub struct ExternFn {
 }
 
 pub struct TypeAlias {
+    pub cfg: CfgExpr,
     pub doc: Doc,
     pub derives: Vec<Derive>,
     pub attrs: OtherAttrs,
@@ -183,6 +190,7 @@ pub struct Signature {
 }
 
 pub struct Var {
+    pub cfg: CfgExpr,
     pub doc: Doc,
     pub attrs: OtherAttrs,
     pub visibility: Token![pub],
@@ -205,6 +213,7 @@ pub struct Receiver {
 }
 
 pub struct Variant {
+    pub cfg: CfgExpr,
     pub doc: Doc,
     pub attrs: OtherAttrs,
     pub name: Pair,

--- a/syntax/tokens.rs
+++ b/syntax/tokens.rs
@@ -39,6 +39,7 @@ impl ToTokens for Type {
 impl ToTokens for Var {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let Var {
+            cfg: _,
             doc: _,
             attrs: _,
             visibility: _,


### PR DESCRIPTION
Needed for #989.