### PR TITLE
`impl` Blocks and Static Methods

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -726,7 +726,7 @@ fn expand_cxx_function_shim(efn: &ExternFn, types: &Types) -> TokenStream {
         #trampolines
         #dispatch
     });
-    match &efn.receiver {
+    match &efn.class {
         None => {
             quote! {
                 #doc
@@ -734,12 +734,12 @@ fn expand_cxx_function_shim(efn: &ExternFn, types: &Types) -> TokenStream {
                 #visibility #unsafety #fn_token #ident #generics #arg_list #ret #fn_body
             }
         }
-        Some(receiver) => {
+        Some(class) => {
             let elided_generics;
-            let receiver_ident = &receiver.ty.rust;
-            let resolve = types.resolve(&receiver.ty);
-            let receiver_generics = if receiver.ty.generics.lt_token.is_some() {
-                &receiver.ty.generics
+            let class_ident = &class.rust;
+            let resolve = types.resolve(class);
+            let class_generics = if class.generics.lt_token.is_some() {
+                &class.generics
             } else {
                 elided_generics = Lifetimes {
                     lt_token: resolve.generics.lt_token,
@@ -758,7 +758,7 @@ fn expand_cxx_function_shim(efn: &ExternFn, types: &Types) -> TokenStream {
                 &elided_generics
             };
             quote_spanned! {ident.span()=>
-                impl #generics #receiver_ident #receiver_generics {
+                impl #generics #class_ident #class_generics {
                     #doc
                     #attrs
                     #visibility #unsafety #fn_token #ident #arg_list #ret #fn_body
@@ -1176,10 +1176,10 @@ fn expand_rust_function_shim_super(
     let vars = receiver_var.iter().chain(arg_vars);
 
     let span = invoke.span();
-    let call = match &sig.receiver {
+    let call = match &sig.class {
         None => quote_spanned!(span=> super::#invoke),
-        Some(receiver) => {
-            let receiver_type = &receiver.ty.rust;
+        Some(class) => {
+            let receiver_type = &class.rust;
             quote_spanned!(span=> #receiver_type::#invoke)
         }
     };

--- a/syntax/file.rs
+++ b/syntax/file.rs
@@ -1,10 +1,13 @@
 use crate::syntax::cfg::CfgExpr;
 use crate::syntax::namespace::Namespace;
+use proc_macro2::TokenStream;
 use quote::quote;
 use syn::parse::{Error, Parse, ParseStream, Result};
+use syn::spanned::Spanned;
 use syn::{
-    braced, token, Abi, Attribute, ForeignItem, Ident, Item as RustItem, ItemEnum, ItemImpl,
-    ItemStruct, ItemUse, LitStr, Token, Visibility,
+    braced, token, Abi, Attribute, ForeignItem as RustForeignItem, ForeignItemFn, ForeignItemMacro,
+    ForeignItemType, Ident, Item as RustItem, ItemEnum, ItemImpl, ItemStruct, ItemUse, LitStr,
+    Token, TypePath, Visibility,
 };
 
 pub struct Module {
@@ -34,6 +37,28 @@ pub struct ItemForeignMod {
     pub abi: Abi,
     pub brace_token: token::Brace,
     pub items: Vec<ForeignItem>,
+}
+
+pub enum ForeignItem {
+    Type(ForeignItemType),
+    Fn(ForeignItemFn),
+    Macro(ForeignItemMacro),
+    Verbatim(TokenStream),
+    Impl(ForeignItemImpl),
+    Other(RustForeignItem),
+}
+
+pub struct ForeignItemImpl {
+    pub attrs: Vec<Attribute>,
+    pub unsafety: Option<Token![unsafe]>,
+    pub impl_token: Token![impl],
+    pub self_ty: TypePath,
+    pub brace_token: token::Brace,
+    pub items: Vec<ForeignImplItem>,
+}
+
+pub enum ForeignImplItem {
+    Fn(ForeignItemFn),
 }
 
 impl Parse for Module {
@@ -83,14 +108,16 @@ impl Parse for Item {
         let attrs = input.call(Attribute::parse_outer)?;
 
         let ahead = input.fork();
-        let unsafety = if ahead.parse::<Option<Token![unsafe]>>()?.is_some()
-            && ahead.parse::<Option<Token![extern]>>()?.is_some()
+        ahead.parse::<Option<Token![unsafe]>>()?;
+        if ahead.parse::<Option<Token![extern]>>()?.is_some()
             && ahead.parse::<Option<LitStr>>().is_ok()
             && ahead.peek(token::Brace)
         {
-            Some(input.parse()?)
-        } else {
-            None
+            let unsafety = input.parse()?;
+            let mut foreign_mod = ItemForeignMod::parse(input)?;
+            foreign_mod.attrs.splice(..0, attrs);
+            foreign_mod.unsafety = unsafety;
+            return Ok(Item::ForeignMod(foreign_mod));
         };
 
         let item = input.parse()?;
@@ -103,16 +130,10 @@ impl Parse for Item {
                 item.attrs.splice(..0, attrs);
                 Ok(Item::Enum(item))
             }
-            RustItem::ForeignMod(mut item) => {
-                item.attrs.splice(..0, attrs);
-                Ok(Item::ForeignMod(ItemForeignMod {
-                    attrs: item.attrs,
-                    unsafety,
-                    abi: item.abi,
-                    brace_token: item.brace_token,
-                    items: item.items,
-                }))
-            }
+            RustItem::ForeignMod(item) => Err(syn::parse::Error::new(
+                item.span(),
+                "Reached generic ForeignMod code instead of custom ItemForeignMod, this is a bug",
+            )),
             RustItem::Impl(mut item) => {
                 item.attrs.splice(..0, attrs);
                 Ok(Item::Impl(item))
@@ -123,5 +144,72 @@ impl Parse for Item {
             }
             other => Ok(Item::Other(other)),
         }
+    }
+}
+
+impl Parse for ItemForeignMod {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut attrs = input.call(Attribute::parse_outer)?;
+        let abi: Abi = input.parse()?;
+
+        let content;
+        let brace_token = braced!(content in input);
+        attrs.extend(content.call(Attribute::parse_inner)?);
+        let mut items = Vec::new();
+        while !content.is_empty() {
+            items.push(content.parse()?);
+        }
+        Ok(ItemForeignMod {
+            attrs,
+            unsafety: None,
+            abi,
+            brace_token,
+            items,
+        })
+    }
+}
+
+impl Parse for ForeignItem {
+    fn parse(input: ParseStream) -> Result<Self> {
+        if input.peek(Token![impl]) {
+            return Ok(ForeignItem::Impl(ForeignItemImpl::parse(input)?));
+        }
+        Ok(match RustForeignItem::parse(input)? {
+            RustForeignItem::Type(ty) => ForeignItem::Type(ty),
+            RustForeignItem::Fn(f) => ForeignItem::Fn(f),
+            RustForeignItem::Macro(m) => ForeignItem::Macro(m),
+            RustForeignItem::Verbatim(t) => ForeignItem::Verbatim(t),
+            i => ForeignItem::Other(i),
+        })
+    }
+}
+
+impl Parse for ForeignItemImpl {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut attrs = input.call(Attribute::parse_outer)?;
+        let unsafety: Option<Token![unsafe]> = input.parse()?;
+        let impl_token: Token![impl] = input.parse()?;
+        let self_ty: TypePath = input.parse()?;
+        let content;
+        let brace_token = braced!(content in input);
+        attrs.extend(content.call(Attribute::parse_inner)?);
+        let mut items = Vec::new();
+        while !content.is_empty() {
+            items.push(content.parse()?);
+        }
+        Ok(ForeignItemImpl {
+            attrs,
+            unsafety,
+            impl_token,
+            self_ty,
+            brace_token,
+            items,
+        })
+    }
+}
+
+impl Parse for ForeignImplItem {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(ForeignImplItem::Fn(input.parse()?))
     }
 }

--- a/syntax/impls.rs
+++ b/syntax/impls.rs
@@ -319,6 +319,7 @@ impl PartialEq for Signature {
             throws,
             paren_token: _,
             throws_tokens: _,
+            class,
         } = self;
         let Signature {
             asyncness: asyncness2,
@@ -331,10 +332,12 @@ impl PartialEq for Signature {
             throws: throws2,
             paren_token: _,
             throws_tokens: _,
+            class: class2,
         } = other;
         asyncness.is_some() == asyncness2.is_some()
             && unsafety.is_some() == unsafety2.is_some()
             && receiver == receiver2
+            && class == class2
             && ret == ret2
             && throws == throws2
             && args.len() == args2.len()
@@ -375,6 +378,7 @@ impl Hash for Signature {
             throws,
             paren_token: _,
             throws_tokens: _,
+            class,
         } = self;
         asyncness.is_some().hash(state);
         unsafety.is_some().hash(state);
@@ -393,6 +397,7 @@ impl Hash for Signature {
         }
         ret.hash(state);
         throws.hash(state);
+        class.hash(state);
     }
 }
 

--- a/syntax/mangle.rs
+++ b/syntax/mangle.rs
@@ -85,13 +85,13 @@ macro_rules! join {
 }
 
 pub fn extern_fn(efn: &ExternFn, types: &Types) -> Symbol {
-    match &efn.receiver {
-        Some(receiver) => {
-            let receiver_ident = types.resolve(&receiver.ty);
+    match &efn.class {
+        Some(class) => {
+            let class_ident = types.resolve(class);
             join!(
                 efn.name.namespace,
                 CXXBRIDGE,
-                receiver_ident.name.cxx,
+                class_ident.name.cxx,
                 efn.name.rust,
             )
         }

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -184,6 +184,7 @@ pub struct Signature {
     pub fn_token: Token![fn],
     pub generics: Generics,
     pub receiver: Option<Receiver>,
+    pub class: Option<NamedType>,
     pub args: Punctuated<Var, Token![,]>,
     pub ret: Option<Type>,
     pub throws: bool,
@@ -299,7 +300,7 @@ pub struct Pair {
 
 // Wrapper for a type which needs to be resolved before it can be printed in
 // C++.
-#[derive(PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct NamedType {
     pub rust: Ident,
     pub generics: Lifetimes,

--- a/syntax/tokens.rs
+++ b/syntax/tokens.rs
@@ -258,6 +258,7 @@ impl ToTokens for Signature {
             throws: _,
             paren_token,
             throws_tokens,
+            class: _,
         } = self;
         fn_token.to_tokens(tokens);
         paren_token.surround(tokens, |tokens| {

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -91,6 +91,14 @@ pub mod ffi {
 
     unsafe extern "C++" {
         include!("tests/ffi/tests.h");
+        type L;
+        impl L {
+            fn impl_method(&self);
+        }
+    }
+
+    unsafe extern "C++" {
+        include!("tests/ffi/tests.h");
 
         type C;
 
@@ -215,6 +223,8 @@ pub mod ffi {
 
         #[namespace = "other"]
         fn ns_c_take_ns_shared(shared: AShared);
+
+        fn build_l() -> UniquePtr<L>;
     }
 
     extern "C++" {
@@ -311,6 +321,10 @@ pub mod ffi {
 
         #[cxx_name = "rAliasedFunction"]
         fn r_aliased_function(x: i32) -> String;
+
+        impl R {
+            fn get2(&self) -> usize;
+        }
     }
 
     struct Dag0 {
@@ -401,6 +415,10 @@ impl R {
     fn set(&mut self, n: usize) -> usize {
         self.0 = n;
         n
+    }
+
+    fn get2(&self) -> usize {
+        self.0
     }
 }
 

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -93,7 +93,9 @@ pub mod ffi {
         include!("tests/ffi/tests.h");
         type L;
         impl L {
+            fn build() -> UniquePtr<L>;
             fn impl_method(&self);
+            fn static_method(x: u32) -> u32;
         }
     }
 
@@ -223,8 +225,6 @@ pub mod ffi {
 
         #[namespace = "other"]
         fn ns_c_take_ns_shared(shared: AShared);
-
-        fn build_l() -> UniquePtr<L>;
     }
 
     extern "C++" {
@@ -324,6 +324,7 @@ pub mod ffi {
 
         impl R {
             fn get2(&self) -> usize;
+            fn assoc() -> usize;
         }
     }
 
@@ -419,6 +420,10 @@ impl R {
 
     fn get2(&self) -> usize {
         self.0
+    }
+
+    fn assoc() -> usize {
+        42
     }
 }
 

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -711,7 +711,12 @@ void L::impl_method() const {
   cxx_test_suite_set_correct();
 }
 
-std::unique_ptr<L> build_l() {
+uint32_t L::static_method(uint32_t arg) {
+  cxx_test_suite_set_correct();
+  return arg + 1;
+}
+
+std::unique_ptr<L> L::build() {
   return std::unique_ptr<L>(new L());
 }
 
@@ -903,6 +908,7 @@ extern "C" const char *cxx_run_test() noexcept {
   (void)rust::Vec<rust::isize>();
 
   // Test impl-based methods and functions
+  ASSERT(R::assoc() == 42);
   ASSERT(r->get() == r->get2());
 
   cxx_test_suite_set_correct();

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -707,6 +707,14 @@ void E::c_take_opaque_mut_ref_method() {
   }
 }
 
+void L::impl_method() const {
+  cxx_test_suite_set_correct();
+}
+
+std::unique_ptr<L> build_l() {
+  return std::unique_ptr<L>(new L());
+}
+
 void c_take_opaque_ns_ref(const ::F::F &f) {
   if (f.f == 40 && f.f_str == "hello") {
     cxx_test_suite_set_correct();
@@ -893,6 +901,9 @@ extern "C" const char *cxx_run_test() noexcept {
   // https://github.com/dtolnay/cxx/issues/705
   (void)rust::Vec<size_t>();
   (void)rust::Vec<rust::isize>();
+
+  // Test impl-based methods and functions
+  ASSERT(r->get() == r->get2());
 
   cxx_test_suite_set_correct();
   return nullptr;

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -72,6 +72,12 @@ struct E {
   void c_take_opaque_mut_ref_method();
 };
 
+struct L {
+  void impl_method() const;
+};
+
+std::unique_ptr<L> build_l();
+
 enum COwnedEnum {
   CVAL1,
   CVAL2,

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -74,9 +74,9 @@ struct E {
 
 struct L {
   void impl_method() const;
+  static uint32_t static_method(uint32_t arg);
+  static std::unique_ptr<L> build();
 };
-
-std::unique_ptr<L> build_l();
 
 enum COwnedEnum {
   CVAL1,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -379,6 +379,11 @@ fn test_raw_ptr() {
 
 #[test]
 fn test_impl_methods() {
-    let l = ffi::build_l();
+    let l = ffi::L::build();
     check!(l.impl_method());
+}
+
+#[test]
+fn test_static_methods() {
+    check!(ffi::L::static_method(7));
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -376,3 +376,9 @@ fn test_raw_ptr() {
     assert_eq!(2025, unsafe { ffi::c_take_const_ptr(c3) });
     assert_eq!(2025, unsafe { ffi::c_take_mut_ptr(c3 as *mut ffi::C) }); // deletes c3
 }
+
+#[test]
+fn test_impl_methods() {
+    let l = ffi::build_l();
+    check!(l.impl_method());
+}


### PR DESCRIPTION
Adds support for using `extern` `impl` blocks to describe methods and static/associated functions on a type.

Requires a companion patch to `rustc`, so this may take some time to be able to land.