### PR TITLE
Add UniquePtr::to_shared and SharedPtr::from_unmanaged

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1801,6 +1801,18 @@ fn write_shared_ptr(out: &mut OutFile, key: NamedImplKey) {
     begin_function_definition(out);
     writeln!(
         out,
+        "void cxxbridge1$shared_ptr${}$from_unmanaged(::std::shared_ptr<{}>* ptr, void* data) noexcept {{",
+        instance, inner,
+    );
+    writeln!(
+        out,
+        "new (ptr) std::shared_ptr<{}>(static_cast<{}*>(data));",
+        inner, inner
+    );
+    writeln!(out, "}}");
+    begin_function_definition(out);
+    writeln!(
+        out,
         "void cxxbridge1$shared_ptr${}$clone(::std::shared_ptr<{}> const &self, ::std::shared_ptr<{}> *ptr) noexcept {{",
         instance, inner, inner,
     );

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1527,6 +1527,7 @@ fn expand_shared_ptr(
     let prefix = format!("cxxbridge1$shared_ptr${}$", resolve.name.to_symbol());
     let link_null = format!("{}null", prefix);
     let link_uninit = format!("{}uninit", prefix);
+    let link_from_unmanaged = format!("{}from_unmanaged", prefix);
     let link_clone = format!("{}clone", prefix);
     let link_get = format!("{}get", prefix);
     let link_drop = format!("{}drop", prefix);
@@ -1569,6 +1570,13 @@ fn expand_shared_ptr(
                 }
             }
             #new_method
+            unsafe fn __from_unmanaged(value: *mut Self, new: *mut ::cxx::core::ffi::c_void) {
+                extern "C" {
+                    #[link_name = #link_from_unmanaged]
+                    fn __from_unmanaged(new: *const ::cxx::core::ffi::c_void, value: *mut ::cxx::core::ffi::c_void);
+                }
+                __from_unmanaged(new, value as *mut ::cxx::core::ffi::c_void);
+            }
             unsafe fn __clone(this: *const ::cxx::core::ffi::c_void, new: *mut ::cxx::core::ffi::c_void) {
                 extern "C" {
                     #[link_name = #link_clone]

--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -704,6 +704,10 @@ static_assert(sizeof(std::string) <= kMaxExpectedWordsInString * sizeof(void *),
       std::shared_ptr<CXX_TYPE> *ptr) noexcept {                               \
     new (ptr) std::shared_ptr<CXX_TYPE>();                                     \
   }                                                                            \
+  void cxxbridge1$std$shared_ptr$##RUST_TYPE##$from_unmanaged(                 \
+      std::shared_ptr<CXX_TYPE> *ptr, void* data) noexcept {                   \
+    new (ptr) std::shared_ptr<CXX_TYPE>(static_cast<CXX_TYPE*>(data));         \
+  }                                                                            \
   CXX_TYPE *cxxbridge1$std$shared_ptr$##RUST_TYPE##$uninit(                    \
       std::shared_ptr<CXX_TYPE> *ptr) noexcept {                               \
     CXX_TYPE *uninit =                                                         \

--- a/src/unique_ptr.rs
+++ b/src/unique_ptr.rs
@@ -1,8 +1,9 @@
 use crate::cxx_vector::{CxxVector, VectorElement};
 use crate::fmt::display;
 use crate::kind::Trivial;
+use crate::memory::SharedPtrTarget;
 use crate::string::CxxString;
-use crate::ExternType;
+use crate::{ExternType, SharedPtr};
 #[cfg(feature = "std")]
 use alloc::string::String;
 #[cfg(feature = "std")]
@@ -112,6 +113,16 @@ where
             repr: unsafe { T::__raw(raw) },
             ty: PhantomData,
         }
+    }
+}
+
+impl<T> UniquePtr<T>
+where
+    T: UniquePtrTarget + SharedPtrTarget,
+{
+    /// Convert this UniquePtr to a SharedPtr, analogous to constructor (13) for [`std::shared_ptr`](https://en.cppreference.com/w/cpp/memory/shared_ptr/shared_ptr)
+    pub fn to_shared(self) -> SharedPtr<T> {
+        unsafe { SharedPtr::from_unmanaged(self.into_raw()) }
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -290,6 +290,31 @@ fn test_shared_ptr_weak_ptr() {
 }
 
 #[test]
+fn test_unique_to_shared_ptr_string() {
+    let unique = ffi::c_return_unique_ptr_string();
+    let ptr = &*unique as *const _;
+    let shared = unique.to_shared();
+    assert_eq!(&*shared as *const _, ptr);
+    assert_eq!(&*shared, "2020");
+}
+
+#[test]
+fn test_unique_to_shared_ptr_cpp_type() {
+    let unique = ffi::c_return_unique_ptr();
+    let ptr = &*unique as *const _;
+    let shared = unique.to_shared();
+    assert_eq!(&*shared as *const _, ptr);
+}
+
+#[test]
+fn test_unique_to_shared_ptr_null() {
+    let unique = cxx::UniquePtr::<ffi::C>::null();
+    assert!(unique.is_null());
+    let shared = unique.to_shared();
+    assert!(shared.is_null());
+}
+
+#[test]
 fn test_c_ns_method_calls() {
     let unique_ptr = ffi2::ns_c_return_unique_ptr_ns();
 


### PR DESCRIPTION
This adds a way to create SharedPtr's from C++ pointers created with `new` (or via `unique_ptr`s).

I'm a new contributor here, let me know if I did this in a reasonable way, and I'm happy to put some effort in if this is something that's interesting. 