### PR TITLE
Add custom deleter support to UniquePtr

### DIFF
--- a/book/src/binding/uniqueptr.md
+++ b/book/src/binding/uniqueptr.md
@@ -8,8 +8,9 @@ the link for documentation of the Rust API.
 
 ### Restrictions:
 
-Only `std::unique_ptr<T, std::default_delete<T>>` is currently supported. Custom
-deleters may be supported in the future.
+If a custom deleter is used, it needs to be a type that is
+[shared between C++ and Rust](../shared.md) so that the instance of UniquePtr can still
+be passed by value in Rust code.
 
 UniquePtr\<T\> does not support T being an opaque Rust type. You should use a
 Box\<T\> (C++ [rust::Box\<T\>](box.md)) instead for transferring ownership of

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1775,7 +1775,10 @@ fn write_unique_ptr_common(out: &mut OutFile, ty: UniquePtr) {
     if deleter_name.is_some() {
         // Check whether the deleter is really the first member as expected by the Rust type
         out.include.cassert = true;
+        #[cfg(not(target_os = "macos"))]
         writeln!(out, "  assert(reinterpret_cast<void*>(&ptr->get_deleter()) == reinterpret_cast<void*>(ptr));");
+        #[cfg(target_os = "macos")]
+        writeln!(out, "  assert(reinterpret_cast<char*>(&ptr->get_deleter()) >= reinterpret_cast<char*>(ptr) + sizeof(void*));");
     }
     if conditional_delete {
         out.builtin.deleter_if = true;

--- a/src/unique_ptr.rs
+++ b/src/unique_ptr.rs
@@ -13,6 +13,7 @@ use cxx::type_id;
 
 /// Rust representation of the default deleter of std::unique_ptr, `std::default_delete<T>`
 #[derive(Default, Copy, Clone, Debug)]
+#[repr(C)]
 pub struct DefaultDeleter([u8; 0]);
 
 unsafe impl ExternType for DefaultDeleter {

--- a/syntax/impls.rs
+++ b/syntax/impls.rs
@@ -1,5 +1,6 @@
 use crate::syntax::{
-    Array, ExternFn, Include, Lifetimes, Ptr, Receiver, Ref, Signature, SliceRef, Ty1, Type, Var,
+    Array, ExternFn, Include, Lifetimes, Ptr, Receiver, Ref, Signature, SliceRef, Ty1, Ty2, Type,
+    Var,
 };
 use std::hash::{Hash, Hasher};
 use std::mem;
@@ -145,6 +146,22 @@ impl Hash for Ty1 {
         } = self;
         name.hash(state);
         inner.hash(state);
+    }
+}
+
+impl Eq for Ty2 {}
+
+impl PartialEq for Ty2 {
+    fn eq(&self, other: &Self) -> bool {
+        self.first == other.first && self.second == other.second && self.name == other.name
+    }
+}
+
+impl Hash for Ty2 {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+        self.first.hash(state);
+        self.second.hash(state);
     }
 }
 

--- a/syntax/instantiate.rs
+++ b/syntax/instantiate.rs
@@ -1,7 +1,7 @@
 use crate::syntax::{NamedType, Ty1, Ty2, Type};
 use proc_macro2::{Ident, Span};
 use std::hash::{Hash, Hasher};
-use syn::Token;
+use syn::{Lifetime, Token, punctuated::Punctuated};
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum ImplKey<'a> {
@@ -20,6 +20,8 @@ pub(crate) struct NamedImplKey<'a> {
     pub rust: &'a Ident,
     #[allow(dead_code)] // only used by cxxbridge-macro, not cxx-build
     pub lt_token: Option<Token![<]>,
+    #[allow(dead_code)] // only used by cxxbridge-macro, not cxx-build
+    pub lifetimes: &'a Punctuated<Lifetime, Token![,]>,
     #[allow(dead_code)] // only used by cxxbridge-macro, not cxx-build
     pub gt_token: Option<Token![>]>,
     #[allow(dead_code)] // only used by cxxbridge-macro, not cxx-build
@@ -87,6 +89,7 @@ impl<'a> NamedImplKey<'a> {
             begin_span: outer.name.span(),
             rust: &inner.rust,
             lt_token: inner.generics.lt_token,
+            lifetimes: &inner.generics.lifetimes,
             gt_token: inner.generics.gt_token,
             end_span: outer.rangle.span,
         }
