### PR TITLE
Remove 'attr!' wrapper around concat in link_name & export_name attributes

### DIFF
--- a/src/cxx_vector.rs
+++ b/src/cxx_vector.rs
@@ -380,19 +380,15 @@ macro_rules! vector_element_by_value_methods {
     (trivial, $segment:expr, $ty:ty) => {
         unsafe fn __push_back(v: Pin<&mut CxxVector<$ty>>, value: &mut ManuallyDrop<$ty>) {
             extern "C" {
-                attr! {
-                    #[link_name = concat!("cxxbridge1$std$vector$", $segment, "$push_back")]
-                    fn __push_back(_: Pin<&mut CxxVector<$ty>>, _: &mut ManuallyDrop<$ty>);
-                }
+                #[link_name = concat!("cxxbridge1$std$vector$", $segment, "$push_back")]
+                fn __push_back(_: Pin<&mut CxxVector<$ty>>, _: &mut ManuallyDrop<$ty>);
             }
             unsafe { __push_back(v, value) }
         }
         unsafe fn __pop_back(v: Pin<&mut CxxVector<$ty>>, out: &mut MaybeUninit<$ty>) {
             extern "C" {
-                attr! {
-                    #[link_name = concat!("cxxbridge1$std$vector$", $segment, "$pop_back")]
-                    fn __pop_back(_: Pin<&mut CxxVector<$ty>>, _: &mut MaybeUninit<$ty>);
-                }
+                #[link_name = concat!("cxxbridge1$std$vector$", $segment, "$pop_back")]
+                fn __pop_back(_: Pin<&mut CxxVector<$ty>>, _: &mut MaybeUninit<$ty>);
             }
             unsafe { __pop_back(v, out) }
         }
@@ -410,38 +406,30 @@ macro_rules! impl_vector_element {
             }
             fn __vector_new() -> *mut CxxVector<Self> {
                 extern "C" {
-                    attr! {
-                        #[link_name = concat!("cxxbridge1$std$vector$", $segment, "$new")]
-                        fn __vector_new() -> *mut CxxVector<$ty>;
-                    }
+                    #[link_name = concat!("cxxbridge1$std$vector$", $segment, "$new")]
+                    fn __vector_new() -> *mut CxxVector<$ty>;
                 }
                 unsafe { __vector_new() }
             }
             fn __vector_size(v: &CxxVector<$ty>) -> usize {
                 extern "C" {
-                    attr! {
-                        #[link_name = concat!("cxxbridge1$std$vector$", $segment, "$size")]
-                        fn __vector_size(_: &CxxVector<$ty>) -> usize;
-                    }
+                    #[link_name = concat!("cxxbridge1$std$vector$", $segment, "$size")]
+                    fn __vector_size(_: &CxxVector<$ty>) -> usize;
                 }
                 unsafe { __vector_size(v) }
             }
             unsafe fn __get_unchecked(v: *mut CxxVector<$ty>, pos: usize) -> *mut $ty {
                 extern "C" {
-                    attr! {
-                        #[link_name = concat!("cxxbridge1$std$vector$", $segment, "$get_unchecked")]
-                        fn __get_unchecked(_: *mut CxxVector<$ty>, _: usize) -> *mut $ty;
-                    }
+                    #[link_name = concat!("cxxbridge1$std$vector$", $segment, "$get_unchecked")]
+                    fn __get_unchecked(_: *mut CxxVector<$ty>, _: usize) -> *mut $ty;
                 }
                 unsafe { __get_unchecked(v, pos) }
             }
             vector_element_by_value_methods!($kind, $segment, $ty);
             fn __unique_ptr_null() -> MaybeUninit<*mut c_void> {
                 extern "C" {
-                    attr! {
-                        #[link_name = concat!("cxxbridge1$unique_ptr$std$vector$", $segment, "$null")]
-                        fn __unique_ptr_null(this: *mut MaybeUninit<*mut c_void>);
-                    }
+                    #[link_name = concat!("cxxbridge1$unique_ptr$std$vector$", $segment, "$null")]
+                    fn __unique_ptr_null(this: *mut MaybeUninit<*mut c_void>);
                 }
                 let mut repr = MaybeUninit::uninit();
                 unsafe { __unique_ptr_null(&mut repr) }
@@ -449,10 +437,8 @@ macro_rules! impl_vector_element {
             }
             unsafe fn __unique_ptr_raw(raw: *mut CxxVector<Self>) -> MaybeUninit<*mut c_void> {
                 extern "C" {
-                    attr! {
-                        #[link_name = concat!("cxxbridge1$unique_ptr$std$vector$", $segment, "$raw")]
-                        fn __unique_ptr_raw(this: *mut MaybeUninit<*mut c_void>, raw: *mut CxxVector<$ty>);
-                    }
+                    #[link_name = concat!("cxxbridge1$unique_ptr$std$vector$", $segment, "$raw")]
+                    fn __unique_ptr_raw(this: *mut MaybeUninit<*mut c_void>, raw: *mut CxxVector<$ty>);
                 }
                 let mut repr = MaybeUninit::uninit();
                 unsafe { __unique_ptr_raw(&mut repr, raw) }
@@ -460,28 +446,22 @@ macro_rules! impl_vector_element {
             }
             unsafe fn __unique_ptr_get(repr: MaybeUninit<*mut c_void>) -> *const CxxVector<Self> {
                 extern "C" {
-                    attr! {
-                        #[link_name = concat!("cxxbridge1$unique_ptr$std$vector$", $segment, "$get")]
-                        fn __unique_ptr_get(this: *const MaybeUninit<*mut c_void>) -> *const CxxVector<$ty>;
-                    }
+                    #[link_name = concat!("cxxbridge1$unique_ptr$std$vector$", $segment, "$get")]
+                    fn __unique_ptr_get(this: *const MaybeUninit<*mut c_void>) -> *const CxxVector<$ty>;
                 }
                 unsafe { __unique_ptr_get(&repr) }
             }
             unsafe fn __unique_ptr_release(mut repr: MaybeUninit<*mut c_void>) -> *mut CxxVector<Self> {
                 extern "C" {
-                    attr! {
-                        #[link_name = concat!("cxxbridge1$unique_ptr$std$vector$", $segment, "$release")]
-                        fn __unique_ptr_release(this: *mut MaybeUninit<*mut c_void>) -> *mut CxxVector<$ty>;
-                    }
+                    #[link_name = concat!("cxxbridge1$unique_ptr$std$vector$", $segment, "$release")]
+                    fn __unique_ptr_release(this: *mut MaybeUninit<*mut c_void>) -> *mut CxxVector<$ty>;
                 }
                 unsafe { __unique_ptr_release(&mut repr) }
             }
             unsafe fn __unique_ptr_drop(mut repr: MaybeUninit<*mut c_void>) {
                 extern "C" {
-                    attr! {
-                        #[link_name = concat!("cxxbridge1$unique_ptr$std$vector$", $segment, "$drop")]
-                        fn __unique_ptr_drop(this: *mut MaybeUninit<*mut c_void>);
-                    }
+                    #[link_name = concat!("cxxbridge1$unique_ptr$std$vector$", $segment, "$drop")]
+                    fn __unique_ptr_drop(this: *mut MaybeUninit<*mut c_void>);
                 }
                 unsafe { __unique_ptr_drop(&mut repr) }
             }

--- a/src/macros/concat.rs
+++ b/src/macros/concat.rs
@@ -1,8 +1,0 @@
-#[macro_export]
-#[doc(hidden)]
-macro_rules! attr {
-    (#[$name:ident = $value:expr] $($rest:tt)*) => {
-        #[$name = $value]
-        $($rest)*
-    };
-}

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -1,4 +1,2 @@
 #[macro_use]
 mod assert;
-#[macro_use]
-mod concat;

--- a/src/shared_ptr.rs
+++ b/src/shared_ptr.rs
@@ -213,46 +213,36 @@ macro_rules! impl_shared_ptr_target {
             }
             unsafe fn __null(new: *mut c_void) {
                 extern "C" {
-                    attr! {
-                        #[link_name = concat!("cxxbridge1$std$shared_ptr$", $segment, "$null")]
-                        fn __null(new: *mut c_void);
-                    }
+                    #[link_name = concat!("cxxbridge1$std$shared_ptr$", $segment, "$null")]
+                    fn __null(new: *mut c_void);
                 }
                 unsafe { __null(new) }
             }
             unsafe fn __new(value: Self, new: *mut c_void) {
                 extern "C" {
-                    attr! {
-                        #[link_name = concat!("cxxbridge1$std$shared_ptr$", $segment, "$uninit")]
-                        fn __uninit(new: *mut c_void) -> *mut c_void;
-                    }
+                    #[link_name = concat!("cxxbridge1$std$shared_ptr$", $segment, "$uninit")]
+                    fn __uninit(new: *mut c_void) -> *mut c_void;
                 }
                 unsafe { __uninit(new).cast::<$ty>().write(value) }
             }
             unsafe fn __clone(this: *const c_void, new: *mut c_void) {
                 extern "C" {
-                    attr! {
-                        #[link_name = concat!("cxxbridge1$std$shared_ptr$", $segment, "$clone")]
-                        fn __clone(this: *const c_void, new: *mut c_void);
-                    }
+                    #[link_name = concat!("cxxbridge1$std$shared_ptr$", $segment, "$clone")]
+                    fn __clone(this: *const c_void, new: *mut c_void);
                 }
                 unsafe { __clone(this, new) }
             }
             unsafe fn __get(this: *const c_void) -> *const Self {
                 extern "C" {
-                    attr! {
-                        #[link_name = concat!("cxxbridge1$std$shared_ptr$", $segment, "$get")]
-                        fn __get(this: *const c_void) -> *const c_void;
-                    }
+                    #[link_name = concat!("cxxbridge1$std$shared_ptr$", $segment, "$get")]
+                    fn __get(this: *const c_void) -> *const c_void;
                 }
                 unsafe { __get(this) }.cast()
             }
             unsafe fn __drop(this: *mut c_void) {
                 extern "C" {
-                    attr! {
-                        #[link_name = concat!("cxxbridge1$std$shared_ptr$", $segment, "$drop")]
-                        fn __drop(this: *mut c_void);
-                    }
+                    #[link_name = concat!("cxxbridge1$std$shared_ptr$", $segment, "$drop")]
+                    fn __drop(this: *mut c_void);
                 }
                 unsafe { __drop(this) }
             }

--- a/src/symbols/rust_vec.rs
+++ b/src/symbols/rust_vec.rs
@@ -14,53 +14,37 @@ macro_rules! rust_vec_shims {
         const_assert_eq!(mem::align_of::<Vec<$ty>>(), mem::align_of::<RustVec<$ty>>());
 
         const _: () = {
-            attr! {
-                #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$new")]
-                unsafe extern "C" fn __new(this: *mut RustVec<$ty>) {
-                    unsafe { ptr::write(this, RustVec::new()) }
-                }
+            #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$new")]
+            unsafe extern "C" fn __new(this: *mut RustVec<$ty>) {
+                unsafe { ptr::write(this, RustVec::new()) }
             }
-            attr! {
-                #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$drop")]
-                unsafe extern "C" fn __drop(this: *mut RustVec<$ty>) {
-                    unsafe { ptr::drop_in_place(this) }
-                }
+            #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$drop")]
+            unsafe extern "C" fn __drop(this: *mut RustVec<$ty>) {
+                unsafe { ptr::drop_in_place(this) }
             }
-            attr! {
-                #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$len")]
-                unsafe extern "C" fn __len(this: *const RustVec<$ty>) -> usize {
-                    unsafe { &*this }.len()
-                }
+            #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$len")]
+            unsafe extern "C" fn __len(this: *const RustVec<$ty>) -> usize {
+                unsafe { &*this }.len()
             }
-            attr! {
-                #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$capacity")]
-                unsafe extern "C" fn __capacity(this: *const RustVec<$ty>) -> usize {
-                    unsafe { &*this }.capacity()
-                }
+            #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$capacity")]
+            unsafe extern "C" fn __capacity(this: *const RustVec<$ty>) -> usize {
+                unsafe { &*this }.capacity()
             }
-            attr! {
-                #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$data")]
-                unsafe extern "C" fn __data(this: *const RustVec<$ty>) -> *const $ty {
-                    unsafe { &*this }.as_ptr()
-                }
+            #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$data")]
+            unsafe extern "C" fn __data(this: *const RustVec<$ty>) -> *const $ty {
+                unsafe { &*this }.as_ptr()
             }
-            attr! {
-                #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$reserve_total")]
-                unsafe extern "C" fn __reserve_total(this: *mut RustVec<$ty>, new_cap: usize) {
-                    unsafe { &mut *this }.reserve_total(new_cap);
-                }
+            #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$reserve_total")]
+            unsafe extern "C" fn __reserve_total(this: *mut RustVec<$ty>, new_cap: usize) {
+                unsafe { &mut *this }.reserve_total(new_cap);
             }
-            attr! {
-                #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$set_len")]
-                unsafe extern "C" fn __set_len(this: *mut RustVec<$ty>, len: usize) {
-                    unsafe { (*this).set_len(len) }
-                }
+            #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$set_len")]
+            unsafe extern "C" fn __set_len(this: *mut RustVec<$ty>, len: usize) {
+                unsafe { (*this).set_len(len) }
             }
-            attr! {
-                #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$truncate")]
-                unsafe extern "C" fn __truncate(this: *mut RustVec<$ty>, len: usize) {
-                    unsafe { (*this).truncate(len) }
-                }
+            #[export_name = concat!("cxxbridge1$rust_vec$", $segment, "$truncate")]
+            unsafe extern "C" fn __truncate(this: *mut RustVec<$ty>, len: usize) {
+                unsafe { (*this).truncate(len) }
             }
         };
     };

--- a/src/weak_ptr.rs
+++ b/src/weak_ptr.rs
@@ -119,46 +119,36 @@ macro_rules! impl_weak_ptr_target {
             }
             unsafe fn __null(new: *mut c_void) {
                 extern "C" {
-                    attr! {
-                        #[link_name = concat!("cxxbridge1$std$weak_ptr$", $segment, "$null")]
-                        fn __null(new: *mut c_void);
-                    }
+                    #[link_name = concat!("cxxbridge1$std$weak_ptr$", $segment, "$null")]
+                    fn __null(new: *mut c_void);
                 }
                 unsafe { __null(new) }
             }
             unsafe fn __clone(this: *const c_void, new: *mut c_void) {
                 extern "C" {
-                    attr! {
-                        #[link_name = concat!("cxxbridge1$std$weak_ptr$", $segment, "$clone")]
-                        fn __clone(this: *const c_void, new: *mut c_void);
-                    }
+                    #[link_name = concat!("cxxbridge1$std$weak_ptr$", $segment, "$clone")]
+                    fn __clone(this: *const c_void, new: *mut c_void);
                 }
                 unsafe { __clone(this, new) }
             }
             unsafe fn __downgrade(shared: *const c_void, weak: *mut c_void) {
                 extern "C" {
-                    attr! {
-                        #[link_name = concat!("cxxbridge1$std$weak_ptr$", $segment, "$downgrade")]
-                        fn __downgrade(shared: *const c_void, weak: *mut c_void);
-                    }
+                    #[link_name = concat!("cxxbridge1$std$weak_ptr$", $segment, "$downgrade")]
+                    fn __downgrade(shared: *const c_void, weak: *mut c_void);
                 }
                 unsafe { __downgrade(shared, weak) }
             }
             unsafe fn __upgrade(weak: *const c_void, shared: *mut c_void) {
                 extern "C" {
-                    attr! {
-                        #[link_name = concat!("cxxbridge1$std$weak_ptr$", $segment, "$upgrade")]
-                        fn __upgrade(weak: *const c_void, shared: *mut c_void);
-                    }
+                    #[link_name = concat!("cxxbridge1$std$weak_ptr$", $segment, "$upgrade")]
+                    fn __upgrade(weak: *const c_void, shared: *mut c_void);
                 }
                 unsafe { __upgrade(weak, shared) }
             }
             unsafe fn __drop(this: *mut c_void) {
                 extern "C" {
-                    attr! {
-                        #[link_name = concat!("cxxbridge1$std$weak_ptr$", $segment, "$drop")]
-                        fn __drop(this: *mut c_void);
-                    }
+                    #[link_name = concat!("cxxbridge1$std$weak_ptr$", $segment, "$drop")]
+                    fn __drop(this: *mut c_void);
                 }
                 unsafe { __drop(this) }
             }


### PR DESCRIPTION
This workaround was originally necessary as the `#[attribute = concat!(...)]` was not accepted by rustc's parser. It became supported in Rust 1.54 (https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html#attributes-can-invoke-function-like-macros).

Since fe16a5dea3a3f2995cf41316c88f2c8961f8f3e7, Rust 1.60+ is required by cxx, so `concat!` can be used directly in an attribute without workaround.