### PR TITLE
Replace half-baked repository_os logic with get_host_triple

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,11 +4,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_rust",
-    sha256 = "d39af65fc3b88c204e101d4ddc7dd7543be4e2509fa21c35a5d228f54821a2a9",
-    strip_prefix = "rules_rust-f7cb22efa64a6a07813e30e9f9d70d1fd18e463e",
+    sha256 = "617082067629939c0a22f587811a3e822a50a203119a90380e21f5aec3373da9",
+    strip_prefix = "rules_rust-e07881fa22a5f0d16230d8b23bbff2bf358823b8",
     urls = [
-        # Main branch as of 2022-04-25
-        "https://github.com/bazelbuild/rules_rust/archive/f7cb22efa64a6a07813e30e9f9d70d1fd18e463e.tar.gz",
+        # Main branch as of 2022-04-27
+        "https://github.com/bazelbuild/rules_rust/archive/e07881fa22a5f0d16230d8b23bbff2bf358823b8.tar.gz",
     ],
 )
 

--- a/tools/bazel/vendor.bzl
+++ b/tools/bazel/vendor.bzl
@@ -2,8 +2,9 @@
 of a crate in the current workspace.
 """
 
-load("@rules_rust//rust:repositories.bzl", "load_arbitrary_tool")
 load("@rules_rust//rust:defs.bzl", "rust_common")
+load("@rules_rust//rust:repositories.bzl", "load_arbitrary_tool")
+load("@rules_rust//rust/platform:triple.bzl", "get_host_triple")
 
 def _impl(repository_ctx):
     # Link cxx repository into @third-party.
@@ -21,20 +22,7 @@ def _impl(repository_ctx):
     if repository_ctx.attr.target_triple:
         target_triple = repository_ctx.attr.target_triple
     else:
-        if "mac" in repository_ctx.os.name:
-            triple_os = "apple-darwin"
-        elif "windows" in repository_ctx.os.name:
-            triple_os = "pc-windows-msvc"
-        else:
-            triple_os = "unknown-linux-gnu"
-
-        # FIXME can we just use `triple_arch = repository_ctx.os.arch`?
-        if "aarch64" in getattr(repository_ctx.os, "arch", ""):
-            triple_arch = "aarch64"
-        else:
-            triple_arch = "x86_64"
-
-        target_triple = "{}-{}".format(triple_arch, triple_os)
+        target_triple = get_host_triple(repository_ctx).str
 
     # Download cargo.
     load_arbitrary_tool(


### PR DESCRIPTION
In https://github.com/bazelbuild/rules_rust/pull/1289 I implemented a better way to figure out the right triple to use with `load_arbitrary_tool`.

This replaces the incomplete `if`/`elif`/`else` logic from #893 and #1038 and #1039.