### PR TITLE
Disallow cfg(test) inside Cargo builds

### DIFF
--- a/gen/build/src/cargo.rs
+++ b/gen/build/src/cargo.rs
@@ -24,6 +24,9 @@ impl CfgEvaluator for CargoEnvCfgEvaluator {
                 let msg = "expected `feature = \"...\"`".to_owned();
                 CfgResult::Undetermined { msg }
             }
+        } else if name == "test" && query_value.is_none() {
+            let msg = "cfg(test) is not supported because Cargo runs your build script only once across the lib and test build of the same crate".to_owned();
+            CfgResult::Undetermined { msg }
         } else {
             match env.cfgs.get(Lookup::new(name)) {
                 Some(cargo_value) => {


### PR DESCRIPTION
`cfg(test)` can't work in Cargo builds because Cargo will make two rustc invocations to build your crate in library mode and test mode, but runs the build script only once across the two of those. We need to pick either true or false for that cfg on the C++ side.