### PR TITLE
Provide cfg option to disable use of cc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,20 +15,21 @@ repository = "https://github.com/dtolnay/cxx"
 rust-version = "1.60"
 
 [features]
-default = ["std", "cxxbridge-flags/default"] # c++11
-"c++14" = ["cxxbridge-flags/c++14"]
-"c++17" = ["cxxbridge-flags/c++17"]
-"c++20" = ["cxxbridge-flags/c++20"]
+default = ["std", "cxxbridge-flags/default", "cc"] # c++11
+"c++14" = ["cc", "cxxbridge-flags/c++14"]
+"c++17" = ["cc", "cxxbridge-flags/c++17"]
+"c++20" = ["cc", "cxxbridge-flags/c++20"]
 alloc = []
 std = ["alloc"]
+cc = [ "dep:cc", "dep:cxxbridge-flags" ]
 
 [dependencies]
 cxxbridge-macro = { version = "=1.0.110", path = "macro" }
 link-cplusplus = "1.0.9"
 
 [build-dependencies]
-cc = "1.0.79"
-cxxbridge-flags = { version = "=1.0.110", path = "flags", default-features = false }
+cc = { version="1.0.79", optional=true }
+cxxbridge-flags = { version = "=1.0.110", path = "flags", default-features = false, optional=true }
 
 [dev-dependencies]
 cxx-build = { version = "=1.0.110", path = "gen/build" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ default = ["std", "cxxbridge-flags/default", "cc"] # c++11
 alloc = []
 std = ["alloc"]
 cc = [ "dep:cc", "dep:cxxbridge-flags" ]
+cxxbridge-flags = [ "dep:cxxbridge-flags" ]
 
 [dependencies]
 cxxbridge-macro = { version = "=1.0.110", path = "macro" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ cxxbridge-macro = { version = "=1.0.110", path = "macro" }
 link-cplusplus = "1.0.9"
 
 [build-dependencies]
-cc = { version="1.0.79", optional=true }
-cxxbridge-flags = { version = "=1.0.110", path = "flags", default-features = false, optional=true }
+cc = { version="1.0.79", optional = true }
+cxxbridge-flags = { version = "=1.0.110", path = "flags", default-features = false, optional = true }
 
 [dev-dependencies]
 cxx-build = { version = "=1.0.110", path = "gen/build" }


### PR DESCRIPTION
In the Chromium build system, we automatically convert Cargo.toml rules into rules for our build system, gn. We also run build.rs files as part of the Chromium build (because it turns out that the vast majority of them just set some feature flags for feature detection).

The build.rs for cxx does more sophisticated things - including building C++ code using cc. That's appropriate in a cargo context, but presents difficulty for our build system where C++ must be built using static build rules beyond the realm of cargo. At the moment we carry a patch for this, but it would be great not to have to do so.

This patch would enable us to use the Cargo.toml and build.rs for cxx without change. It's only one out of four patches we currently carry for cxx, but it would be great to get rid of it! Obviously this may seem like a bit of a niche use-case, but hopefully this helps anyone else who builds cxx using non-Cargo build systems, but reusing the Cargo.toml and build.rs.

The intention is that this change is a no-op except for folks who disable default features.