### PR TITLE
Explicit cast from size_t to Slice<T>::iterator::difference_type in cxx.h

### DIFF
--- a/include/cxx.h
+++ b/include/cxx.h
@@ -659,7 +659,7 @@ typename Slice<T>::iterator::difference_type
 Slice<T>::iterator::operator-(const iterator &other) const noexcept {
   auto diff = std::distance(static_cast<char *>(other.pos),
                             static_cast<char *>(this->pos));
-  return diff / this->stride;
+  return diff / static_cast<typename Slice<T>::iterator::difference_type>(this->stride);
 }
 
 template <typename T>


### PR DESCRIPTION
This is a suggested fix for #1227. I was able to build both the `cxx` crate dependency and my own C++ code referencing generated `cxxbridge` headers with this change without disabling the signed/unsigned mismatch warning in MSVC.