### PR TITLE
Remove pre-1.57 proc_macro2::fallback::force()

### DIFF
--- a/gen/src/mod.rs
+++ b/gen/src/mod.rs
@@ -124,7 +124,6 @@ fn generate_from_string(source: &str, opt: &Opt) -> Result<GeneratedCode> {
         let shebang_end = source.find('\n').unwrap_or(source.len());
         source = &source[shebang_end..];
     }
-    proc_macro2::fallback::force();
     let syntax: File = syn::parse_str(source)?;
     generate(syntax, opt)
 }


### PR DESCRIPTION
This is obsolete since `proc_macro2::is_available()` became available in Rust 1.57, which avoids needing a catch_unwind for libproc_macro detection.