### PR TITLE
Restore documented cfg on cxx::Exception

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -477,6 +477,7 @@ mod weak_ptr;
 
 pub use crate::cxx_vector::CxxVector;
 #[cfg(feature = "alloc")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
 pub use crate::exception::Exception;
 pub use crate::extern_type::{kind, ExternType};
 pub use crate::shared_ptr::SharedPtr;


### PR DESCRIPTION
This regressed with https://github.com/rust-lang/rust/pull/113091 in nightly-2023-12-16. The doc(cfg()) from the type definition is no longer rendered.