### PR TITLE
C++: Fix build on no-except compilers

### DIFF
--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -75,7 +75,9 @@ inline namespace cxxbridge1 {
 
 template <typename Exception>
 void panic [[noreturn]] (const char *msg) {
-#if defined(RUST_CXX_NO_EXCEPTIONS)
+// Do not attempt to throw if the compiler explicitly does not support it.
+// If __cpp_attributes is not set, the compiler may not implement feature-test macros.
+#if defined(RUST_CXX_NO_EXCEPTIONS) || (defined(__cpp_attributes) && !defined(__cpp_exceptions))
   std::cerr << "Error: " << msg << ". Aborting." << std::endl;
   std::terminate();
 #else


### PR DESCRIPTION
This fix was necessary for my project (C++ depending on Rust) to compile. The approach here is conservative, only deferring from the existing behavior when the compiler *explicitly does not support exceptions* via feature-test macros. There may be other approaches here, like attempting to compile a test file with `throw`.
