### PR TITLE
Fix: pick up changed tests.h/cc to rebuild the bridge

### DIFF
--- a/tests/ffi/build.rs
+++ b/tests/ffi/build.rs
@@ -15,4 +15,7 @@ fn main() {
         build.define("CXX_TEST_INSTANTIATIONS", None);
     }
     build.compile("cxx-test-suite");
+
+    println!("cargo:rerun-if-changed=tests.cc");
+    println!("cargo:rerun-if-changed=tests.h");
 }


### PR DESCRIPTION
Previously, modifying tests.h/cc would not trigger rebuild of the bridge, preventing efficient test development.