### PR TITLE
Expose the inner rust side error type via the exception on the c++ side

### DIFF
--- a/gen/src/builtin.rs
+++ b/gen/src/builtin.rs
@@ -42,13 +42,13 @@ impl<'a> Builtins<'a> {
     }
 }
 
-pub(super) fn write(out: &mut OutFile) {
-    if out.builtin == Default::default() {
+pub(super) fn write(out_file: &mut OutFile) {
+    if out_file.builtin == Default::default() {
         return;
     }
 
-    let include = &mut out.include;
-    let builtin = &mut out.builtin;
+    let include = &mut out_file.include;
+    let builtin = &mut out_file.builtin;
     let out = &mut builtin.content;
 
     if builtin.rust_string {
@@ -280,6 +280,8 @@ pub(super) fn write(out: &mut OutFile) {
         writeln!(out, "struct PtrLen final {{");
         writeln!(out, "  void *ptr;");
         writeln!(out, "  ::std::size_t len;");
+        writeln!(out, "  void* inner;");
+        writeln!(out, "  void (*inner_destructor)(void*);");
         writeln!(out, "}};");
         out.end_block(Block::Namespace("repr"));
     }
@@ -327,7 +329,7 @@ pub(super) fn write(out: &mut OutFile) {
         writeln!(out, "}};");
     }
 
-    if builtin.rust_error {
+    if builtin.rust_error && !out_file.header {
         out.next_section();
         writeln!(out, "template <>");
         writeln!(out, "class impl<Error> final {{");
@@ -336,6 +338,8 @@ pub(super) fn write(out: &mut OutFile) {
         writeln!(out, "    Error error;");
         writeln!(out, "    error.msg = static_cast<const char *>(repr.ptr);");
         writeln!(out, "    error.len = repr.len;");
+        writeln!(out, "    error.inner = repr.inner;");
+        writeln!(out, "    error.inner_destructor = repr.inner_destructor;");
         writeln!(out, "    return error;");
         writeln!(out, "  }}");
         writeln!(out, "}};");

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -197,8 +197,16 @@ fn write_std_specializations(out: &mut OutFile, apis: &[Api]) {
 
 fn pick_includes_and_builtins(out: &mut OutFile, apis: &[Api]) {
     for api in apis {
-        if let Api::Include(include) = api {
-            out.include.insert(include);
+        match api {
+            Api::Include(include) => {
+                out.include.insert(include);
+            }
+            Api::RustFunction(function) => {
+                if function.sig.throws {
+                    out.builtin.rust_error = true;
+                }
+            }
+            _ => {}
         }
     }
 

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -395,11 +395,22 @@ public:
 
   const char *what() const noexcept override;
 
+  template<class T>
+  const T* inner_error() const {
+    if (this->inner) {
+      return reinterpret_cast<const T*>(this->inner);
+    } else {
+      return nullptr;
+    }
+  }
+
 private:
   Error() noexcept = default;
   friend impl<Error>;
   const char *msg;
   std::size_t len;
+  void* inner;
+  void (*inner_destructor)(void*);
 };
 #endif // CXXBRIDGE1_RUST_ERROR
 

--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -471,13 +471,18 @@ Error::Error(Error &&other) noexcept
   other.len = 0;
 }
 
-Error::~Error() noexcept { delete[] this->msg; }
+Error::~Error() noexcept {
+  delete[] this->msg;
+  this->inner_destructor(this->inner);
+}
 
 Error &Error::operator=(const Error &other) & {
   if (this != &other) {
     std::exception::operator=(other);
     delete[] this->msg;
     this->msg = nullptr;
+    this->inner_destructor(this->inner);
+    this->inner = nullptr;
     if (other.msg) {
       this->msg = errorCopy(other.msg, other.len);
       this->len = other.len;
@@ -490,8 +495,11 @@ Error &Error::operator=(Error &&other) &noexcept {
   std::exception::operator=(std::move(other));
   this->msg = other.msg;
   this->len = other.len;
+  this->inner = other.inner;
+  this->inner_destructor = other.inner_destructor;
   other.msg = nullptr;
   other.len = 0;
+  other.inner = nullptr;
   return *this;
 }
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -4,6 +4,7 @@
 use crate::exception::Exception;
 use alloc::boxed::Box;
 use alloc::string::{String, ToString};
+use core::ffi::c_void;
 use core::fmt::Display;
 use core::ptr::{self, NonNull};
 use core::result::Result as StdResult;
@@ -15,12 +16,20 @@ use core::str;
 struct PtrLen {
     ptr: NonNull<u8>,
     len: usize,
+    inner_err: *mut c_void,
+    inner_destructor: extern "C" fn(*mut c_void),
 }
 
 #[repr(C)]
 pub union Result {
     err: PtrLen,
     ok: *const u8, // null
+}
+
+extern "C" fn free_boxed_error<E>(ptr: *mut c_void) {
+    if !ptr.is_null() {
+        unsafe { std::mem::drop(Box::from_raw(ptr as *mut E)) }
+    }
 }
 
 pub unsafe fn r#try<T, E>(ret: *mut T, result: StdResult<T, E>) -> Result
@@ -32,11 +41,22 @@ where
             unsafe { ptr::write(ret, ok) }
             Result { ok: ptr::null() }
         }
-        Err(err) => unsafe { to_c_error(err.to_string()) },
+        Err(err) => {
+            let msg = err.to_string();
+            let boxed_error = Box::new(err);
+            let destructor = free_boxed_error::<E>;
+            unsafe {
+                to_c_error(
+                    msg,
+                    Box::leak(boxed_error) as *mut E as *mut c_void,
+                    destructor,
+                )
+            }
+        }
     }
 }
 
-unsafe fn to_c_error(msg: String) -> Result {
+unsafe fn to_c_error(msg: String, inner_err: *mut c_void, destructor: extern "C" fn(*mut c_void)) -> Result {
     let mut msg = msg;
     unsafe { msg.as_mut_vec() }.push(b'\0');
     let ptr = msg.as_ptr();
@@ -48,7 +68,12 @@ unsafe fn to_c_error(msg: String) -> Result {
     }
 
     let copy = unsafe { error(ptr, len) };
-    let err = PtrLen { ptr: copy, len };
+    let err = PtrLen {
+        ptr: copy,
+        len,
+        inner_err,
+        inner_destructor: destructor,
+    };
     Result { err }
 }
 


### PR DESCRIPTION
This is an attempt to address https://github.com/dtolnay/cxx/issues/870 and similar issues. 

I attempt to expose more information on the underlying rust error by including the the original error into the c++ side exception. This allows accessing any error related information from the c++ side as well, assuming that the error type is exposed as part of the cxx bridge definition.

I deliberately open this PR in this state, to gather some feedback on the design idea before spending to much time on details.