### PR TITLE
Documentation: Use `builder.std` rather than explicit compiler flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ cxx-build = "1.0"
 fn main() {
     cxx_build::bridge("src/main.rs")  // returns a cc::Build
         .file("src/demo.cc")
-        .flag_if_supported("-std=c++11")
+        .std("c++11")
         .compile("cxxbridge-demo");
 
     println!("cargo:rerun-if-changed=src/main.rs");

--- a/book/src/build/cargo.md
+++ b/book/src/build/cargo.md
@@ -38,7 +38,7 @@ set up any additional source files and compiler flags as normal.
 fn main() {
     cxx_build::bridge("src/main.rs")  // returns a cc::Build
         .file("src/demo.cc")
-        .flag_if_supported("-std=c++11")
+        .std("c++11")
         .compile("cxxbridge-demo");
 
     println!("cargo:rerun-if-changed=src/main.rs");

--- a/book/src/tutorial.md
+++ b/book/src/tutorial.md
@@ -159,7 +159,7 @@ std::unique_ptr<BlobstoreClient> new_blobstore_client() {
 }
 ```
 
-Using `std::make_unique` would work too, as long as you pass `-std=c++14` to the
+Using `std::make_unique` would work too, as long as you pass `std("c++14")` to the
 C++ compiler as described later on.
 
 The placement in *include/* and *src/* is not significant; you can place C++
@@ -222,7 +222,7 @@ integration.
 # fn main() {
     cxx_build::bridge("src/main.rs")
         .file("src/blobstore.cc")
-        .flag_if_supported("-std=c++14")
+        .std("c++14")
         .compile("cxx-demo");
 # }
 ```


### PR DESCRIPTION
Small documentation update after running into this issue using the MSVC `cl` compiler on Windows.

Thanks for the awesome library.

---

The `-std=c++11` flag only works with GNU-style compiler frontends for MSVC this should be `/std:c++11`.
Even better is to use the builder's explicit C/C++ standard setter.