### PR TITLE
Reduce the set of crates that get vendored

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,8 @@ jobs:
       - uses: dtolnay/install@buck2
       - name: Install lld
         run: sudo apt-get install lld
-      - name: Vendor dependencies
-        run: |
-          cp third-party/Cargo.lock .
-          cargo vendor --versioned-dirs --locked third-party/vendor
+      - run: cargo vendor --versioned-dirs --locked
+        working-directory: third-party
       - run: buck2 run demo
       - run: buck2 build ...
 

--- a/third-party/Cargo.lock
+++ b/third-party/Cargo.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,24 +13,6 @@ name = "cc"
 version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
-dependencies = [
- "jobserver",
-]
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "clang-ast"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ec567dd2f3a079936500b168b605e9d840ebc7b919a5b3b3e14f09ad79d07a"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "clap"
@@ -46,7 +22,6 @@ checksum = "4d63b9e9c07271b9957ad22c173bae2a4d9a81127680962039296abcd2f8251d"
 dependencies = [
  "bitflags",
  "clap_lex",
- "strsim",
 ]
 
 [[package]]
@@ -69,174 +44,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "cxx"
-version = "1.0.83"
-dependencies = [
- "cc",
- "cxx-build",
- "cxx-gen",
- "cxx-test-suite",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
- "rustversion",
- "trybuild",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.83"
-dependencies = [
- "cc",
- "codespan-reporting",
- "cxx",
- "cxx-gen",
- "once_cell",
- "pkg-config",
- "proc-macro2",
- "quote",
- "scratch",
- "syn",
-]
-
-[[package]]
-name = "cxx-gen"
-version = "0.7.83"
-dependencies = [
- "codespan-reporting",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "cxx-test-suite"
-version = "0.0.0"
-dependencies = [
- "cxx",
- "cxx-build",
- "cxxbridge-flags",
-]
-
-[[package]]
-name = "cxxbridge-cmd"
-version = "1.0.83"
-dependencies = [
- "clap",
- "codespan-reporting",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.83"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.83"
-dependencies = [
- "clang-ast",
- "cxx",
- "flate2",
- "memmap",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "syn",
-]
-
-[[package]]
-name = "demo"
-version = "0.0.0"
-dependencies = [
- "cxx",
- "cxx-build",
-]
-
-[[package]]
-name = "dissimilar"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c97b9233581d84b8e1e689cdd3a47b6f69770084fc246e86a7f78b0d9c1d4a5"
-
-[[package]]
-name = "flate2"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
-name = "glob"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
-name = "itoa"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
-
-[[package]]
-name = "jobserver"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "libc"
-version = "0.2.137"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "memmap"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
-dependencies = [
- "adler",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,12 +54,6 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "proc-macro2"
@@ -273,59 +74,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
-
-[[package]]
-name = "ryu"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
-
-[[package]]
 name = "scratch"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
-
-[[package]]
-name = "serde"
-version = "1.0.148"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.148"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -348,28 +100,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+name = "third-party"
+version = "0.0.0"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "trybuild"
-version = "1.0.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db29f438342820400f2d9acfec0d363e987a38b2950bdb50a7069ed17b2148ee"
-dependencies = [
- "dissimilar",
- "glob",
+ "cc",
+ "clap",
+ "codespan-reporting",
  "once_cell",
- "serde",
- "serde_derive",
- "serde_json",
- "termcolor",
- "toml",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
 ]
 
 [[package]]

--- a/third-party/Cargo.toml
+++ b/third-party/Cargo.toml
@@ -1,0 +1,18 @@
+[workspace]
+[package]
+name = "third-party"
+version = "0.0.0"
+publish = false
+
+[lib]
+path = "/dev/null"
+
+[dependencies]
+cc = "1.0.49"
+clap = { version = "4", default-features = false, features = ["error-context", "help", "std", "usage"] }
+codespan-reporting = "0.11.1"
+once_cell = "1.9"
+proc-macro2 = { version = "1.0.39", features = ["span-locations"] }
+quote = "1.0.4"
+scratch = "1"
+syn = { version = "1.0.95", features = ["full"] }


### PR DESCRIPTION
**Before:**

```
adler-1.0.2                  libc-0.2.137            serde_json-1.0.89
bitflags-1.3.2               link-cplusplus-1.0.7    strsim-0.10.0
cc-1.0.77                    memmap-0.7.0            syn-1.0.105
cfg-if-1.0.0                 miniz_oxide-0.6.2       termcolor-1.1.3
clang-ast-0.1.9              once_cell-1.16.0        toml-0.5.9
clap-4.0.29                  os_str_bytes-6.4.1      trybuild-1.0.72
clap_lex-0.3.0               pkg-config-0.3.26       unicode-ident-1.0.5
codespan-reporting-0.11.1    proc-macro2-1.0.47      unicode-width-0.1.10
crc32fast-1.3.2              quote-1.0.21            winapi-0.3.9
dissimilar-1.0.4             rustversion-1.0.9       winapi-i686-pc-windows-gnu-0.4.0
flate2-1.0.25                ryu-1.0.11              winapi-util-0.1.5
glob-0.3.0                   scratch-1.0.2           winapi-x86_64-pc-windows-gnu-0.4.0
itoa-1.0.4                   serde-1.0.148
jobserver-0.1.25             serde_derive-1.0.148
```

**After:**

```
bitflags-1.3.2               os_str_bytes-6.4.1      unicode-ident-1.0.5
cc-1.0.77                    proc-macro2-1.0.47      unicode-width-0.1.10
clap-4.0.29                  quote-1.0.21            winapi-0.3.9
clap_lex-0.3.0               scratch-1.0.2           winapi-i686-pc-windows-gnu-0.4.0
codespan-reporting-0.11.1    syn-1.0.105             winapi-util-0.1.5
once_cell-1.16.0             termcolor-1.1.3         winapi-x86_64-pc-windows-gnu-0.4.0
```