### PR TITLE
Add a cfg evaluator for the non-Cargo builds

### DIFF
--- a/gen/cmd/src/cfg.rs
+++ b/gen/cmd/src/cfg.rs
@@ -1,0 +1,93 @@
+use crate::gen::{CfgEvaluator, CfgResult};
+use std::collections::{BTreeMap as Map, BTreeSet as Set};
+use std::fmt::{self, Debug};
+use syn::parse::ParseStream;
+use syn::{Ident, LitBool, LitStr, Token};
+
+#[derive(Ord, PartialOrd, Eq, PartialEq)]
+pub enum CfgValue {
+    Bool(bool),
+    Str(String),
+}
+
+impl CfgValue {
+    const FALSE: Self = CfgValue::Bool(false);
+    const TRUE: Self = CfgValue::Bool(true);
+}
+
+pub struct FlagsCfgEvaluator {
+    map: Map<String, Set<CfgValue>>,
+}
+
+impl FlagsCfgEvaluator {
+    pub fn new(map: Map<String, Set<CfgValue>>) -> Self {
+        FlagsCfgEvaluator { map }
+    }
+}
+
+impl CfgEvaluator for FlagsCfgEvaluator {
+    fn eval(&self, name: &str, value: Option<&str>) -> CfgResult {
+        let set = self.map.get(name);
+        if let Some(value) = value {
+            if let Some(set) = set {
+                CfgResult::from(set.contains(&CfgValue::Str(value.to_owned())))
+            } else if name == "feature" {
+                CfgResult::False
+            } else {
+                let msg = format!(
+                    "pass `--cfg {}=\"...\"` to be able to use this attribute",
+                    name,
+                );
+                CfgResult::Undetermined { msg }
+            }
+        } else {
+            let (mut is_false, mut is_true) = (false, false);
+            if let Some(set) = set {
+                is_false = set.contains(&CfgValue::FALSE);
+                is_true = set.contains(&CfgValue::TRUE);
+            }
+            if is_false && is_true {
+                let msg = format!("the cxxbridge flags say both {0}=false and {0}=true", name);
+                CfgResult::Undetermined { msg }
+            } else if is_false {
+                CfgResult::False
+            } else if is_true {
+                CfgResult::True
+            } else {
+                let msg = format!(
+                    "pass either `--cfg {0}=true` or `--cfg {0}=false` to be able to use this cfg attribute",
+                    name,
+                );
+                CfgResult::Undetermined { msg }
+            }
+        }
+    }
+}
+
+impl Debug for CfgValue {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CfgValue::Bool(value) => Debug::fmt(value, formatter),
+            CfgValue::Str(value) => Debug::fmt(value, formatter),
+        }
+    }
+}
+
+pub fn parse(input: ParseStream) -> syn::Result<(String, CfgValue)> {
+    let ident: Ident = input.parse()?;
+    let name = ident.to_string();
+    if input.is_empty() {
+        return Ok((name, CfgValue::TRUE));
+    }
+    input.parse::<Token![=]>()?;
+    let lookahead = input.lookahead1();
+    if lookahead.peek(LitBool) {
+        let lit: LitBool = input.parse()?;
+        Ok((name, CfgValue::Bool(lit.value)))
+    } else if lookahead.peek(LitStr) {
+        let lit: LitStr = input.parse()?;
+        Ok((name, CfgValue::Str(lit.value())))
+    } else {
+        Err(lookahead.error())
+    }
+}

--- a/gen/cmd/src/main.rs
+++ b/gen/cmd/src/main.rs
@@ -29,14 +29,17 @@
 )]
 
 mod app;
+mod cfg;
 mod gen;
 mod output;
 mod syntax;
 
+use crate::cfg::{CfgValue, FlagsCfgEvaluator};
 use crate::gen::error::{report, Result};
 use crate::gen::fs;
 use crate::gen::include::{self, Include};
 use crate::output::Output;
+use std::collections::{BTreeMap as Map, BTreeSet as Set};
 use std::io::{self, Write};
 use std::path::PathBuf;
 use std::process;
@@ -48,6 +51,7 @@ struct Opt {
     cxx_impl_annotations: Option<String>,
     include: Vec<Include>,
     outputs: Vec<Output>,
+    cfg: Map<String, Set<CfgValue>>,
 }
 
 fn main() {
@@ -91,6 +95,7 @@ fn try_main() -> Result<()> {
         cxx_impl_annotations: opt.cxx_impl_annotations,
         gen_header,
         gen_implementation,
+        cfg_evaluator: Box::new(FlagsCfgEvaluator::new(opt.cfg)),
         ..Default::default()
     };
 

--- a/gen/cmd/src/test.rs
+++ b/gen/cmd/src/test.rs
@@ -13,6 +13,10 @@ ARGS:
             Input Rust source file containing #[cxx::bridge].
 
 OPTIONS:
+        --cfg <name=\"value\" | name[=true] | name=false>
+            Compilation configuration matching what will be used to build
+            the Rust side of the bridge.
+
         --cxx-impl-annotations <annotation>
             Optional annotation for implementations of C++ function wrappers
             that may be exposed to Rust. You may for example need to provide


### PR DESCRIPTION
Conditional compilation support for non-Cargo builds (part of #989). This is the non-Cargo followup to #1000. The C++ code generator evaluates `#[cfg(...)]` attributes by taking flags equivalent to `rustc`'s `--cfg` flag:

```console
$ cxxbridge --cfg 'unix' --cfg 'target_arch="x86_64"' --cfg 'target_endian="little"' --cfg 'test=false' …
```