### PR TITLE
chore: clippy let-underscore-untyped

### DIFF
--- a/book/src/async.md
+++ b/book/src/async.md
@@ -60,7 +60,7 @@ pub async fn do_thing(arg: Arg) -> Ret {
 
     ffi::shim_doThing(
         arg,
-        |context, ret| { let _ = context.0.send(ret); },
+        |context, ret| { _ = context.0.send(ret); },
         context,
     );
 

--- a/book/src/binding/box.md
+++ b/book/src/binding/box.md
@@ -91,7 +91,7 @@ fn main() {
     let out = std::fs::File::create("example.log").unwrap();
 
     ffi::f(
-        |mut out, fst, snd| { let _ = write!(out.0, "{}{}\n", fst, snd); },
+        |mut out, fst, snd| { _ = write!(out.0, "{}{}\n", fst, snd); },
         Box::new(File(out)),
     );
 }

--- a/gen/build/src/error.rs
+++ b/gen/build/src/error.rs
@@ -22,7 +22,7 @@ pub(super) enum Error {
 
 macro_rules! expr {
     ($expr:expr) => {{
-        let _ = $expr; // ensure it doesn't fall out of sync with CFG definition
+        _ = $expr; // ensure it doesn't fall out of sync with CFG definition
         stringify!($expr)
     }};
 }

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -136,7 +136,7 @@ pub fn bridge(rust_source_file: impl AsRef<Path>) -> Build {
 pub fn bridges(rust_source_files: impl IntoIterator<Item = impl AsRef<Path>>) -> Build {
     let ref mut rust_source_files = rust_source_files.into_iter();
     build(rust_source_files).unwrap_or_else(|err| {
-        let _ = writeln!(io::stderr(), "\n\ncxxbridge error: {}\n\n", report(err));
+        _ = writeln!(io::stderr(), "\n\ncxxbridge error: {}\n\n", report(err));
         process::exit(1);
     })
 }
@@ -374,7 +374,7 @@ fn make_crate_dir(prj: &Project) -> PathBuf {
         Signature: 8a477f597d28d172789f06886806bc55\n\
         # This file is a cache directory tag created by cxx.\n\
         # For information about cache directory tags see https://bford.info/cachedir/\n";
-        let _ = out::write(crate_dir.join("CACHEDIR.TAG"), cachedir_tag.as_bytes());
+        _ = out::write(crate_dir.join("CACHEDIR.TAG"), cachedir_tag.as_bytes());
         let max_depth = 6;
         best_effort_copy_headers(manifest_dir, link, max_depth);
     }
@@ -414,7 +414,7 @@ fn generate_bridge(prj: &Project, build: &mut Build, rust_source_file: &Path) ->
     out::write(header_path, &generated.header)?;
 
     let ref link_path = include_dir.join(rel_path);
-    let _ = out::symlink_file(header_path, link_path);
+    _ = out::symlink_file(header_path, link_path);
 
     let ref rel_path_cc = rel_path.with_appended_extension(".cc");
     let ref implementation_path = sources_dir.join(rel_path_cc);
@@ -423,8 +423,8 @@ fn generate_bridge(prj: &Project, build: &mut Build, rust_source_file: &Path) ->
 
     let shared_h = prj.shared_dir.join(&prj.include_prefix).join(rel_path_h);
     let shared_cc = prj.shared_dir.join(&prj.include_prefix).join(rel_path_cc);
-    let _ = out::symlink_file(header_path, shared_h);
-    let _ = out::symlink_file(implementation_path, shared_cc);
+    _ = out::symlink_file(header_path, shared_h);
+    _ = out::symlink_file(implementation_path, shared_cc);
     Ok(())
 }
 
@@ -463,8 +463,8 @@ fn best_effort_copy_headers(src: &Path, dst: &Path, max_depth: usize) {
                 }
                 dst_created = true;
                 let dst = dst.join(file_name);
-                let _ = fs::remove_file(&dst);
-                let _ = fs::copy(src, dst);
+                _ = fs::remove_file(&dst);
+                _ = fs::copy(src, dst);
             }
             _ => {}
         }

