### PR TITLE
Avoid a warning generated when compiling with g++ -Wshadow

### DIFF
--- a/gen/src/builtin.rs
+++ b/gen/src/builtin.rs
@@ -279,7 +279,7 @@ pub(super) fn write(out: &mut OutFile) {
         writeln!(out, "  T value;");
         writeln!(
             out,
-            "  ManuallyDrop(T &&value) : value(::std::move(value)) {{}}",
+            "  ManuallyDrop(T &&arg) : value(::std::move(arg)) {{}}",
         );
         writeln!(out, "  ~ManuallyDrop() {{}}");
         writeln!(out, "}};");


### PR DESCRIPTION
warning: .../src/lib.rs.cc:801:20: warning: declaration of ‘value’ shadows a member of ‘rust::cxxbridge1::ManuallyDrop<T>’ [-Wshadow]
warning:   801 |   ManuallyDrop(T &&value) : value(::std::move(value)) {}
warning:       |                ~~~~^~~~~
warning: .../src/lib.rs.cc:800:5: note: shadowed declaration is here
warning:   800 |   T value;
warning:       |     ^~~~~