### PR TITLE
Work around new dead_code warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -548,4 +548,4 @@ chars! {
 }
 
 #[repr(transparent)]
-struct void(core::ffi::c_void);
+struct void(#[allow(dead_code)] core::ffi::c_void);

--- a/syntax/cfg.rs
+++ b/syntax/cfg.rs
@@ -6,9 +6,12 @@ use syn::{parenthesized, token, Attribute, LitStr, Token};
 #[derive(Clone)]
 pub(crate) enum CfgExpr {
     Unconditional,
+    #[allow(dead_code)] // only used by cxx-build, not cxxbridge-macro
     Eq(Ident, Option<LitStr>),
     All(Vec<CfgExpr>),
+    #[allow(dead_code)] // only used by cxx-build, not cxxbridge-macro
     Any(Vec<CfgExpr>),
+    #[allow(dead_code)] // only used by cxx-build, not cxxbridge-macro
     Not(Box<CfgExpr>),
 }
 

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -49,6 +49,7 @@ pub(crate) use self::parse::parse_items;
 pub(crate) use self::types::Types;
 
 pub(crate) enum Api {
+    #[allow(dead_code)] // only used by cxx-build, not cxxbridge-macro
     Include(Include),
     Struct(Struct),
     Enum(Enum),

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -408,7 +408,7 @@ impl R {
     }
 }
 
-pub struct Reference<'a>(&'a String);
+pub struct Reference<'a>(pub &'a String);
 
 impl ffi::Shared {
     fn r_method_on_shared(&self) -> String {


### PR DESCRIPTION
Warnings are new in nightly-2024-01-06 due to https://github.com/rust-lang/rust/pull/118297.