### PR TITLE
Fix incorrect string len if an exception's message is invalid UTF-8

### DIFF
--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -68,9 +68,6 @@ void cxxbridge1$slice$new(void *self, const void *ptr,
                           std::size_t len) noexcept;
 void *cxxbridge1$slice$ptr(const void *self) noexcept;
 std::size_t cxxbridge1$slice$len(const void *self) noexcept;
-
-// try/catch
-const char *cxxbridge1$exception(const char *, std::size_t len) noexcept;
 } // extern "C"
 
 namespace rust {
@@ -516,6 +513,10 @@ struct PtrLen final {
 };
 } // namespace repr
 
+extern "C" {
+repr::PtrLen cxxbridge1$exception(const char *, std::size_t len) noexcept;
+}
+
 namespace detail {
 // On some platforms size_t is the same C++ type as one of the sized integer
 // types; on others it is a distinct type. Only in the latter case do we need to
@@ -539,8 +540,7 @@ public:
 };
 
 void Fail::operator()(const char *catch$) noexcept {
-  throw$.len = std::strlen(catch$);
-  throw$.ptr = const_cast<char *>(cxxbridge1$exception(catch$, throw$.len));
+  throw$ = cxxbridge1$exception(catch$, std::strlen(catch$));
 }
 } // namespace detail
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -12,9 +12,9 @@ use core::str;
 
 #[repr(C)]
 #[derive(Copy, Clone)]
-struct PtrLen {
-    ptr: NonNull<u8>,
-    len: usize,
+pub struct PtrLen {
+    pub ptr: NonNull<u8>,
+    pub len: usize,
 }
 
 #[repr(C)]

--- a/src/symbols/exception.rs
+++ b/src/symbols/exception.rs
@@ -1,12 +1,18 @@
 #![cfg(feature = "alloc")]
 
+use crate::result::PtrLen;
 use alloc::boxed::Box;
 use alloc::string::String;
+use core::ptr::NonNull;
 use core::slice;
 
 #[export_name = "cxxbridge1$exception"]
-unsafe extern "C" fn exception(ptr: *const u8, len: usize) -> *const u8 {
+unsafe extern "C" fn exception(ptr: *const u8, len: usize) -> PtrLen {
     let slice = unsafe { slice::from_raw_parts(ptr, len) };
-    let boxed = String::from_utf8_lossy(slice).into_owned().into_boxed_str();
-    Box::leak(boxed).as_ptr()
+    let string = String::from_utf8_lossy(slice);
+    let len = string.len();
+    let raw_str = Box::into_raw(string.into_owned().into_boxed_str());
+    let raw_u8 = raw_str.cast::<u8>();
+    let nonnull = unsafe { NonNull::new_unchecked(raw_u8) };
+    PtrLen { ptr: nonnull, len }
 }


### PR DESCRIPTION
Previously we'd create a PtrLen with the C++ string's length and the String::from_utf8_lossy string's data pointer. This is later turned back into a Rust string by:

https://github.com/dtolnay/cxx/blob/a39652409c2838138abc7e2eb88e5af095b632ce/src/result.rs#L61-L66

Since in general the length of string produced by from_utf8_lossy can be longer than the original string, this could end up truncating characters off the end of the exception message when printed from Rust code.