### PR TITLE
make #derive before #attr when expand to avoid warning legacy_derive_helpers

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -172,8 +172,8 @@ fn expand_struct(strct: &Struct) -> TokenStream {
 
     quote! {
         #doc
-        #attrs
         #derives
+        #attrs
         #[repr(C)]
         #struct_def
 
@@ -342,8 +342,8 @@ fn expand_enum(enm: &Enum) -> TokenStream {
 
     quote! {
         #doc
-        #attrs
         #derives
+        #attrs
         #[repr(transparent)]
         #enum_def
 


### PR DESCRIPTION
when use cxx with derive macros with helper container attribute will meet the warning
https://github.com/rust-lang/rust/issues/79202

a minimal case:
```
#[cxx::bridge]
mod ffi {
    #[derive(Debug, Default, Deserialize)]
    #[serde(rename(deserialize = "de_name"))]
    struct Data {
        size: usize,
    }
}
```
