### PR TITLE
cxx-build: symlink headers to GENERATED_HEADER_DIR

### DIFF
--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -424,6 +424,16 @@ fn generate_bridge(prj: &Project, build: &mut Build, rust_source_file: &Path) ->
     let shared_cc = prj.shared_dir.join(&prj.include_prefix).join(rel_path_cc);
     let _ = out::symlink_file(header_path, shared_h);
     let _ = out::symlink_file(implementation_path, shared_cc);
+
+    if let Ok(export_path) = env::var("GENERATED_HEADER_DIR") {
+        out::symlink_file(
+            header_path,
+            PathBuf::from(export_path)
+                .join(&prj.include_prefix)
+                .join(rel_path_h),
+        )?;
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Symlink (or copy on Windows) generated headers to a directory specified by the GENERATED_HEADER_DIR environment variable, if this variable is set. This makes cxx-build usable by C++ build systems if they set GENERATED_HEADER_DIR before calling cargo and add it to their include paths. This is a better solution than the CLI tool for several reasons:

* Don't need to build/distribute/install a separate program
* Saves build time because cxx crates are not built redundantly for the CLI tool and the macro
* No risk of version mismatches between CLI tool and cxx macro crate
* One library crate that uses cxx can be usable in applications built either with Cargo or a C++ build system

Fixes https://github.com/dtolnay/cxx/issues/462