### PR TITLE
Add feature flag to skip building cxx.cc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ default = ["std", "cxxbridge-flags/default"] # c++11
 "c++20" = ["cxxbridge-flags/c++20"]
 alloc = []
 std = ["alloc"]
+skip_cxxbridge1_build = []
 
 [dependencies]
 cxxbridge-macro = { version = "=1.0.92", path = "macro" }

--- a/build.rs
+++ b/build.rs
@@ -3,17 +3,20 @@ use std::path::Path;
 use std::process::Command;
 
 fn main() {
-    cc::Build::new()
-        .file("src/cxx.cc")
-        .cpp(true)
-        .cpp_link_stdlib(None) // linked via link-cplusplus crate
-        .flag_if_supported(cxxbridge_flags::STD)
-        .warnings_into_errors(cfg!(deny_warnings))
-        .compile("cxxbridge1");
+    let skip_build = env::var_os("CARGO_FEATURE_SKIP_CXXBRIDGE1_BUILD").is_some();
+    if !skip_build {
+        cc::Build::new()
+            .file("src/cxx.cc")
+            .cpp(true)
+            .cpp_link_stdlib(None) // linked via link-cplusplus crate
+            .flag_if_supported(cxxbridge_flags::STD)
+            .warnings_into_errors(cfg!(deny_warnings))
+            .compile("cxxbridge1");
 
-    println!("cargo:rerun-if-changed=src/cxx.cc");
-    println!("cargo:rerun-if-changed=include/cxx.h");
-    println!("cargo:rustc-cfg=built_with_cargo");
+        println!("cargo:rerun-if-changed=src/cxx.cc");
+        println!("cargo:rerun-if-changed=include/cxx.h");
+        println!("cargo:rustc-cfg=built_with_cargo");
+    }
 
     if let Some(manifest_dir) = env::var_os("CARGO_MANIFEST_DIR") {
         let cxx_h = Path::new(&manifest_dir).join("include").join("cxx.h");


### PR DESCRIPTION
This adds a new feature flag, `skip_cxxbridge1_build` to skip building `cxx.cc` in cxx's build.rs.

# Why add this feature flag?
* To support build systems that wrap Cargo, but don't allow the use of the `cc` crate, or don't have the environment correctly setup for a C++ build.
* Allow dependents to avoid rebuilding `cxx.cc` multiple times if there are multiple Rust static libraries (.so or .lib) being built separately that are then linked together.
* To allow a single Rust library to be consumed by multiple C++ projects that are using different STL implementations.

# Naming discussion
* Prefixed with `skip` to indicate that `cxx.cc` is built by default (avoiding breaking changes for dependents using `default-features = false`).
* `cxx.cc` is built into a library called `cxxbridge1` - not sure if there is a better way to reference this? (Maybe `skip_static_library_build`, `skip_support_library_build` or `skip_runtime_build`?)