### PR TITLE
Include printing of "cargo:rerun-if-changed" in tutorial

### DIFF
--- a/book/src/tutorial.md
+++ b/book/src/tutorial.md
@@ -204,6 +204,10 @@ fn main() {
     cxx_build::bridge("src/main.rs")
         .file("src/blobstore.cc")
         .compile("cxx-demo");
+
+    println!("cargo:rerun-if-changed=src/main.rs");
+    println!("cargo:rerun-if-changed=src/blobstore.cc");
+    println!("cargo:rerun-if-changed=include/blobstore.h");
 }
 ```
 


### PR DESCRIPTION
I ran into some compilation issues while going through the tutorial step-by-step.
Looking at the tutorial files in the repo, I expect this was caused by me missing the `cargo:rerun-if-changed` lines in the build script (without them, changes to the .cc and .h files did not have any effect).
I'm adding those on the tutorial page so other people will be aware of them from the start.