### PR TITLE
[bazel] Only use lld on Linux

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,2 @@
-build --@rules_rust//:extra_rustc_flags=-Clink-arg=-fuse-ld=lld
+build --enable_platform_specific_config
+build:linux --@rules_rust//:extra_rustc_flags=-Clink-arg=-fuse-ld=lld


### PR DESCRIPTION
macOS C++ toolchains from Apple do not contain lld, so bazel builds in
this repo would fail. This change scopes this only to Linux