--- a/gen/build/src/out.rs
+++ b/gen/build/src/out.rs
@@ -93,16 +93,16 @@ fn best_effort_remove(path: &Path) {
         // with "Access is denied".
         if let Ok(metadata) = fs::metadata(path) {
             if metadata.is_dir() {
-                let _ = fs::remove_dir_all(path);
+                _ = fs::remove_dir_all(path);
             } else {
-                let _ = fs::remove_file(path);
+                _ = fs::remove_file(path);
             }
         } else if fs::symlink_metadata(path).is_ok() {
             // The symlink might exist but be dangling, in which case there is
             // no standard way to determine what "kind" of symlink it is. Try
             // deleting both ways.
             if fs::remove_dir_all(path).is_err() {
-                let _ = fs::remove_file(path);
+                _ = fs::remove_file(path);
             }
         }
     } else {
@@ -110,9 +110,9 @@ fn best_effort_remove(path: &Path) {
         // symlinks are removed using remove_file.
         if let Ok(metadata) = fs::symlink_metadata(path) {
             if metadata.is_dir() {
-                let _ = fs::remove_dir_all(path);
+                _ = fs::remove_dir_all(path);
             } else {
-                let _ = fs::remove_file(path);
+                _ = fs::remove_file(path);
             }
         }
     }

--- a/gen/cmd/src/app.rs
+++ b/gen/cmd/src/app.rs
@@ -64,7 +64,7 @@ pub(super) fn from_args() -> Opt {
     let matches = app().get_matches();
 
     if matches.get_flag(HELP) {
-        let _ = app().print_long_help();
+        _ = app().print_long_help();
         process::exit(0);
     }
 

--- a/gen/cmd/src/main.rs
+++ b/gen/cmd/src/main.rs
@@ -57,7 +57,7 @@ struct Opt {
 
 fn main() {
     if let Err(err) = try_main() {
-        let _ = writeln!(io::stderr(), "cxxbridge: {}", report(err));
+        _ = writeln!(io::stderr(), "cxxbridge: {}", report(err));
         process::exit(1);
     }
 }

--- a/gen/src/cfg.rs
+++ b/gen/src/cfg.rs
@@ -10,8 +10,8 @@ pub(super) struct UnsupportedCfgEvaluator;
 
 impl CfgEvaluator for UnsupportedCfgEvaluator {
     fn eval(&self, name: &str, value: Option<&str>) -> CfgResult {
-        let _ = name;
-        let _ = value;
+        _ = name;
+        _ = value;
         let msg = "cfg attribute is not supported".to_owned();
         CfgResult::Undetermined { msg }
     }

--- a/gen/src/error.rs
+++ b/gen/src/error.rs
@@ -64,19 +64,19 @@ pub(super) fn format_err(path: &Path, source: &str, error: Error) -> ! {
             let writer = StandardStream::stderr(ColorChoice::Auto);
             let ref mut stderr = writer.lock();
             for error in syn_error {
-                let _ = writeln!(stderr);
+                _ = writeln!(stderr);
                 display_syn_error(stderr, path, source, error);
             }
         }
         Error::NoBridgeMod => {
-            let _ = writeln!(
+            _ = writeln!(
                 io::stderr(),
                 "cxxbridge: no #[cxx::bridge] module found in {}",
                 path.display(),
             );
         }
         _ => {
-            let _ = writeln!(io::stderr(), "cxxbridge: {}", report(error));
+            _ = writeln!(io::stderr(), "cxxbridge: {}", report(error));
         }
     }
     process::exit(1);
@@ -152,7 +152,7 @@ fn display_syn_error(stderr: &mut dyn WriteColor, path: &Path, source: &str, err
     let diagnostic = diagnose(file, start_offset..end_offset, error);
 
     let config = Config::default();
-    let _ = term::emit(stderr, &config, &files, &diagnostic);
+    _ = term::emit(stderr, &config, &files, &diagnostic);
 }
 
 fn diagnose(file: usize, range: Range<usize>, error: syn::Error) -> Diagnostic<usize> {

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -864,7 +864,7 @@ fn expand_rust_type_assert_unpin(ety: &ExternType, types: &Types) -> TokenStream
     let lifetimes = resolve.generics.to_underscore_lifetimes();
 
     quote_spanned! {ident.span()=>
-        let _ = {
+        _ = {
             fn __AssertUnpin<T: ?::cxx::core::marker::Sized + #unpin>() {}
             __AssertUnpin::<#ident #lifetimes>
         };
@@ -1285,7 +1285,7 @@ fn expand_rust_box(key: NamedImplKey, types: &Types, explicit_impl: Option<&Impl
         #[export_name = #link_dealloc]
         unsafe extern "C" fn #local_dealloc #impl_generics(ptr: *mut ::cxx::core::mem::MaybeUninit<#ident #ty_generics>) {
             // No prevent_unwind: the global allocator is not allowed to panic.
-            let _ = ::cxx::alloc::boxed::Box::from_raw(ptr);
+            _ = ::cxx::alloc::boxed::Box::from_raw(ptr);
         }
         #[doc(hidden)]
         #[export_name = #link_drop]

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -68,7 +68,7 @@ use syn::parse_macro_input;
 /// placed into that same namespace in the generated C++ code.
 #[proc_macro_attribute]
 pub fn bridge(args: TokenStream, input: TokenStream) -> TokenStream {
-    let _ = syntax::error::ERRORS;
+    _ = syntax::error::ERRORS;
 
     let namespace = match Namespace::parse_bridge_attr_namespace.parse(args) {
         Ok(namespace) => namespace,

--- a/macro/src/load.rs
+++ b/macro/src/load.rs
@@ -227,7 +227,7 @@ fn traverse<'a>(
         traverse(cx, inner, namespace, variants_from_header, idx);
     }
     if let Clang::NamespaceDecl(_) = &node.kind {
-        let _ = namespace.pop().unwrap();
+        _ = namespace.pop().unwrap();
     }
 }
 

--- a/src/cxx_vector.rs
+++ b/src/cxx_vector.rs
@@ -341,16 +341,16 @@ pub unsafe trait VectorElement: Sized {
     unsafe fn __push_back(v: Pin<&mut CxxVector<Self>>, value: &mut ManuallyDrop<Self>) {
         // Opaque C type vector elements do not get this method because they can
         // never exist by value on the Rust side of the bridge.
-        let _ = v;
-        let _ = value;
+        _ = v;
+        _ = value;
         unreachable!()
     }
     #[doc(hidden)]
     unsafe fn __pop_back(v: Pin<&mut CxxVector<Self>>, out: &mut MaybeUninit<Self>) {
         // Opaque C type vector elements do not get this method because they can
         // never exist by value on the Rust side of the bridge.
-        let _ = v;
-        let _ = out;
+        _ = v;
+        _ = out;
         unreachable!()
     }
     #[doc(hidden)]

--- a/src/shared_ptr.rs
+++ b/src/shared_ptr.rs
@@ -191,10 +191,10 @@ pub unsafe trait SharedPtrTarget {
     where
         Self: Sized,
     {
-        // Opoaque C types do not get this method because they can never exist
+        // Opaque C types do not get this method because they can never exist
         // by value on the Rust side of the bridge.
-        let _ = value;
-        let _ = new;
+        _ = value;
+        _ = new;
         unreachable!()
     }
     #[doc(hidden)]

--- a/src/unique_ptr.rs
+++ b/src/unique_ptr.rs
@@ -218,7 +218,7 @@ pub unsafe trait UniquePtrTarget {
     {
         // Opaque C types do not get this method because they can never exist by
         // value on the Rust side of the bridge.
-        let _ = value;
+        _ = value;
         unreachable!()
     }
     #[doc(hidden)]

--- a/syntax/attrs.rs
+++ b/syntax/attrs.rs
@@ -305,7 +305,7 @@ impl ToTokens for OtherAttrs {
                 meta,
             } = attr;
             pound_token.to_tokens(tokens);
-            let _ = style; // ignore; render outer and inner attrs both as outer
+            _ = style; // ignore; render outer and inner attrs both as outer
             bracket_token.surround(tokens, |tokens| meta.to_tokens(tokens));
         }
     }

--- a/syntax/toposort.rs
+++ b/syntax/toposort.rs
@@ -12,7 +12,7 @@ pub fn sort<'a>(cx: &mut Errors, apis: &'a [Api], types: &Types<'a>) -> Vec<&'a 
     let ref mut marks = Map::new();
     for api in apis {
         if let Api::Struct(strct) = api {
-            let _ = visit(cx, strct, &mut sorted, marks, types);
+            _ = visit(cx, strct, &mut sorted, marks, types);
         }
     }
     sorted

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -479,12 +479,12 @@ fn r_return_mut(shared: &mut ffi::Shared) -> &mut usize {
 }
 
 fn r_return_str(shared: &ffi::Shared) -> &str {
-    let _ = shared;
+    _ = shared;
     "2020"
 }
 
 fn r_return_sliceu8(shared: &ffi::Shared) -> &[u8] {
-    let _ = shared;
+    _ = shared;
     b"2020"
 }
 
@@ -516,12 +516,12 @@ fn r_return_rust_vec_extern_struct() -> Vec<ffi::Job> {
 }
 
 fn r_return_ref_rust_vec(shared: &ffi::Shared) -> &Vec<u8> {
-    let _ = shared;
+    _ = shared;
     unimplemented!()
 }
 
 fn r_return_mut_rust_vec(shared: &mut ffi::Shared) -> &mut Vec<u8> {
-    let _ = shared;
+    _ = shared;
     unimplemented!()
 }
 
@@ -552,23 +552,23 @@ fn r_take_shared(shared: ffi::Shared) {
 }
 
 fn r_take_box(r: Box<R>) {
-    let _ = r;
+    _ = r;
 }
 
 fn r_take_unique_ptr(c: UniquePtr<ffi::C>) {
-    let _ = c;
+    _ = c;
 }
 
 fn r_take_shared_ptr(c: SharedPtr<ffi::C>) {
-    let _ = c;
+    _ = c;
 }
 
 fn r_take_ref_r(r: &R) {
-    let _ = r;
+    _ = r;
 }
 
 fn r_take_ref_c(c: &ffi::C) {
-    let _ = c;
+    _ = c;
 }
 
 fn r_take_str(s: &str) {
@@ -600,23 +600,23 @@ fn r_take_ref_empty_vector(v: &CxxVector<u64>) {
 }
 
 fn r_take_rust_vec(v: Vec<u8>) {
-    let _ = v;
+    _ = v;
 }
 
 fn r_take_rust_vec_string(v: Vec<String>) {
-    let _ = v;
+    _ = v;
 }
 
 fn r_take_ref_rust_vec(v: &Vec<u8>) {
-    let _ = v;
+    _ = v;
 }
 
 fn r_take_ref_rust_vec_string(v: &Vec<String>) {
-    let _ = v;
+    _ = v;
 }
 
 fn r_take_enum(e: ffi::Enum) {
-    let _ = e;
+    _ = e;
 }
 
 fn r_try_return_void() -> Result<(), Error> {

--- a/tools/cargo/build.rs
+++ b/tools/cargo/build.rs
@@ -68,6 +68,6 @@ fn main() {
         }
     }
 
-    let _ = io::stderr().write_all(message.as_bytes());
+    _ = io::stderr().write_all(message.as_bytes());
     process::exit(1);
 }


### PR DESCRIPTION
Clippy keeps complaining about
  https://rust-lang.github.io/rust-clippy/master/index.html#let_underscore_untyped

Seems like a noop, esp considering that @dtolnay has filed a bug in
  https://github.com/rust-lang/rust-clippy/issues/10411

One issue though is that MSRV in .clippy.toml is not matching the one in Cargo.toml:
* .clippy.toml:  msrv = "1.48.0"
* Cargo.toml: rust-version = "1.60"

Which one is the accurate one?  I would assume its the Cargo.toml, in which case it might be better to apply this change?