### PR TITLE
gen: Fix panic in clap when handling `--include`

### DIFF
--- a/gen/cmd/src/app.rs
+++ b/gen/cmd/src/app.rs
@@ -60,6 +60,7 @@ const INCLUDE: &str = "include";
 const OUTPUT: &str = "output";
 const CFG: &str = "cfg";
 
+#[allow(deprecated)]
 pub(super) fn from_args() -> Opt {
     let matches = app().get_matches();
 
@@ -121,6 +122,7 @@ fn validate_utf8(arg: &OsStr) -> Result<(), &'static str> {
     }
 }
 
+#[allow(deprecated)]
 fn arg_input() -> Arg<'static> {
     Arg::new(INPUT)
         .help("Input Rust source file containing #[cxx::bridge].")
@@ -128,6 +130,7 @@ fn arg_input() -> Arg<'static> {
         .allow_invalid_utf8(true)
 }
 
+#[allow(deprecated)]
 fn arg_cxx_impl_annotations() -> Arg<'static> {
     const HELP: &str = "\
 Optional annotation for implementations of C++ function wrappers
@@ -151,6 +154,7 @@ a path ending in `.h`.";
     Arg::new(HEADER).long(HEADER).help(HELP)
 }
 
+#[allow(deprecated)]
 fn arg_include() -> Arg<'static> {
     const HELP: &str = "\
 Any additional headers to #include. The cxxbridge tool does not
@@ -166,6 +170,7 @@ into the generated C++ code as #include lines.";
         .help(HELP)
 }
 
+#[allow(deprecated)]
 fn arg_output() -> Arg<'static> {
     const HELP: &str = "\
 Path of file to write as output. Output goes to stdout if -o is
@@ -180,6 +185,7 @@ not specified.";
         .help(HELP)
 }
 
+#[allow(deprecated)]
 fn arg_cfg() -> Arg<'static> {
     const HELP: &str = "\
 Compilation configuration matching what will be used to build

--- a/gen/cmd/src/app.rs
+++ b/gen/cmd/src/app.rs
@@ -67,9 +67,10 @@ pub(super) fn from_args() -> Opt {
     let cxx_impl_annotations = matches.value_of(CXX_IMPL_ANNOTATIONS).map(str::to_owned);
     let header = matches.is_present(HEADER);
     let include = matches
-        .values_of(INCLUDE)
+        .values_of_os(INCLUDE)
         .unwrap_or_default()
         .map(|include| {
+            let include = include.to_str().expect("Invalid UTF-8 in include");
             if include.starts_with('<') && include.ends_with('>') {
                 Include {
                     path: include[1..include.len() - 1].to_owned(),


### PR DESCRIPTION
For some reason I don't yet fully understand, the build
of rpm-ostree started failing with a panic in `cxxbridge`:
https://github.com/coreos/rpm-ostree/pull/3763#issuecomment-1154193336

What I haven't worked out is what changed to break this; my best
guess is something like compiler type inference?  AFAICS, the
code here hasn't changed in a long time, and neither has the lockfiles.

(Hmm...unless we're not using lockfiles for this...ah yes, that would
 explain it.  And https://crates.io/crates/clap/3.2.1 was just published.
 Will dig into this more)

Anyways, this is not an elegant fix; we just (correctly) ask clap
to give us `OsString` and not `String`.  The real fix is clearly
to stop using all the deprecated clap APIs, but I'm trying to make
the least invasive change for the moment.