### PR TITLE
Update codespan-reporting to build with -Zminimal-versions

### DIFF
--- a/gen/build/Cargo.toml
+++ b/gen/build/Cargo.toml
@@ -19,7 +19,7 @@ experimental-async-fn = []
 
 [dependencies]
 cc = "1.0.49"
-codespan-reporting = "0.11"
+codespan-reporting = "0.11.1"
 once_cell = "1.9"
 proc-macro2 = { version = "1.0.39", default-features = false, features = ["span-locations"] }
 quote = { version = "1.0", default-features = false }


### PR DESCRIPTION
`codespan-reporting` 0.11.0 does not build with `-Zminimal-versions` because it has a constraint
 on `termcolor = 1` whereas it depends on the `Copy` trait being implemented on types in `termcolor`
which were not added until 1.0.4.

See:

- https://github.com/brendanzab/codespan/issues/322
- https://github.com/brendanzab/codespan/commit/e99c867339a877731437e7ee6a903a3d03b5439e