### PR TITLE
Allow Rust vector of array of trivially relocatable type

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -472,10 +472,10 @@ fn check_trivial_extern_type(out: &mut OutFile, alias: &TypeAlias, reasons: &[Tr
     writeln!(out, "static_assert(");
     if reasons
         .iter()
-        .all(|r| matches!(r, TrivialReason::StructField(_)))
+        .all(|r| matches!(r, TrivialReason::StructField(_) | TrivialReason::VecElement))
     {
-        // If the type is only used as a struct field and not as by-value
-        // function argument or any other use, then C array of trivially
+        // If the type is only used as a struct field or Vec element, not as
+        // by-value function argument or return value, then C array of trivially
         // relocatable type is also permissible.
         //
         //     --- means something sane:


### PR DESCRIPTION
Closes #1098.