### PR TITLE
Globally set C++ standard in Bazel builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,4 @@
 build --enable_platform_specific_config
 build:linux --@rules_rust//:extra_rustc_flags=-Clink-arg=-fuse-ld=lld
+build:linux --cxxopt=-std=c++17
+build:macos --cxxopt=-std=c++17

--- a/demo/BUILD
+++ b/demo/BUILD
@@ -22,7 +22,6 @@ rust_cxx_bridge(
 cc_library(
     name = "blobstore-sys",
     srcs = ["src/blobstore.cc"],
-    copts = ["-std=c++14"],
     deps = [
         ":blobstore-include",
         ":bridge/include",


### PR DESCRIPTION
Fixes #1254.

The choice of `-std=c++17` matches what we have been setting up for Buck builds.

https://github.com/dtolnay/cxx/blob/377f47e5a4519784083cc6ab39f24ec73f357cf7/tools/buck/toolchains/BUCK#L6-L12