### PR TITLE
support resolving arm triplet with bazel

### DIFF
--- a/tools/bazel/vendor.bzl
+++ b/tools/bazel/vendor.bzl
@@ -21,9 +21,14 @@ def _impl(repository_ctx):
     if repository_ctx.attr.target_triple:
         target_triple = repository_ctx.attr.target_triple
     elif "mac" in repository_ctx.os.name:
-        target_triple = "x86_64-apple-darwin"
+        if "arm" in getattr(repository_ctx.os, "arch", ""):
+            target_triple = "aarch64-apple-darwin"
+        else:
+            target_triple = "x86_64-apple-darwin"
     elif "windows" in repository_ctx.os.name:
         target_triple = "x86_64-pc-windows-msvc"
+    elif "arm" in getattr(repository_ctx.os, "arch", ""):
+        target_triple = "aarch64-unknown-linux-gnu"
     else:
         target_triple = "x86_64-unknown-linux-gnu"
 

--- a/tools/bazel/vendor.bzl
+++ b/tools/bazel/vendor.bzl
@@ -17,17 +17,18 @@ def _impl(repository_ctx):
     root_lockfile = repository_ctx.path("workspace/Cargo.lock")
     _copy_file(repository_ctx, src = vendor_lockfile, dst = root_lockfile)
 
+    is_mac = "mac" in repository_ctx.os.name
+    is_arm = "arm" in getattr(repository_ctx.os, "arch", "")
     # Figure out which version of cargo to use.
     if repository_ctx.attr.target_triple:
         target_triple = repository_ctx.attr.target_triple
-    elif "mac" in repository_ctx.os.name:
-        if "arm" in getattr(repository_ctx.os, "arch", ""):
-            target_triple = "aarch64-apple-darwin"
-        else:
-            target_triple = "x86_64-apple-darwin"
+    elif is_mac and is_arm:
+         target_triple = "aarch64-apple-darwin"
+    elif is_mac:
+         target_triple = "x86_64-apple-darwin"
     elif "windows" in repository_ctx.os.name:
         target_triple = "x86_64-pc-windows-msvc"
-    elif "arm" in getattr(repository_ctx.os, "arch", ""):
+    elif is_arm:
         target_triple = "aarch64-unknown-linux-gnu"
     else:
         target_triple = "x86_64-unknown-linux-gnu"


### PR DESCRIPTION
Adds support to vendor.bzl for resolving the arm triplet. This only works with Bazel 5.1, but the way we access the new field should be safe for older versions and result in a negative check, maintaining the old behavior