### PR TITLE
Replace deprecated rust_repositories call in bazel WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,11 +12,13 @@ http_archive(
     ],
 )
 
-load("@rules_rust//rust:repositories.bzl", "rust_repositories")
+load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains")
 
 RUST_VERSION = "1.60.0"
 
-rust_repositories(
+rules_rust_dependencies()
+
+rust_register_toolchains(
     version = RUST_VERSION,
 )
 


### PR DESCRIPTION
This function is documented as deprecated in rules_rust.

```markdown
**Deprecated**: Use [rules_rust_dependencies](#rules_rust_dependencies)
and [rust_register_toolchains](#rust_register_toolchains) directly.
```