### PR TITLE
CxxVector: implement reserve() and capacity()

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1925,10 +1925,28 @@ fn write_cxx_vector(out: &mut OutFile, key: NamedImplKey) {
     begin_function_definition(out);
     writeln!(
         out,
+        "::std::size_t cxxbridge1$std$vector${}$capacity(::std::vector<{}> const &s) noexcept {{",
+        instance, inner,
+    );
+    writeln!(out, "  return s.capacity();");
+    writeln!(out, "}}");
+
+    begin_function_definition(out);
+    writeln!(
+        out,
         "{} *cxxbridge1$std$vector${}$get_unchecked(::std::vector<{}> *s, ::std::size_t pos) noexcept {{",
         inner, instance, inner,
     );
     writeln!(out, "  return &(*s)[pos];");
+    writeln!(out, "}}");
+
+    begin_function_definition(out);
+    writeln!(
+        out,
+        "void cxxbridge1$std$vector${}$reserve(::std::vector<{}> *s, ::std::size_t new_cap) {{",
+        instance, inner,
+    );
+    writeln!(out, "  s->reserve(new_cap);");
     writeln!(out, "}}");
 
     if out.types.is_maybe_trivial(element) {

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1678,7 +1678,9 @@ fn expand_cxx_vector(
     let prefix = format!("cxxbridge1$std$vector${}$", resolve.name.to_symbol());
     let link_new = format!("{}new", prefix);
     let link_size = format!("{}size", prefix);
+    let link_capacity = format!("{}capacity", prefix);
     let link_get_unchecked = format!("{}get_unchecked", prefix);
+    let link_reserve = format!("{}reserve", prefix);
     let link_push_back = format!("{}push_back", prefix);
     let link_pop_back = format!("{}pop_back", prefix);
     let unique_ptr_prefix = format!(
@@ -1760,6 +1762,13 @@ fn expand_cxx_vector(
                 }
                 unsafe { __vector_size(v) }
             }
+            fn __vector_capacity(v: &::cxx::CxxVector<Self>) -> usize {
+                extern "C" {
+                    #[link_name = #link_capacity]
+                    fn __vector_capacity #impl_generics(_: &::cxx::CxxVector<#elem #ty_generics>) -> usize;
+                }
+                unsafe { __vector_capacity(v) }
+            }
             unsafe fn __get_unchecked(v: *mut ::cxx::CxxVector<Self>, pos: usize) -> *mut Self {
                 extern "C" {
                     #[link_name = #link_get_unchecked]
@@ -1769,6 +1778,16 @@ fn expand_cxx_vector(
                     ) -> *mut ::cxx::core::ffi::c_void;
                 }
                 unsafe { __get_unchecked(v, pos) as *mut Self }
+            }
+            unsafe fn __reserve(v: ::cxx::core::pin::Pin<&mut ::cxx::CxxVector<Self>>, new_cap: usize) {
+                extern "C" {
+                    #[link_name = #link_reserve]
+                    fn __reserve #impl_generics(
+                        v: ::cxx::core::pin::Pin<&mut ::cxx::CxxVector<#elem #ty_generics>>,
+                        new_cap: usize,
+                    );
+                }
+                unsafe { __reserve(v, new_cap) }
             }
             #by_value_methods
             fn __unique_ptr_null() -> ::cxx::core::mem::MaybeUninit<*mut ::cxx::core::ffi::c_void> {

--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -600,9 +600,17 @@ static_assert(sizeof(std::string) <= kMaxExpectedWordsInString * sizeof(void *),
       const std::vector<CXX_TYPE> &s) noexcept {                               \
     return s.size();                                                           \
   }                                                                            \
+  std::size_t cxxbridge1$std$vector$##RUST_TYPE##$capacity(                    \
+      const std::vector<CXX_TYPE> &s) noexcept {                               \
+    return s.capacity();                                                       \
+  }                                                                            \
   CXX_TYPE *cxxbridge1$std$vector$##RUST_TYPE##$get_unchecked(                 \
       std::vector<CXX_TYPE> *s, std::size_t pos) noexcept {                    \
     return &(*s)[pos];                                                         \
+  }                                                                            \
+  void cxxbridge1$std$vector$##RUST_TYPE##$reserve(                            \
+      std::vector<CXX_TYPE> *s, std::size_t new_cap) noexcept {                \
+    s->reserve(new_cap);                                                       \
   }                                                                            \
   void cxxbridge1$unique_ptr$std$vector$##RUST_TYPE##$null(                    \
       std::unique_ptr<std::vector<CXX_TYPE>> *ptr) noexcept {                  \

--- a/src/cxx_vector.rs
+++ b/src/cxx_vector.rs
@@ -219,6 +219,18 @@ where
     }
 }
 