@@ -97,6 +100,7 @@ impl<'a> NamedImplKey<'a> {
             begin_span: outer.name.span(),
             rust: &inner.rust,
             lt_token: inner.generics.lt_token,
+            lifetimes: &inner.generics.lifetimes,
             gt_token: inner.generics.gt_token,
             end_span: outer.rangle.span,
         }

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -264,7 +264,7 @@ pub(crate) enum Type {
     Ident(NamedType),
     RustBox(Box<Ty1>),
     RustVec(Box<Ty1>),
-    UniquePtr(Box<Ty1>),
+    UniquePtr(Box<Ty2>),
     SharedPtr(Box<Ty1>),
     WeakPtr(Box<Ty1>),
     Ref(Box<Ref>),
@@ -281,6 +281,14 @@ pub(crate) struct Ty1 {
     pub name: Ident,
     pub langle: Token![<],
     pub inner: Type,
+    pub rangle: Token![>],
+}
+
+pub(crate) struct Ty2 {
+    pub name: Ident,
+    pub langle: Token![<],
+    pub first: Type,
+    pub second: Option<Type>,
     pub rangle: Token![>],
 }
 

--- a/syntax/types.rs
+++ b/syntax/types.rs
@@ -178,7 +178,7 @@ impl<'a> Types<'a> {
             let implicit_impl = match impl_key {
                 ImplKey::RustBox(ident)
                 | ImplKey::RustVec(ident)
-                | ImplKey::UniquePtr(ident)
+                | ImplKey::UniquePtr(ident, _)
                 | ImplKey::SharedPtr(ident)
                 | ImplKey::WeakPtr(ident)
                 | ImplKey::CxxVector(ident) => {
@@ -243,8 +243,8 @@ impl<'a> Types<'a> {
 
     pub(crate) fn needs_indirect_abi(&self, ty: &Type) -> bool {
         match ty {
-            Type::RustBox(_) | Type::UniquePtr(_) => false,
-            Type::Array(_) => true,
+            Type::RustBox(_) => false,
+            Type::Array(_) | Type::UniquePtr(_) => true,
             _ => !self.is_guaranteed_pod(ty),
         }
     }

--- a/syntax/visit.rs
+++ b/syntax/visit.rs
@@ -13,11 +13,11 @@ where
     match ty {
         Type::Ident(_) | Type::Str(_) | Type::Void(_) => {}
         Type::RustBox(ty)
-        | Type::UniquePtr(ty)
         | Type::SharedPtr(ty)
         | Type::WeakPtr(ty)
         | Type::CxxVector(ty)
         | Type::RustVec(ty) => visitor.visit_type(&ty.inner),
+        Type::UniquePtr(ty) => visitor.visit_type(&ty.first),
         Type::Ref(r) => visitor.visit_type(&r.inner),
         Type::Ptr(p) => visitor.visit_type(&p.inner),
         Type::Array(a) => visitor.visit_type(&a.inner),

--- a/tests/ffi/build.rs
+++ b/tests/ffi/build.rs
@@ -13,6 +13,8 @@ fn main() {
     build.warnings_into_errors(cfg!(deny_warnings));
     if cfg!(not(target_env = "msvc")) {
         build.define("CXX_TEST_INSTANTIATIONS", None);
+    } else {
+        build.flag_if_supported("/Zc:__cplusplus");
     }
     build.compile("cxx-test-suite");
 

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -13,6 +13,9 @@
 extern "C" void cxx_test_suite_set_correct() noexcept;
 extern "C" tests::R *cxx_test_suite_get_box() noexcept;
 extern "C" bool cxx_test_suite_r_is_correct(const tests::R *) noexcept;
+extern "C" bool PmrDeleterForC_callback_used;
+
+bool PmrDeleterForC_callback_used{false};
 
 namespace tests {
 
@@ -138,8 +141,6 @@ rust::Box<R> c_return_box() {
 std::unique_ptr<C> c_return_unique_ptr() {
   return std::unique_ptr<C>(new C{2020});
 }
-
-extern "C" bool PmrDeleterForC_callback_used{false};
 
 void PmrDeleterForC::operator()(C* obj) {
     alloc.destroy(obj);

--- a/tests/ui/unique_ptr_to_opaque.stderr
+++ b/tests/ui/unique_ptr_to_opaque.stderr
@@ -11,11 +11,11 @@ note: expected this to be `Trivial`
    |
 8  |         type Kind = cxx::kind::Opaque;
    |                     ^^^^^^^^^^^^^^^^^
-note: required by a bound in `UniquePtr::<T>::new`
+note: required by a bound in `UniquePtr::<T, D>::new`
   --> src/unique_ptr.rs
    |
    |     pub fn new(value: T) -> Self
    |            --- required by a bound in this associated function
    |     where
    |         T: ExternType<Kind = Trivial>,
-   |                       ^^^^^^^^^^^^^^ required by this bound in `UniquePtr::<T>::new`
+   |                       ^^^^^^^^^^^^^^ required by this bound in `UniquePtr::<T, D>::new`


### PR DESCRIPTION
Add the possibility to use shared trivial types as deleters for objects managed by std::unique_ptr / UniquePtr.