### PR TITLE
Minimal support for Rust type aliases

### DIFF
--- a/gen/src/namespace.rs
+++ b/gen/src/namespace.rs
@@ -6,9 +6,10 @@ impl Api {
         match self {
             Api::CxxFunction(efn) | Api::RustFunction(efn) => &efn.name.namespace,
             Api::CxxType(ety) | Api::RustType(ety) => &ety.name.namespace,
+            Api::TypeAlias(ety) => &ety.name.namespace,
             Api::Enum(enm) => &enm.name.namespace,
             Api::Struct(strct) => &strct.name.namespace,
-            Api::Impl(_) | Api::Include(_) | Api::TypeAlias(_) => Default::default(),
+            Api::Impl(_) | Api::Include(_) => Default::default(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,7 +506,7 @@ pub mod private {
     pub use crate::rust_str::RustStr;
     #[cfg(feature = "alloc")]
     pub use crate::rust_string::RustString;
-    pub use crate::rust_type::{ImplBox, ImplVec, RustType};
+    pub use crate::rust_type::{ImplBox, ImplVec, RustType, verify_rust_type};
     #[cfg(feature = "alloc")]
     pub use crate::rust_vec::RustVec;
     pub use crate::shared_ptr::SharedPtrTarget;

--- a/src/rust_type.rs
+++ b/src/rust_type.rs
@@ -3,3 +3,6 @@
 pub unsafe trait RustType {}
 pub unsafe trait ImplBox {}
 pub unsafe trait ImplVec {}
+
+#[doc(hidden)]
+pub fn verify_rust_type<T: RustType>() {}

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -3,7 +3,8 @@ use crate::syntax::report::Errors;
 use crate::syntax::visit::{self, Visit};
 use crate::syntax::{
     error, ident, trivial, Api, Array, Enum, ExternFn, ExternType, Impl, Lang, Lifetimes,
-    NamedType, Ptr, Receiver, Ref, Signature, SliceRef, Struct, Trait, Ty1, Type, TypeAlias, Types,
+    NamedType, Ptr, Receiver, Ref, RustType, Signature, SliceRef, Struct, Trait, Ty1, Type,
+    TypeAlias, Types,
 };
 use proc_macro2::{Delimiter, Group, Ident, TokenStream};
 use quote::{quote, ToTokens};
@@ -499,6 +500,25 @@ fn check_api_type_alias(cx: &mut Check, alias: &TypeAlias) {
     for derive in &alias.derives {
         let msg = format!("derive({}) on extern type alias is not supported", derive);
         cx.error(derive, msg);
+    }
+
+    if alias.lang == Lang::Rust {
+        let ty = &alias.ty;
+        if let RustType::Path(path) = &ty {
+            // OK, we support path
+            if let Some(last) = path.path.segments.last() {
+                if last.ident != alias.name.rust {
+                    cx.error(
+                        &alias.name.rust,
+                        "`extern \"Rust\"` alias must have the same name as the target type",
+                    );
+                }
+            } else {
+                cx.error(ty, "unsupported `extern \"Rust\"` alias target type");
+            }
+        } else {
+            cx.error(ty, "unsupported `extern \"Rust\"` alias target");
+        }
     }
 }
 

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -154,6 +154,7 @@ pub struct TypeAlias {
     pub visibility: Token![pub],
     pub type_token: Token![type],
     pub name: Pair,
+    pub lang: Lang,
     pub generics: Lifetimes,
     pub eq_token: Token![=],
     pub ty: RustType,

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -874,12 +874,6 @@ fn parse_type_alias(
         },
     ));
 
-    if lang == Lang::Rust {
-        let span = quote!(#type_token #semi_token);
-        let msg = "type alias in extern \"Rust\" block is not supported";
-        return Err(Error::new_spanned(span, msg));
-    }
-
     let visibility = visibility_pub(&visibility, type_token.span);
     let name = pair(namespace, &ident, cxx_name, rust_name);
 
@@ -891,6 +885,7 @@ fn parse_type_alias(
         visibility,
         type_token,
         name,
+        lang,
         generics,
         eq_token,
         ty,

--- a/tests/ffi/module.rs
+++ b/tests/ffi/module.rs
@@ -17,6 +17,10 @@ pub mod ffi {
 
 #[cxx::bridge(namespace = "tests")]
 pub mod ffi2 {
+    extern "Rust" {
+        type R = crate::R;
+    }
+
     unsafe extern "C++" {
         include!("tests/ffi/tests.h");
 
@@ -69,6 +73,8 @@ pub mod ffi2 {
 
         #[namespace = "I"]
         fn ns_c_return_unique_ptr_ns() -> UniquePtr<I>;
+
+        fn c_return_box_from_aliased_rust_type() -> Box<R>;
     }
 
     impl UniquePtr<D> {}

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -72,6 +72,8 @@ rust::Box<R> c_return_box() {
   return rust::Box<R>::from_raw(cxx_test_suite_get_box());
 }
 
+rust::Box<R> c_return_box_from_aliased_rust_type() { return r_return_box(); }
+
 std::unique_ptr<C> c_return_unique_ptr() {
   return std::unique_ptr<C>(new C{2020});
 }

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -91,6 +91,7 @@ Shared c_return_shared();
 ::A::AShared c_return_ns_shared();
 ::A::B::ABShared c_return_nested_ns_shared();
 rust::Box<R> c_return_box();
+rust::Box<R> c_return_box_from_aliased_rust_type();
 std::unique_ptr<C> c_return_unique_ptr();
 std::shared_ptr<C> c_return_shared_ptr();
 std::unique_ptr<::H::H> c_return_ns_unique_ptr();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -41,6 +41,7 @@ fn test_c_return() {
     assert_eq!(2020, ffi::c_return_primitive());
     assert_eq!(2020, ffi::c_return_shared().z);
     assert_eq!(2020, ffi::c_return_box().0);
+    assert_eq!(2020, ffi2::c_return_box_from_aliased_rust_type().0);
     ffi::c_return_unique_ptr();
     ffi2::c_return_ns_unique_ptr();
     assert_eq!(2020, *ffi::c_return_ref(&shared));

--- a/tests/ui/type_alias_rust.stderr
+++ b/tests/ui/type_alias_rust.stderr
@@ -1,5 +1,5 @@
-error: type alias in extern "Rust" block is not supported
- --> tests/ui/type_alias_rust.rs:5:9
+error: `extern "Rust"` alias must have the same name as the target type
+ --> tests/ui/type_alias_rust.rs:5:14
   |
 5 |         type Alias = crate::Type;
-  |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+  |              ^^^^^

--- a/tests/ui/type_alias_rust2.rs
+++ b/tests/ui/type_alias_rust2.rs
@@ -1,0 +1,15 @@
+pub mod other_module {
+    pub struct Source {
+        member: u32,
+    }
+}
+
+#[cxx::bridge]
+mod ffi {
+    extern "Rust" {
+        // Not allowed - the target is not `extern "Rust"`.
+        type Source = crate::other_module::Source;
+    }
+}
+
+fn main() {}

--- a/tests/ui/type_alias_rust2.stderr
+++ b/tests/ui/type_alias_rust2.stderr
@@ -1,0 +1,11 @@
+error[E0277]: the trait bound `other_module::Source: RustType` is not satisfied
+  --> tests/ui/type_alias_rust2.rs:11:23
+   |
+11 |         type Source = crate::other_module::Source;
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `RustType` is not implemented for `other_module::Source`
+   |
+note: required by a bound in `verify_rust_type`
+  --> src/rust_type.rs
+   |
+   | pub fn verify_rust_type<T: RustType>() {}
+   |                            ^^^^^^^^ required by this bound in `verify_rust_type`

--- a/tests/ui/type_alias_rust3.rs
+++ b/tests/ui/type_alias_rust3.rs
@@ -1,0 +1,11 @@
+struct Type;
+
+#[cxx::bridge]
+mod ffi {
+    extern "Rust" {
+        // Not allowed - the target is not a path.
+        type Source = &crate::Type;
+    }
+}
+
+fn main() {}

--- a/tests/ui/type_alias_rust3.stderr
+++ b/tests/ui/type_alias_rust3.stderr
@@ -1,0 +1,5 @@
+error: unsupported `extern "Rust"` alias target
+ --> tests/ui/type_alias_rust3.rs:7:23
+  |
+7 |         type Source = &crate::Type;
+  |                       ^^^^^^^^^^^^


### PR DESCRIPTION
The intention is to provide support to re-import Rust types already exported elsewhere into other bridges, creating equivalence of `extern "Rust"` types on the C++ side.

Currently, the support is limited to re-exporting the type under the same name and the C++ namespace must be explicitly specified. Then, C++ functions can use the same type.