+impl<A> Extend<A> for Pin<&mut CxxVector<A>>
+where
+    A: ExternType<Kind = Trivial>,
+    A: VectorElement,
+{
+    fn extend<T: IntoIterator<Item = A>>(&mut self, iter: T) {
+        for i in iter {
+            self.as_mut().push(i);
+        }
+    }
+}
+
 /// Iterator over elements of a `CxxVector` by shared reference.
 ///
 /// The iterator element type is `&'a T`.

--- a/src/cxx_vector.rs
+++ b/src/cxx_vector.rs
@@ -225,6 +225,8 @@ where
     A: VectorElement,
 {
     fn extend<T: IntoIterator<Item = A>>(&mut self, iter: T) {
+        let iter = iter.into_iter();
+        self.as_mut().reserve(iter.size_hint().0);
         for i in iter {
             self.as_mut().push(i);
         }

--- a/src/cxx_vector.rs
+++ b/src/cxx_vector.rs
@@ -57,7 +57,7 @@ where
     ///
     /// Matches the behavior of C++ [std::vector\<T\>::capacity][capacity].
     ///
-    /// [size]: https://en.cppreference.com/w/cpp/container/vector/capacity
+    /// [capacity]: https://en.cppreference.com/w/cpp/container/vector/capacity
     pub fn capacity(&self) -> usize {
         T::__vector_capacity(self)
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -161,7 +161,7 @@ fn test_c_take() {
     assert_eq!(vector.pin_mut().pop(), Some(9));
     check!(ffi::c_take_unique_ptr_vector_u8(vector));
     let mut vector = ffi::c_return_unique_ptr_vector_f64();
-    vector.pin_mut().push(9.0);
+    vector.pin_mut().extend(Some(9.0));
     assert!(vector.pin_mut().capacity() >= 1);
     vector.pin_mut().reserve(100);
     assert!(vector.pin_mut().capacity() >= 101);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -56,6 +56,7 @@ fn test_c_return() {
     assert_eq!("Hello \u{fffd}World", ffi::c_return_rust_string_lossy());
     assert_eq!("2020", ffi::c_return_unique_ptr_string().to_str().unwrap());
     assert_eq!(4, ffi::c_return_unique_ptr_vector_u8().len());
+    assert!(4 <= ffi::c_return_unique_ptr_vector_u8().capacity());
     assert_eq!(
         200_u8,
         ffi::c_return_unique_ptr_vector_u8().into_iter().sum(),
@@ -65,6 +66,7 @@ fn test_c_return() {
         ffi::c_return_unique_ptr_vector_f64().into_iter().sum(),
     );
     assert_eq!(2, ffi::c_return_unique_ptr_vector_shared().len());
+    assert!(2 <= ffi::c_return_unique_ptr_vector_shared().capacity());
     assert_eq!(
         2021_usize,
         ffi::c_return_unique_ptr_vector_shared()
@@ -160,6 +162,9 @@ fn test_c_take() {
     check!(ffi::c_take_unique_ptr_vector_u8(vector));
     let mut vector = ffi::c_return_unique_ptr_vector_f64();
     vector.pin_mut().push(9.0);
+    assert!(vector.pin_mut().capacity() >= 1);
+    vector.pin_mut().reserve(100);
+    assert!(vector.pin_mut().capacity() >= 101);
     check!(ffi::c_take_unique_ptr_vector_f64(vector));
     let mut vector = ffi::c_return_unique_ptr_vector_shared();
     vector.pin_mut().push(ffi::Shared { z: 9 });


### PR DESCRIPTION
Efficient insertions into CxxVector requires reserving additional capacity. This also adds a way to query current capacity.

Also implement `extend`, which can use the size hint