### PR TITLE
cxx-gen: Add span() to Error type

### DIFF
--- a/gen/lib/src/error.rs
+++ b/gen/lib/src/error.rs
@@ -9,6 +9,16 @@ pub struct Error {
     pub(crate) err: crate::gen::Error,
 }
 
+impl Error {
+    /// Returns the span of the error, if available.
+    pub fn span(&self) -> Option<proc_macro2::Span> {
+        match &self.err {
+            crate::gen::Error::Syn(err) => Some(err.span()),
+            _ => None,
+        }
+    }
+}
+
 impl From<crate::gen::Error> for Error {
     fn from(err: crate::gen::Error) -> Self {
         Error { err }


### PR DESCRIPTION
The Error type exposed in cxx-gen is very minimal currently. For use in CXX-Qt, we'd like to access the span if the Error has one. This would allow us to greatly improve our build script diagnostics (very similar to how CXX displays errors itself).

cc: @ahayzen-kdab
See: https://github.com/KDAB/cxx-qt/issues/536