### PR TITLE
Fix missing <string> include in std::string example

### DIFF
--- a/book/src/binding/cxxstring.md
+++ b/book/src/binding/cxxstring.md
@@ -73,6 +73,7 @@ fn main() {
 #pragma once
 #include <map>
 #include <memory>
+#include <string>
 #include <variant>
 #include <vector>
 


### PR DESCRIPTION
The previous code works in _some_ STL implementations, namely if _either_ of the following is true:

1. At least one of the other four STL headers included by json.h transitively includes \<string\>, as opposed to just \<stringfwd.h\>; or

2. The way std::variant is implemented does not require knowing the inner types' type traits when just naming the std::variant without yet instantiating any of its member function templates.

On other STL implementations in which neither of the above is true, this example failed to build with an error such as:

```console
In file included from target/debug/build/example-d2d484e0c793273c/out/cxxbridge/sources/example/src/main.rs.cc:1:
In file included from target/debug/build/example-d2d484e0c793273c/out/cxxbridge/crate/example/include/json.h:2:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/map:60:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:63:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_algobase.h:64:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_pair.h:59:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/move.h:57:
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/type_traits:1339:23: error: implicit instantiation of undefined template 'std::basic_string<char>'
                    __bool_constant<__has_trivial_destructor(_Tp)>>
                                    ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/type_traits:3214:5: note: in instantiation of template class 'std::is_trivially_destructible<std::basic_string<char>>' requested here
    is_trivially_destructible<_Tp>::value;
    ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:299:5: note: in instantiation of variable template specialization 'std::is_trivially_destructible_v<std::basic_string<char>>' requested here
          (is_trivially_destructible_v<_Types> && ...);
           ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:308:4: note: in instantiation of static data member 'std::__detail::__variant::_Traits<std::monostate, double, std::basic_string<char>, std::vector<json>, std::map<std::basic_string<char>, json>>::_S_trivial_dtor' requested here
          _S_trivial_dtor && _S_trivial_move_ctor
          ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:689:45: note: in instantiation of static data member 'std::__detail::__variant::_Traits<std::monostate, double, std::basic_string<char>, std::vector<json>, std::map<std::basic_string<char>, json>>::_S_trivial_move_assign' requested here
      _Move_assign_base<_Traits<_Types...>::_S_trivial_move_assign, _Types...>;
                                            ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:692:28: note: in instantiation of template type alias '_Move_assign_alias' requested here
    struct _Variant_base : _Move_assign_alias<_Types...>
                           ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1318:15: note: in instantiation of template class 'std::__detail::__variant::_Variant_base<std::monostate, double, std::basic_string<char>, std::vector<json>, std::map<std::basic_string<char>, json>>' requested here
    : private __detail::__variant::_Variant_base<_Types...>,
              ^
target/debug/build/example-d2d484e0c793273c/out/cxxbridge/crate/example/include/json.h:33:63: note: in instantiation of template class 'std::variant<std::monostate, double, std::basic_string<char>, std::vector<json>, std::map<std::basic_string<char>, json>>' requested here
  std::variant<std::monostate, number, string, array, object> value;
                                                              ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stringfwd.h:74:11: note: template is declared here
    class basic_string;
          ^
```