### PR TITLE
tests/ffi: strange error with a function returning Vec<Buffer>

### DIFF
--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -421,7 +421,9 @@ impl ffi::Array {
 
 #[derive(Default)]
 #[repr(C)]
-pub struct Buffer([c_char; 12]);
+pub struct Buffer {
+    buf: [c_char; 12],
+}
 
 unsafe impl ExternType for Buffer {
     type Id = type_id!("tests::Buffer");

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -270,6 +270,7 @@ pub mod ffi {
         fn r_return_rust_string() -> String;
         fn r_return_unique_ptr_string() -> UniquePtr<CxxString>;
         fn r_return_rust_vec() -> Vec<u8>;
+        fn r_return_rust_vec_trivial() -> Vec<Buffer>;
         fn r_return_rust_vec_string() -> Vec<String>;
         fn r_return_rust_vec_extern_struct() -> Vec<Job>;
         fn r_return_ref_rust_vec(shared: &Shared) -> &Vec<u8>;
@@ -503,6 +504,10 @@ fn r_return_unique_ptr_string() -> UniquePtr<CxxString> {
 }
 
 fn r_return_rust_vec() -> Vec<u8> {
+    Vec::new()
+}
+
+fn r_return_rust_vec_trivial() -> Vec<Buffer> {
     Vec::new()
 }
 

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -84,7 +84,9 @@ struct Borrow {
   const std::string &s;
 };
 
-typedef char Buffer[12];
+struct Buffer {
+  char buf[12];
+};
 
 size_t c_return_primitive();
 Shared c_return_shared();


### PR DESCRIPTION
The error triggers a warning for the Buffer field in Array that was already there but somehow silent.

    cargo:warning=.../out/cxxbridge/sources/tests/ffi/lib.rs.cc:1387:45:
        error: static assertion failed: type tests::Buffer should be trivially
               move constructible and trivially destructible in C++ to be used
               as a field of `Array` or vector element in Vec<Buffer> in Rust
    cargo:warning= 1387 |     ::rust::IsRelocatable<::tests::Buffer>::value,

- Here the [failing pipeline log](https://github.com/dtolnay/cxx/actions/runs/3081009896/jobs/4979054704#step:7:57) for the error above (first commit c858291a9ff62bcbd123363407cd73e05ab1a46a).
- The "fix" is not complete either, the plain Buffer struct code does not pass the tests on windows: [msvc pipeline logs](https://github.com/dtolnay/cxx/actions/runs/3081012199/jobs/4979060118#step:7:59) (second commit d0537c91e56e570b880046be092c4068739cb41c)