### PR TITLE
Added support for std::function

### DIFF
--- a/gen/src/cfg.rs
+++ b/gen/src/cfg.rs
@@ -113,6 +113,7 @@ impl Api {
         match self {
             Api::Include(include) => &include.cfg,
             Api::Struct(strct) => &strct.cfg,
+            Api::TupleStruct(_) => &CfgExpr::Unconditional,
             Api::Enum(enm) => &enm.cfg,
             Api::CxxType(ety) | Api::RustType(ety) => &ety.cfg,
             Api::CxxFunction(efn) | Api::RustFunction(efn) => &efn.cfg,

--- a/gen/src/namespace.rs
+++ b/gen/src/namespace.rs
@@ -8,7 +8,7 @@ impl Api {
             Api::CxxType(ety) | Api::RustType(ety) => &ety.name.namespace,
             Api::Enum(enm) => &enm.name.namespace,
             Api::Struct(strct) => &strct.name.namespace,
-            Api::Impl(_) | Api::Include(_) | Api::TypeAlias(_) => Default::default(),
+            Api::TupleStruct(_) | Api::Impl(_) | Api::Include(_) | Api::TypeAlias(_) => Default::default(),
         }
     }
 }

--- a/src/cxx_function.rs
+++ b/src/cxx_function.rs
@@ -1,0 +1,73 @@
+use core::marker::{PhantomData};
+use std::mem::MaybeUninit;
+use core::ffi::c_void;
+use crate::std::fmt;
+
+/// Binding to C++ `std::function<R(A...)`.
+///
+/// # Invariants
+///
+/// As an invariant of this API and the static analysis of the cxx::bridge
+/// macro, in Rust code we can never obtain a `CxxFunction` by value. Instead in
+/// Rust code we will only ever look at a callback behind a reference or smart
+/// pointer, as in `&CxxFunction<A, R>` or `UniquePtr<CxxFunction<A, R>>`.
+#[repr(C, packed)]
+pub struct CxxFunction<A, R> {
+    // A thing, because repr(C) structs are not allowed to consist exclusively
+    // of PhantomData fields.
+    _void: [c_void; 0],
+    _func: PhantomData<fn(R) -> A>,
+}
+
+impl<A: CxxFunctionArguments<R>, R> CxxFunction<A, R> {
+
+    /// Sends the callback and the arguments to C++ land, and calls it there
+    pub fn call(&self, arguments: A) -> R {
+        unsafe { A::__call(self, arguments) }
+    }
+}
+
+/// Trait bound for types which may be used as the `A` inside of a
+/// `CxxFunction<A, R>` in generic code.
+///
+/// This trait has no publicly callable or implementable methods. Implementing
+/// it outside of the CXX codebase is not supported.
+///
+/// # Example
+///
+/// A bound `T: CxxFunctionArguments` may be necessary when manipulating
+/// [`CxxFunction`] in generic code.
+///
+/// ```
+/// use cxx::CxxFunction;
+/// use cxx::private::CxxFunctionArguments;
+/// use std::fmt::Display;
+///
+/// pub fn take_generic_function<A, R>(ptr: &CxxFunction<A, R>, arguments: A)
+/// where
+///     A: CxxFunctionArguments<R>,
+///     R: Display,
+/// {
+///     let result = ptr.call(arguments);
+///     println!("the callback returned: {}", result);
+/// }
+/// ```
+///
+/// Writing the same generic function without a `CxxFunctionArguments` trait bound
+/// would not compile.
+pub unsafe trait CxxFunctionArguments<R>: Sized {
+    #[doc(hidden)]
+    unsafe fn __call(f: &CxxFunction<Self, R>, arg: Self) -> R;
+    #[doc(hidden)]
+    fn __typename(f: &mut fmt::Formatter) -> fmt::Result;
+    #[doc(hidden)]
+    fn __unique_ptr_null() -> MaybeUninit<*mut c_void>;
+    #[doc(hidden)]
+    unsafe fn __unique_ptr_raw(raw: *mut CxxFunction<Self, R>) -> MaybeUninit<*mut c_void>;
+    #[doc(hidden)]
+    unsafe fn __unique_ptr_get(repr: MaybeUninit<*mut c_void>) -> *const CxxFunction<Self, R>;
+    #[doc(hidden)]
+    unsafe fn __unique_ptr_release(repr: MaybeUninit<*mut c_void>) -> *mut CxxFunction<Self, R>;
+    #[doc(hidden)]
+    unsafe fn __unique_ptr_drop(repr: MaybeUninit<*mut c_void>);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,6 +437,7 @@ compile_error! {
 mod macros;
 
 mod c_char;
+mod cxx_function;
 mod cxx_vector;
 mod exception;
 mod extern_type;
@@ -464,6 +465,7 @@ pub mod vector;
 mod weak_ptr;
 
 pub use crate::cxx_vector::CxxVector;
+pub use crate::cxx_function::CxxFunction;
 #[cfg(feature = "alloc")]
 pub use crate::exception::Exception;
 pub use crate::extern_type::{kind, ExternType};
@@ -491,6 +493,7 @@ pub type Vector<T> = CxxVector<T>;
 #[doc(hidden)]
 pub mod private {
     pub use crate::cxx_vector::VectorElement;
+    pub use crate::cxx_function::CxxFunctionArguments;
     pub use crate::extern_type::{verify_extern_kind, verify_extern_type};
     pub use crate::function::FatFunction;
     pub use crate::hash::hash;

--- a/src/unique_ptr.rs
+++ b/src/unique_ptr.rs
@@ -2,13 +2,14 @@ use crate::cxx_vector::{CxxVector, VectorElement};
 use crate::fmt::display;
 use crate::kind::Trivial;
 use crate::string::CxxString;
-use crate::ExternType;
+use crate::{CxxFunction, ExternType};
 use core::ffi::c_void;
 use core::fmt::{self, Debug, Display};
 use core::marker::PhantomData;
 use core::mem::{self, MaybeUninit};
 use core::ops::{Deref, DerefMut};
 use core::pin::Pin;
+use cxx::private::CxxFunctionArguments;
 
 /// Binding to C++ `std::unique_ptr<T, std::default_delete<T>>`.
 #[repr(C)]
@@ -277,6 +278,30 @@ where
 {
     fn __typename(f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "CxxVector<{}>", display(T::__typename))
+    }
+    fn __null() -> MaybeUninit<*mut c_void> {
+        T::__unique_ptr_null()
+    }
+    unsafe fn __raw(raw: *mut Self) -> MaybeUninit<*mut c_void> {
+        unsafe { T::__unique_ptr_raw(raw) }
+    }
+    unsafe fn __get(repr: MaybeUninit<*mut c_void>) -> *const Self {
+        unsafe { T::__unique_ptr_get(repr) }
+    }
+    unsafe fn __release(repr: MaybeUninit<*mut c_void>) -> *mut Self {
+        unsafe { T::__unique_ptr_release(repr) }
+    }
+    unsafe fn __drop(repr: MaybeUninit<*mut c_void>) {
+        unsafe { T::__unique_ptr_drop(repr) }
+    }
+}
+
+unsafe impl<T, U> UniquePtrTarget for CxxFunction<T, U>
+    where
+        T: CxxFunctionArguments<U>,
+{
+    fn __typename(f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "CxxFunction<{}>", display(T::__typename))
     }
     fn __null() -> MaybeUninit<*mut c_void> {
         T::__unique_ptr_null()

--- a/syntax/ident.rs
+++ b/syntax/ident.rs
@@ -33,7 +33,10 @@ pub(crate) fn check_all(cx: &mut Check, apis: &[Api]) {
                 for field in &strct.fields {
                     check(cx, &field.name);
                 }
-            }
+            },
+            Api::TupleStruct(tstrct) => {
+                check(cx, &tstrct.name);
+            },
             Api::Enum(enm) => {
                 check(cx, &enm.name);
                 for variant in &enm.variants {

--- a/syntax/improper.rs
+++ b/syntax/improper.rs
@@ -28,7 +28,7 @@ impl<'a> Types<'a> {
             | Type::Fn(_)
             | Type::Void(_)
             | Type::SliceRef(_) => Definite(true),
-            Type::UniquePtr(_) | Type::SharedPtr(_) | Type::WeakPtr(_) | Type::CxxVector(_) => {
+            Type::UniquePtr(_) | Type::SharedPtr(_) | Type::WeakPtr(_) | Type::CxxVector(_) | Type::CxxFunction(_) => {
                 Definite(false)
             }
             Type::Ref(ty) => self.determine_improper_ctype(&ty.inner),

--- a/syntax/instantiate.rs
+++ b/syntax/instantiate.rs
@@ -1,4 +1,4 @@
-use crate::syntax::{NamedType, Ty1, Type};
+use crate::syntax::{NamedType, Ty1, Ty2, Type};
 use proc_macro2::{Ident, Span};
 use std::hash::{Hash, Hasher};
 use syn::Token;
@@ -11,6 +11,7 @@ pub enum ImplKey<'a> {
     SharedPtr(NamedImplKey<'a>),
     WeakPtr(NamedImplKey<'a>),
     CxxVector(NamedImplKey<'a>),
+    CxxFunction(DoubleNamedImplKey<'a>),
 }
 
 #[derive(Copy, Clone)]
@@ -19,6 +20,19 @@ pub struct NamedImplKey<'a> {
     pub rust: &'a Ident,
     pub lt_token: Option<Token![<]>,
     pub gt_token: Option<Token![>]>,
+    pub end_span: Span,
+}
+
+#[derive(Copy, Clone)]
+pub struct DoubleNamedImplKey<'a> {
+    pub begin_span: Span,
+    pub id1_ampersand: Option<Token![&]>,
+    pub id1: &'a Ident,
+    pub id1_lt_token: Option<Token![<]>,
+    pub id1_gt_token: Option<Token![>]>,
+    pub id2: Option<&'a Ident>,
+    pub id2_lt_token: Option<Token![<]>,
+    pub id2_gt_token: Option<Token![>]>,
     pub end_span: Span,
 }
 
@@ -48,6 +62,22 @@ impl Type {
             if let Type::Ident(ident) = &ty.inner {
                 return Some(ImplKey::CxxVector(NamedImplKey::new(ty, ident)));
             }
+        } else if let Type::CxxFunction(ty) = self {
+            let ret: Option<&NamedType> = if let Type::Ident(ret) = &ty.second {
+                Some(ret)
+            } else if let Type::Void(_) = &ty.second {
+                None
+            } else {
+                return None;
+            };
+
+            if let Type::Ident(args) = &ty.first {
+                return Some(ImplKey::CxxFunction(DoubleNamedImplKey::new(ty, None, args, ret)));
+            } else if let Type::Ref(rf) = &ty.first {
+                if let Type::Ident(args) = &rf.inner {
+                    return Some(ImplKey::CxxFunction(DoubleNamedImplKey::new(ty, Some(rf.ampersand), args, ret)));
+                }
+            }
         }
         None
     }
@@ -74,6 +104,40 @@ impl<'a> NamedImplKey<'a> {
             rust: &inner.rust,
             lt_token: inner.generics.lt_token,
             gt_token: inner.generics.gt_token,
+            end_span: outer.rangle.span,
+        }
+    }
+}
+
+impl<'a> PartialEq for DoubleNamedImplKey<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        self.id1_ampersand.is_some() == other.id1_ampersand.is_some()
+            && PartialEq::eq(&self.id1, &other.id1)
+            && PartialEq::eq(&self.id2, &other.id2)
+    }
+}
+
+impl<'a> Eq for DoubleNamedImplKey<'a> {}
+
+impl<'a> Hash for DoubleNamedImplKey<'a> {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        self.id1_ampersand.is_some().hash(hasher);
+        self.id1.hash(hasher);
+        self.id2.hash(hasher);
+    }
+}
+
+impl<'a> DoubleNamedImplKey<'a> {
+    fn new(outer: &Ty2, ampersand: Option<Token![&]>, first: &'a NamedType, second: Option<&'a NamedType>) -> Self {
+        DoubleNamedImplKey {
+            begin_span: outer.name.span(),
+            id1_ampersand: ampersand,
+            id1: &first.rust,
+            id1_lt_token: first.generics.lt_token,
+            id1_gt_token: first.generics.gt_token,
+            id2: second.map(|s| &s.rust),
+            id2_lt_token: second.map(|s| s.generics.lt_token).flatten(),
+            id2_gt_token: second.map(|s| s.generics.gt_token).flatten(),
             end_span: outer.rangle.span,
         }
     }

--- a/syntax/mangle.rs
+++ b/syntax/mangle.rs
@@ -73,8 +73,9 @@
 //             - CXXBRIDGE1_STRUCT_org$rust$Struct
 //             - CXXBRIDGE1_ENUM_Enabled
 
+use proc_macro2::Ident;
 use crate::syntax::symbol::{self, Symbol};
-use crate::syntax::{ExternFn, Pair, Types};
+use crate::syntax::{Atom, ExternFn, Pair, Types};
 
 const CXXBRIDGE: &str = "cxxbridge1";
 
@@ -117,4 +118,16 @@ pub fn c_trampoline(efn: &ExternFn, var: &Pair, types: &Types) -> Symbol {
 // The Rust half of a function pointer trampoline.
 pub fn r_trampoline(efn: &ExternFn, var: &Pair, types: &Types) -> Symbol {
     join!(extern_fn(efn, types), var.rust, 1)
+}
+
+pub fn mangle_ident(ident: Option<&Ident>, types: &Types) -> Symbol {
+    if let Some(some) = ident {
+        if let Some(_) = Atom::from(&some) {
+            symbol::join(&[&&some.to_string()[..]])
+        } else {
+            types.resolve(some).name.to_symbol()
+        }
+    } else {
+        symbol::join(&[&"void"])
+    }
 }

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -51,6 +51,7 @@ pub use self::types::Types;
 pub enum Api {
     Include(Include),
     Struct(Struct),
+    TupleStruct(TupleStruct),
     Enum(Enum),
     CxxType(ExternType),
     CxxFunction(ExternFn),
@@ -191,6 +192,13 @@ pub struct Signature {
     pub throws_tokens: Option<(kw::Result, Token![<], Token![>])>,
 }
 
+pub struct TupleStruct {
+    pub name: Pair,
+    pub types: Punctuated<Type, Token![,]>,
+    pub paren_token: Paren,
+    pub generics: Lifetimes,
+}
+
 pub struct Var {
     pub cfg: CfgExpr,
     pub doc: Doc,
@@ -234,6 +242,7 @@ pub enum Type {
     Ptr(Box<Ptr>),
     Str(Box<Ref>),
     CxxVector(Box<Ty1>),
+    CxxFunction(Box<Ty2>),
     Fn(Box<Signature>),
     Void(Span),
     SliceRef(Box<SliceRef>),
@@ -244,6 +253,15 @@ pub struct Ty1 {
     pub name: Ident,
     pub langle: Token![<],
     pub inner: Type,
+    pub rangle: Token![>],
+}
+
+pub struct Ty2 {
+    pub name: Ident,
+    pub langle: Token![<],
+    pub first: Type,
+    pub comma: Token![,],
+    pub second: Type,
     pub rangle: Token![>],
 }
 

--- a/syntax/pod.rs
+++ b/syntax/pod.rs
@@ -28,6 +28,7 @@ impl<'a> Types<'a> {
             | Type::SharedPtr(_)
             | Type::WeakPtr(_)
             | Type::CxxVector(_)
+            | Type::CxxFunction(_)
             | Type::Void(_) => false,
             Type::Ref(_) | Type::Str(_) | Type::Fn(_) | Type::SliceRef(_) | Type::Ptr(_) => true,
             Type::Array(array) => self.is_guaranteed_pod(&array.inner),

--- a/syntax/resolve.rs
+++ b/syntax/resolve.rs
@@ -1,5 +1,5 @@
-use crate::syntax::instantiate::NamedImplKey;
-use crate::syntax::{Lifetimes, NamedType, Pair, Types};
+use crate::syntax::instantiate::{DoubleNamedImplKey, NamedImplKey};
+use crate::syntax::{Lifetime, Lifetimes, NamedType, Pair, Type, Types, TupleStruct};
 use proc_macro2::Ident;
 
 #[derive(Copy, Clone)]
@@ -9,6 +9,27 @@ pub struct Resolution<'a> {
 }
 
 impl<'a> Types<'a> {
+    pub fn resolve_tuple_struct(&self, ident: &impl UnresolvedName) -> Option<&TupleStruct> {
+        self.tuple_structs.get(ident.ident()).map(|t| *t)
+    }
+
+    pub fn resolve_cxx_arg_type(&self, key: &DoubleNamedImplKey) -> (Option<&Type>, Option<&Lifetime>) {
+        for t in self.all.iter() {
+            if let Type::Ident(t_ident) = t {
+                if &t_ident.rust == key.id1 && key.id1_ampersand.is_none() {
+                    return (Some(t), None)
+                }
+            } else if let Type::Ref(t_ref) = t {
+                if let Type::Ident(t_ident) = &t_ref.inner {
+                    if &t_ident.rust == key.id1 && key.id1_ampersand.is_some() {
+                        return (Some(t), t_ref.lifetime.as_ref())
+                    }
+                }
+            }
+        }
+        (None, None)
+    }
+
     pub fn resolve(&self, ident: &impl UnresolvedName) -> Resolution<'a> {
         let ident = ident.ident();
         match self.try_resolve(ident) {

--- a/syntax/tokens.rs
+++ b/syntax/tokens.rs
@@ -1,7 +1,7 @@
 use crate::syntax::atom::Atom::*;
 use crate::syntax::{
     Array, Atom, Derive, Enum, EnumRepr, ExternFn, ExternType, Impl, Lifetimes, NamedType, Ptr,
-    Ref, Signature, SliceRef, Struct, Ty1, Type, TypeAlias, Var,
+    Ref, Signature, SliceRef, Struct, Ty1, Ty2, Type, TypeAlias, Var,
 };
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote_spanned, ToTokens};
@@ -26,6 +26,7 @@ impl ToTokens for Type {
             | Type::WeakPtr(ty)
             | Type::CxxVector(ty)
             | Type::RustVec(ty) => ty.to_tokens(tokens),
+            Type::CxxFunction(ty) => ty.to_tokens(tokens),
             Type::Ref(r) | Type::Str(r) => r.to_tokens(tokens),
             Type::Ptr(p) => p.to_tokens(tokens),
             Type::Array(a) => a.to_tokens(tokens),
@@ -63,7 +64,7 @@ impl ToTokens for Ty1 {
         } = self;
         let span = name.span();
         match name.to_string().as_str() {
-            "UniquePtr" | "SharedPtr" | "WeakPtr" | "CxxVector" => {
+            "UniquePtr" | "SharedPtr" | "WeakPtr" | "CxxVector" | "CxxFunction" => {
                 tokens.extend(quote_spanned!(span=> ::cxx::));
             }
             "Vec" => {
@@ -74,6 +75,32 @@ impl ToTokens for Ty1 {
         name.to_tokens(tokens);
         langle.to_tokens(tokens);
         inner.to_tokens(tokens);
+        rangle.to_tokens(tokens);
+    }
+}
+
+impl ToTokens for Ty2 {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let Ty2 {
+            name,
+            langle,
+            first,
+            comma,
+            second,
+            rangle,
+        } = self;
+        let span = name.span();
+        match name.to_string().as_str() {
+            "CxxFunction" => {
+                tokens.extend(quote_spanned!(span=> ::cxx::));
+            }
+            _ => {}
+        }
+        name.to_tokens(tokens);
+        langle.to_tokens(tokens);
+        first.to_tokens(tokens);
+        comma.to_tokens(tokens);
+        second.to_tokens(tokens);
         rangle.to_tokens(tokens);
     }
 }

--- a/syntax/visit.rs
+++ b/syntax/visit.rs
@@ -18,6 +18,10 @@ where
         | Type::WeakPtr(ty)
         | Type::CxxVector(ty)
         | Type::RustVec(ty) => visitor.visit_type(&ty.inner),
+        | Type::CxxFunction(ty) => {
+            visitor.visit_type(&ty.first);
+            visitor.visit_type(&ty.second);
+        }
         Type::Ref(r) => visitor.visit_type(&r.inner),
         Type::Ptr(p) => visitor.visit_type(&p.inner),
         Type::Array(a) => visitor.visit_type(&a.inner),

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -16,7 +16,7 @@
 pub mod cast;
 pub mod module;
 
-use cxx::{type_id, CxxString, CxxVector, ExternType, SharedPtr, UniquePtr};
+use cxx::{type_id, CxxFunction, CxxString, CxxVector, ExternType, SharedPtr, UniquePtr};
 use std::fmt::{self, Display};
 use std::mem::MaybeUninit;
 use std::os::raw::c_char;
@@ -254,6 +254,19 @@ pub mod ffi {
         type Buffer = crate::Buffer;
     }
 
+    pub struct TestArgs<'a>(
+        u8,
+        &'a R,
+        Vec<u8>,
+        &'a Vec<u8>,
+        String,
+        &'a String,
+        SharedString,
+        &'a SharedString,
+        Box<R>,
+    );
+    pub struct NoArgs();
+
     extern "Rust" {
         type R;
 
@@ -290,6 +303,10 @@ pub mod ffi {
         fn r_take_rust_string(s: String);
         fn r_take_unique_ptr_string(s: UniquePtr<CxxString>);
         fn r_take_ref_vector(v: &CxxVector<u8>);
+        fn r_take_ref_func_tuple_args(v: &CxxFunction<TestArgs, u8>);
+        unsafe fn r_take_ref_func_single_arg_opaque<'a>(f: &CxxFunction<&'a R, ()>);
+        fn r_take_unique_ptr_func(v: UniquePtr<CxxFunction<NoArgs, ()>>);
+        fn r_take_ref_func_no_args(v: &'static CxxFunction<NoArgs, ()>);
         fn r_take_ref_empty_vector(v: &CxxVector<u64>);
         fn r_take_rust_vec(v: Vec<u8>);
         fn r_take_rust_vec_string(v: Vec<String>);
@@ -591,6 +608,35 @@ fn r_take_unique_ptr_string(s: UniquePtr<CxxString>) {
 fn r_take_ref_vector(v: &CxxVector<u8>) {
     let slice = v.as_slice();
     assert_eq!(slice, [20, 2, 0]);
+}
+
+fn r_take_ref_func_tuple_args(f: &CxxFunction<ffi::TestArgs, u8>) {
+    let retval = f.call(
+        ffi::TestArgs(
+            2,
+            &R(911),
+            vec![42],
+            &vec![64],
+            "malin".to_owned(),
+            &"iladalen".to_string(),
+            ffi::SharedString { msg: "sagene".to_owned() },
+            &ffi::SharedString { msg: "torshov".to_owned() },
+            Box::new(R(777)),
+        )
+    );
+    assert_eq!(200, retval);
+}
+
+unsafe fn r_take_ref_func_single_arg_opaque<'a>(f: &CxxFunction<&'a R, ()>) {
+    f.call(&R(128));
+}
+
+fn r_take_unique_ptr_func(f: UniquePtr<CxxFunction<ffi::NoArgs, ()>>) {
+    f.call(ffi::NoArgs());
+}
+
+fn r_take_ref_func_no_args(f: &'static CxxFunction<ffi::NoArgs, ()>) {
+    f.call(ffi::NoArgs());
 }
 
 fn r_take_ref_empty_vector(v: &CxxVector<u64>) {

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -794,6 +794,63 @@ extern "C" const char *cxx_run_test() noexcept {
   r_take_unique_ptr_string(
       std::unique_ptr<std::string>(new std::string("2020")));
   r_take_ref_vector(std::vector<uint8_t>{20, 2, 0});
+
+  uint8_t capture_val1;
+  size_t capture_val2;
+  uint8_t capture_vec_elem;
+  uint8_t capture_vec_ref_elem;
+  std::string capture_string;
+  std::string capture_string_ref;
+  SharedString capture_shared;
+  SharedString capture_shared_ref;
+  size_t capture_box_value;
+  auto fn = [&](
+    uint8_t arg,
+    const tests::R& arg2,
+    rust::Vec<uint8_t> vec,
+    const rust::Vec<uint8_t>& vec_ref,
+    rust::String str,
+    const rust::String& str_ref,
+    SharedString shared_str,
+    const SharedString& shared_str_ref,
+    rust::Box<tests::R> box
+  ) {
+    capture_val1 = arg;
+    capture_val2 = arg2.get();
+    capture_vec_elem = vec.at(0);
+    capture_vec_ref_elem = vec_ref.at(0);
+    capture_string = static_cast<std::string>(str);
+    capture_string_ref = static_cast<std::string>(str_ref);
+    capture_shared = shared_str;
+    capture_shared_ref = shared_str_ref;
+    capture_box_value = box->get();
+    return (uint8_t)200;
+  };
+  r_take_ref_func_tuple_args(fn);
+  ASSERT(capture_val1 == 2);
+  ASSERT(capture_val2 == 911);
+  ASSERT(capture_vec_elem == 42);
+  ASSERT(capture_vec_ref_elem == 64);
+  ASSERT(capture_string == "malin");
+  ASSERT(capture_string_ref == "iladalen");
+  ASSERT(capture_shared.msg == "sagene");
+  ASSERT(capture_shared_ref.msg == "torshov");
+  ASSERT(capture_box_value == 777);
+
+  uint8_t capture_from_noarg_lambda;
+  auto noarg_fn = [&]() {
+    capture_from_noarg_lambda = 66;
+  };
+  r_take_ref_func_no_args(noarg_fn);
+  ASSERT(capture_from_noarg_lambda == 66);
+
+
+  uint8_t capture_from_struct;
+  r_take_ref_func_single_arg_opaque([&](const tests::R& arg) {
+    capture_from_struct = arg.get();
+  });
+  ASSERT(capture_from_struct == 128);
+
   std::vector<uint64_t> empty_vector;
   r_take_ref_empty_vector(empty_vector);
   empty_vector.reserve(10);


### PR DESCRIPTION
I put this up as a draft to get feedback; the code still needs cleanup / documentation.

I have added support for `std::function`, with the following interface:

```rust
#[cxx::bridge]
pub mod ffi {
    pub struct CallbackArgs<'a>(
        u8,
        &'a Vec<u8>,
        Box<OpaqueStruct>,
    );
    
    extern "Rust" {
        type OpaqueStruct;
        fn t_take_ref_func(v: &CxxFunction<CallbackArgs, u16>);
    }
}

fn r_take_ref_func_tuple_args(f: &CxxFunction<ffi::CallbackArgs, u16>) {
    let ret = f.call(
        ffi::TestArgs(
            2,
            vec![42],
            Box::new(OpaqueStruct { ... }),
        )
    );
}
```

Usage from C++:

```c++
r_take_ref_func_tuple_args([&](
    uint8_t arg,
    rust::Vec<uint8_t> arg2,
    rust::Box<tests::OpaqueStruct> arg3
) {
    ...
    return (uint16_t)200;
});
```

## Explanation

The `CxxFunction<A, R>` takes two template arguments.

* `A` - the arguments. Can be one of:
    1. A shared or opaque Rust type that is declared in the crate
    2. A tuple struct (most internal types supported)
* `R` - the return type.

If `A` is a tuple struct, the contents will be spread out, so that each element will match a function argument. The tuple struct itself evaporates at the language boundary.

The callback can also be passed by value, wrapped in a UniquePtr.

## Rationale

I wanted the API to resemble those of CxxVector, UniquePtr, etc. The tuple struct is not ideal, but necessary to allow for multiple arguments.

I considered looking into a wrapper that would expose the callback as a Fn trait object, but that seems out of line with the rest of the API.

## Possible improvements

* The code can probably be simplified / cleaned up a bit more
* Some things are skipped for now - checking-logic, documentation, etc.

## Discussion

How was this functionality imagined? Is this the way to go, or are there better ways to solve the problem at hand?

Closes: #52 