### PR TITLE
Add Unpin impl for UniquePtr.

### DIFF
--- a/src/unique_ptr.rs
+++ b/src/unique_ptr.rs
@@ -177,6 +177,10 @@ where
     }
 }
 
+/// UniquePtr is not a self-referential type and can be moved around freely.
+/// Therefore it can be Unpin, even if its target is not Unpin.
+impl<T> Unpin for UniquePtr<T> where T: UniquePtrTarget {}
+
 /// Trait bound for types which may be used as the `T` inside of a
 /// `UniquePtr<T>` in generic code.
 ///


### PR DESCRIPTION
Similar to a std::boxed::Box, a UniquePtr itself can be Unpin, even if
its target is not Unpin.
As UniquePtr is not a self-referential type, this is safe to do.

See:
- https://doc.rust-lang.org/std/pin/index.html#unpin
- https://doc.rust-lang.org/std/boxed/struct.Box.html#impl-Unpin