### PR TITLE
Update to clap 3.1.0

### DIFF
--- a/gen/cmd/Cargo.toml
+++ b/gen/cmd/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 experimental-async-fn = []
 
 [dependencies]
-clap = { version = "3.0", default-features = false, features = ["std", "suggestions"] }
+clap = { version = "3.1", default-features = false, features = ["std", "suggestions"] }
 codespan-reporting = "0.11"
 proc-macro2 = { version = "1.0.26", default-features = false, features = ["span-locations"] }
 quote = { version = "1.0", default-features = false }

--- a/gen/cmd/src/app.rs
+++ b/gen/cmd/src/app.rs
@@ -6,7 +6,7 @@ use super::{Opt, Output};
 use crate::cfg::{self, CfgValue};
 use crate::gen::include::Include;
 use crate::syntax::IncludeKind;
-use clap::{App, AppSettings, Arg};
+use clap::{Arg, Command};
 use std::collections::{BTreeMap as Map, BTreeSet as Set};
 use std::ffi::OsStr;
 use std::path::PathBuf;
@@ -33,11 +33,11 @@ OPTIONS:
 {options}\
 ";
 
-fn app() -> App<'static> {
-    let mut app = App::new("cxxbridge")
+fn app() -> Command<'static> {
+    let mut app = Command::new("cxxbridge")
         .override_usage(USAGE)
         .help_template(TEMPLATE)
-        .setting(AppSettings::NextLineHelp)
+        .next_line_help(true)
         .arg(arg_input())
         .arg(arg_cxx_impl_annotations())
         .arg(arg_header())

--- a/third-party/BUCK
+++ b/third-party/BUCK
@@ -15,7 +15,7 @@ rust_library(
 
 rust_library(
     name = "clap",
-    srcs = glob(["vendor/clap-3.0.14/src/**"]),
+    srcs = glob(["vendor/clap-3.1.0/src/**"]),
     features = ["std"],
     visibility = ["PUBLIC"],
     deps = [

--- a/third-party/BUILD
+++ b/third-party/BUILD
@@ -18,7 +18,7 @@ rust_library(
 
 rust_library(
     name = "clap",
-    srcs = glob(["vendor/clap-3.0.14/src/**"]),
+    srcs = glob(["vendor/clap-3.1.0/src/**"]),
     crate_features = ["std"],
     visibility = ["//visibility:public"],
     deps = [

--- a/third-party/Cargo.lock
+++ b/third-party/Cargo.lock
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.14"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
+checksum = "e5f1fea81f183005ced9e59cdb01737ef2423956dac5a6d731b06b2ecfaa3467"
 dependencies = [
  "bitflags",
  "indexmap",


### PR DESCRIPTION
There are several deprecations in this release:
https://github.com/clap-rs/clap/releases/tag/v3.1.0