### PR TITLE
Fix: Prevent crash on OOM in error copy

### DIFF
--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -449,8 +449,9 @@ static_assert(!std::is_same<Vec<std::uint8_t>::const_iterator,
               "Vec<T>::const_iterator != Vec<T>::iterator");
 
 static const char *errorCopy(const char *ptr, std::size_t len) {
-  char *copy = new char[len];
+  char *copy = new char[len + 1];
   std::memcpy(copy, ptr, len);
+  copy[len] = 0;
   return copy;
 }
 


### PR DESCRIPTION
When the error message is copied, the allocation may fail. This would terminate the process, since it's called from a `noexcept` function.

Make the allocation `nothrow` and handle `nullptr` in `what()` method appropriately, returning a generic message saying that the message cannot be allocated.

This also prevents a crash if `what()` is called on a moved object (which is technically UB, but still better not to crash).