### PR TITLE
Add bazel annotations as Cargo.toml package metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,22 @@ members = ["demo", "flags", "gen/build", "gen/cmd", "gen/lib", "macro", "tests/f
 targets = ["x86_64-unknown-linux-gnu"]
 rustdoc-args = ["--cfg", "doc_cfg", "--generate-link-to-definition"]
 
+[package.metadata.bazel]
+additive_build_file_content = """
+cc_library(
+    name = "cxx_cc",
+    srcs = ["src/cxx.cc"],
+    hdrs = ["include/cxx.h"],
+    include_prefix = "rust",
+    includes = ["include"],
+    linkstatic = True,
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+)
+"""
+extra_aliased_targets = { cxx_cc = "cxx_cc" }
+gen_build_script = false
+
 [patch.crates-io]
 cxx = { path = "." }
 cxx-build = { path = "gen/build" }


### PR DESCRIPTION
Adapted from the "@using_cxx" example added by https://github.com/bazelbuild/rules_rust/pull/2103.

I plan to send a rules_rust PR to read this package metadata and obviate the `annotations = { "cxx": [crate.annotation( .... )] }` for crates that provide it.

I considered a more TOML-native form for `additive_build_file_content`, but just using multiline string literal containing Starlark seems all right. Support for the structured form can be introduced separately.

```toml
[package.metadata.bazel]
extra_aliased_targets = { cxx_cc = "cxx_cc" }
gen_build_script = false

[[package.metadata.bazel.additive_build_file_content]]
[package.metadata.bazel.additive_build_file_content.cc_library]
name = "cxx_cc"
srcs = ["src/cxx.cc"]
hdrs = ["include/cxx.h"]
include_prefix = "rust"
includes = ["include"]
linkstatic = true
strip_include_prefix = "include"
visibility = ["//visibility:public"]
```