### PR TITLE
bazel: force vendored proc-macro2 to edition=2018

### DIFF
--- a/third-party/BUILD
+++ b/third-party/BUILD
@@ -86,6 +86,7 @@ rust_library(
         "proc-macro",
         "span-locations",
     ],
+    edition = "2018",
     visibility = ["//visibility:public"],
     deps = [
         ":proc-macro2@build",


### PR DESCRIPTION
```
Proc-macro2 uses macro syntax which changed meaning in the 2021 edition
of rust[1] and thus throws a compile error unless/until you change the
symbol to one not introduced in proc-macro2's current MSRV.

cxx.rs currently sets edition=2018 at its top level, but other
repositories importing it may set edition=2021, which will apply to
vendored repositories unless overwritten at the target level
(apparently).

As proc-macro2 does not compile under edition=2021, force it to use
edition=2018.

[1] https://doc.rust-lang.org/edition-guide/rust-2021/or-patterns-macro-rules.html
```

Fixes #1031.

I'm assuming this is preferable to fixing proc-macro2 itself, which from my testing would require an MSRV bump to much newer rust for `pat_param`.

This change is sufficient to get my build working again even with a default top-level `edition="2021"`.