### PR TITLE
[docs] Add `geekbrother/cxx-corrosion-cmake` repo to the CMake docs.

### DIFF
--- a/book/src/build/cmake.md
+++ b/book/src/build/cmake.md
@@ -30,6 +30,14 @@ what is available in these links, feel free to make a PR adding it to this list.
 
 ---
 
+- **<https://github.com/geekbrother/cxx-corrosion-cmake>**
+
+  - Improved rusty_cmake CMake file to use modern C++
+  - Rich examples of using different primitive types and Rust's Result return to C++
+  - MacOS and Linux only
+
+---
+
 - **<https://github.com/paandahl/cpp-with-rust>**
 
   - Same blobstore example as the official demo, but inverted languages


### PR DESCRIPTION
Update the CMake docs repositories list with the `geekbrother/cxx-corrosion-cmake` repository that has good examples, is easy to build with Docker and Nix, and a modern CMake file to use a CXX+Corrosion.