### PR TITLE
Implement fmt::Write for CxxString

### DIFF
--- a/src/cxx_string.rs
+++ b/src/cxx_string.rs
@@ -5,7 +5,7 @@ use alloc::borrow::Cow;
 #[cfg(feature = "alloc")]
 use alloc::string::String;
 use core::cmp::Ordering;
-use core::fmt::{self, Debug, Display};
+use core::fmt::{self, Debug, Display, Write};
 use core::hash::{Hash, Hasher};
 use core::marker::{PhantomData, PhantomPinned};
 use core::mem::MaybeUninit;
@@ -254,6 +254,27 @@ impl Ord for CxxString {
 impl Hash for CxxString {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.as_bytes().hash(state);
+    }
+}
+
+impl Write for Pin<&mut CxxString> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.as_mut().push_str(s);
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::io::Write for Pin<&mut CxxString> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.as_mut().push_bytes(buf);
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
     }
 }
 

--- a/tests/cxx_string.rs
+++ b/tests/cxx_string.rs
@@ -1,4 +1,5 @@
 use cxx::{let_cxx_string, CxxString};
+use std::fmt::Write as _;
 
 #[test]
 fn test_async_cxx_string() {
@@ -19,4 +20,25 @@ fn test_debug() {
     let_cxx_string!(s = "x\"y\'z");
 
     assert_eq!(format!("{:?}", s), r#""x\"y'z""#);
+}
+
+#[test]
+fn test_fmt_write() {
+    let_cxx_string!(s = "");
+
+    let name = "world";
+    write!(s, "Hello, {name}!").unwrap();
+    assert_eq!(s.to_str(), Ok("Hello, world!"));
+
+    write!(s, "\nAnd friends!").unwrap();
+    assert_eq!(s.to_str(), Ok("Hello, world!\nAnd friends!"));
+}
+
+#[test]
+fn test_io_write() {
+    let_cxx_string!(s = "");
+    let mut reader: &[u8] = b"Hello, world!";
+
+    std::io::copy(&mut reader, &mut s).unwrap();
+    assert_eq!(s.to_str(), Ok("Hello, world!"));
 }


### PR DESCRIPTION
This allows formatted writes (e.g. with the `write!()` macro) directly on a `CxxString`. This can eliminate a needless allocation from formatting to a `String` then converting to a `CxxString`.

While testing this, I ran into #1201. Nothing else stood out as unusual.