### PR TITLE
Allow trycatch to call Fail using std::string

### DIFF
--- a/gen/src/builtin.rs
+++ b/gen/src/builtin.rs
@@ -255,6 +255,7 @@ pub(super) fn write(out: &mut OutFile) {
     }
 
     if builtin.trycatch {
+        include.string = true;
         out.next_section();
         writeln!(out, "class Fail final {{");
         writeln!(out, "  ::rust::repr::PtrLen &throw$;");
@@ -264,6 +265,7 @@ pub(super) fn write(out: &mut OutFile) {
             "  Fail(::rust::repr::PtrLen &throw$) : throw$(throw$) {{}}"
         );
         writeln!(out, "  void operator()(const char *) noexcept;");
+        writeln!(out, "  void operator()(const std::string &) noexcept;");
         writeln!(out, "}};");
     }
 

--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -537,10 +537,15 @@ class Fail final {
 public:
   Fail(repr::PtrLen &throw$) : throw$(throw$) {}
   void operator()(const char *) noexcept;
+  void operator()(const std::string &) noexcept;
 };
 
 void Fail::operator()(const char *catch$) noexcept {
   throw$ = cxxbridge1$exception(catch$, std::strlen(catch$));
+}
+
+void Fail::operator()(const std::string &catch$) noexcept {
+  throw$ = cxxbridge1$exception(catch$.data(), catch$.length());
 }
 } // namespace detail
 


### PR DESCRIPTION
**Before:**

```cpp
template <typename Try, typename Fail>
static void trycatch(Try &&func, Fail &&fail) noexcept try {
  func();
} catch (const whatever &ex) {
  std::ostringstream buf;
  ex.dump(buf);
  fail(buf.str().c_str());
}
```

**After:** just `fail(buf.str())` without `.c_str()`, and performs better because we bypass a redundant strlen computation.