### PR TITLE
Add CxxVector::new for creating an empty vector

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1671,6 +1671,7 @@ fn write_unique_ptr_common(out: &mut OutFile, ty: UniquePtr) {
         "static_assert(alignof(::std::unique_ptr<{}>) == alignof(void *), \"\");",
         inner,
     );
+
     begin_function_definition(out);
     writeln!(
         out,
@@ -1679,6 +1680,7 @@ fn write_unique_ptr_common(out: &mut OutFile, ty: UniquePtr) {
     );
     writeln!(out, "  ::new (ptr) ::std::unique_ptr<{}>();", inner);
     writeln!(out, "}}");
+
     if can_construct_from_value {
         out.builtin.maybe_uninit = true;
         begin_function_definition(out);
@@ -1926,6 +1928,20 @@ fn write_cxx_vector(out: &mut OutFile, key: NamedImplKey) {
         writeln!(out, "}}");
     }
 
+    let ty = UniquePtr::CxxVector(element);
+
     out.include.memory = true;
-    write_unique_ptr_common(out, UniquePtr::CxxVector(element));
+    write_unique_ptr_common(out, ty);
+
+    let inner = ty.to_typename(out.types);
+    let instance = ty.to_mangled(out.types);
+
+    begin_function_definition(out);
+    writeln!(
+        out,
+        "{} *cxxbridge1$unique_ptr${}$new() noexcept {{",
+        inner, instance,
+    );
+    writeln!(out, "  return new {}();", inner);
+    writeln!(out, "}}");
 }

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1622,6 +1622,7 @@ fn expand_cxx_vector(
         resolve.name.to_symbol(),
     );
     let link_unique_ptr_null = format!("{}null", unique_ptr_prefix);
+    let link_unique_ptr_new = format!("{}new", unique_ptr_prefix);
     let link_unique_ptr_raw = format!("{}raw", unique_ptr_prefix);
     let link_unique_ptr_get = format!("{}get", unique_ptr_prefix);
     let link_unique_ptr_release = format!("{}release", unique_ptr_prefix);
@@ -1698,6 +1699,13 @@ fn expand_cxx_vector(
                 let mut repr = ::cxx::core::mem::MaybeUninit::uninit();
                 unsafe { __unique_ptr_null(&mut repr) }
                 repr
+            }
+            fn __unique_ptr_new() -> *mut ::cxx::CxxVector<Self> {
+                extern "C" {
+                    #[link_name = #link_unique_ptr_new]
+                    fn __unique_ptr_new #impl_generics() -> *mut ::cxx::CxxVector<#elem #ty_generics>;
+                }
+                unsafe { __unique_ptr_new() }
             }
             unsafe fn __unique_ptr_raw(raw: *mut ::cxx::CxxVector<Self>) -> ::cxx::core::mem::MaybeUninit<*mut ::cxx::core::ffi::c_void> {
                 extern "C" {

--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -605,6 +605,10 @@ static_assert(sizeof(std::string) <= kMaxExpectedWordsInString * sizeof(void *),
       std::unique_ptr<std::vector<CXX_TYPE>> *ptr) noexcept {                  \
     new (ptr) std::unique_ptr<std::vector<CXX_TYPE>>();                        \
   }                                                                            \
+  std::vector<CXX_TYPE>                                                        \
+      *cxxbridge1$unique_ptr$std$vector$##RUST_TYPE##$new() noexcept {         \
+    return new std::vector<CXX_TYPE>();                                        \
+  }                                                                            \
   void cxxbridge1$unique_ptr$std$vector$##RUST_TYPE##$raw(                     \
       std::unique_ptr<std::vector<CXX_TYPE>> *ptr,                             \
       std::vector<CXX_TYPE> *raw) noexcept {                                   \

--- a/tests/cxx_vector.rs
+++ b/tests/cxx_vector.rs
@@ -1,5 +1,4 @@
 use cxx::{CxxVector};
-use std::fmt::Write as _;
 
 #[test]
 fn test_cxx_vector_new() {

--- a/tests/cxx_vector.rs
+++ b/tests/cxx_vector.rs
@@ -1,0 +1,9 @@
+use cxx::{CxxVector};
+use std::fmt::Write as _;
+
+#[test]
+fn test_cxx_vector_new() {
+    let vector = CxxVector::<i32>::new();
+    assert!(vector.is_empty());
+}
+


### PR DESCRIPTION
When constructing a CxxVector to pass to C++, you have to end up writing your own utility function that constructs a `UniquePtr<CxxVector<...>>` and add that to your projects cxx bridge. Creating an empty vector seems like a simple enough task to afford having an API for it on `CxxVector`.