### PR TITLE
minor nit in tutorial.md

### DIFF
--- a/book/src/tutorial.md
+++ b/book/src/tutorial.md
@@ -308,10 +308,10 @@ As usual, now we need to provide Rust definitions of everything declared by the
 #     }
 # }
 
-// An iterator over contiguous chunks of a discontiguous file object. Toy
-// implementation uses a Vec<Vec<u8>> but in reality this might be iterating
-// over some more complex Rust data structure like a rope, or maybe loading
-// chunks lazily from somewhere.
+/// An iterator over contiguous chunks of a discontiguous file object. Toy
+/// implementation uses a `Vec<Vec<u8>>` but in reality this might be iterating
+/// over some more complex Rust data structure like a rope, or maybe loading
+/// chunks lazily from somewhere.
 pub struct MultiBuf {
     chunks: Vec<Vec<u8>>,
     pos: usize,


### PR DESCRIPTION
function comment should follow rust's fn md docs for consistency