### PR TITLE
bazel: Add dependency on cxx_cc via annotation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 """
+deps = [":cxx_cc"]
 extra_aliased_targets = { cxx_cc = "cxx_cc" }
 gen_build_script = false
 


### PR DESCRIPTION
Context: https://github.com/dtolnay/cxx/pull/1257#issuecomment-1755782014, https://github.com/bazelbuild/rules_rust/pull/2192