### PR TITLE
Add NUL character at the end of copied error message

### DIFF
--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -449,8 +449,9 @@ static_assert(!std::is_same<Vec<std::uint8_t>::const_iterator,
               "Vec<T>::const_iterator != Vec<T>::iterator");
 
 static const char *errorCopy(const char *ptr, std::size_t len) {
-  char *copy = new char[len];
+  char *copy = new char[len + 1];
   std::memcpy(copy, ptr, len);
+  copy[len] = 0;
   return copy;
 }
 


### PR DESCRIPTION
C++ error message returned by `what` must be NUL-terminated. However, the current copy function only copied the characters, but didn't add the NUL. Allocate one more byte and set it to NUL.