### PR TITLE
Added another CMake example application

### DIFF
--- a/book/src/build/cmake.md
+++ b/book/src/build/cmake.md
@@ -29,3 +29,10 @@ what is available in these links, feel free to make a PR adding it to this list.
   - Tested on Windows 10 with GNU target, and on Linux
 
 ---
+
+- **<https://github.com/paandahl/cpp-with-rust>**
+
+  - Same blobstore example as the official demo, but inverted languages
+  - Minimal CMake configuration
+  - Tested on Linux, Mac, and on Windows
+---


### PR DESCRIPTION
I always wished for an inverted example when learning to use CXX (blobstore in Rust, main() in C++).

I decided to make it, and to keep it as close to the official demo as possible. I also kept the CMake-configuration to a minimum, avoiding advanced topics & tricks, since it's supposed to be an introductory example.

Tested on Linux, Mac, Windows.