### PR TITLE
Set up Bazel rust_repositories with a default edition that is not usable

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,11 +4,12 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_rust",
-    sha256 = "3cf493f845837b9c0c44311992a8e387b508a267cb8f261ef97b94c915f292cc",
-    strip_prefix = "rules_rust-55790492aca01b389d208cd1335b9d8c05e28329",
+    sha256 = "29954bced3e0d1a57ff8db816f5cd8a5856179fc657455729f1eb53b39611419",
+    strip_prefix = "rules_rust-6e1cbbfcd0d140baacc8ff1080f885d2a45296a9",
     urls = [
-        # Main branch as of 2022-04-10
-        "https://github.com/bazelbuild/rules_rust/archive/55790492aca01b389d208cd1335b9d8c05e28329.tar.gz",
+        # PR https://github.com/bazelbuild/rules_rust/pull/1254
+        # on top of the main branch as of 2022-04-10
+        "https://github.com/bazelbuild/rules_rust/archive/6e1cbbfcd0d140baacc8ff1080f885d2a45296a9.tar.gz",
     ],
 )
 
@@ -16,7 +17,10 @@ load("@rules_rust//rust:repositories.bzl", "rust_repositories")
 
 RUST_VERSION = "1.60.0"
 
-rust_repositories(version = RUST_VERSION)
+rust_repositories(
+    edition = "required",
+    version = RUST_VERSION,
+)
 
 load("//tools/bazel:vendor.bzl", "vendor")
 


### PR DESCRIPTION
Closes #1031. Closes #1032.

Requires https://github.com/bazelbuild/rules_rust/pull/1254, since some targets from the rules_rust repo otherwise end up using the default edition set by cxx's WORKSPACE. (This behavior is silly, but a consequence of https://github.com/bazelbuild/rules_rust/issues/1251.)

Using rules_rust's current `main` branch this change would fail as follows:

```console
$ bazel build ...
INFO: Analyzed 48 targets (5 packages loaded, 382 targets configured).
INFO: Found 48 targets...
ERROR: /home/david/.cache/bazel/_bazel_david/ebce1d0721fb68dda9c70c0dd1405803/external/rules_rust/util/process_wrapper/BUILD.bazel:6:36: Compiling Rust (without process_wrapper) bin process_wrapper (4 files) [for host] failed: (Exit 1): rustc failed: error executing command bazel-out/host/bin/external/rust_linux_x86_64/toolchain_for_x86_64-unknown-linux-gnu_impl/bin/rustc external/rules_rust/util/process_wrapper/main.rs '--crate-name=process_wrapper' '--crate-type=bin' ... (remaining 15 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
error: argument for `--edition` must be one of: 2015|2018|2021. (instead was `required`)

INFO: Elapsed time: 15.072s, Critical Path: 0.14s
INFO: 3 processes: 3 internal.
FAILED: Build did NOT complete successfully
```