### PR TITLE
Remove option_if_let_else clippy suppression

### DIFF
--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -65,7 +65,6 @@
     clippy::needless_pass_by_value,
     clippy::new_without_default,
     clippy::nonminimal_bool,
-    clippy::option_if_let_else,
     clippy::or_fun_call,
     clippy::redundant_else,
     clippy::shadow_unrelated,

--- a/gen/cmd/src/main.rs
+++ b/gen/cmd/src/main.rs
@@ -16,7 +16,6 @@
     clippy::needless_pass_by_value,
     clippy::new_without_default,
     clippy::nonminimal_bool,
-    clippy::option_if_let_else,
     clippy::or_fun_call,
     clippy::redundant_else,
     clippy::shadow_unrelated,

--- a/gen/lib/src/lib.rs
+++ b/gen/lib/src/lib.rs
@@ -28,7 +28,6 @@
     clippy::needless_pass_by_value,
     clippy::new_without_default,
     clippy::nonminimal_bool,
-    clippy::option_if_let_else,
     clippy::or_fun_call,
     clippy::redundant_else,
     clippy::shadow_unrelated,

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -15,7 +15,6 @@
     clippy::needless_pass_by_value,
     clippy::new_without_default,
     clippy::nonminimal_bool,
-    clippy::option_if_let_else,
     clippy::or_fun_call,
     clippy::redundant_else,
     clippy::shadow_unrelated,


### PR DESCRIPTION
This lint got downgraded from `pedantic` to `nursery` by https://github.com/rust-lang/rust-clippy/pull/7568 so we no longer run it.