### PR TITLE
Set C++ standard version using cc::Build::std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ cxxbridge-macro = { version = "=1.0.118", path = "macro" }
 link-cplusplus = "1.0.9"
 
 [build-dependencies]
-cc = "1.0.79"
+cc = "1.0.83"
 cxxbridge-flags = { version = "=1.0.118", path = "flags", default-features = false }
 
 [dev-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,7 @@ fn main() {
         .file(manifest_dir.join("src/cxx.cc"))
         .cpp(true)
         .cpp_link_stdlib(None) // linked via link-cplusplus crate
-        .flag_if_supported(cxxbridge_flags::STD)
+        .std(cxxbridge_flags::STD)
         .warnings_into_errors(cfg!(deny_warnings))
         .compile("cxxbridge1");
 

--- a/flags/src/impl.rs
+++ b/flags/src/impl.rs
@@ -1,20 +1,15 @@
 #[allow(unused_assignments, unused_mut, unused_variables)]
 pub const STD: &str = {
-    let mut flags = ["-std=c++11", "/std:c++11"];
+    let mut flag = "c++11";
 
     #[cfg(feature = "c++14")]
-    (flags = ["-std=c++14", "/std:c++14"]);
+    (flag = "c++14");
 
     #[cfg(feature = "c++17")]
-    (flags = ["-std=c++17", "/std:c++17"]);
+    (flag = "c++17");
 
     #[cfg(feature = "c++20")]
-    (flags = ["-std=c++20", "/std:c++20"]);
-
-    let [mut flag, msvc_flag] = flags;
-
-    #[cfg(target_env = "msvc")]
-    (flag = msvc_flag);
+    (flag = "c++20");
 
     flag
 };

--- a/flags/src/lib.rs
+++ b/flags/src/lib.rs
@@ -1,6 +1,8 @@
 //! This crate is an implementation detail of the `cxx` and `cxx-build` crates,
 //! and does not expose any public API.
 
+#![allow(clippy::let_and_return)]
+
 mod r#impl;
 
 #[doc(hidden)]

--- a/gen/build/Cargo.toml
+++ b/gen/build/Cargo.toml
@@ -19,7 +19,7 @@ parallel = ["cc/parallel"]
 experimental-async-fn = []
 
 [dependencies]
-cc = "1.0.79"
+cc = "1.0.83"
 codespan-reporting = "0.11.1"
 once_cell = "1.18"
 proc-macro2 = { version = "1.0.74", default-features = false, features = ["span-locations"] }

--- a/tests/ffi/build.rs
+++ b/tests/ffi/build.rs
@@ -9,7 +9,7 @@ fn main() {
     let sources = vec!["lib.rs", "module.rs"];
     let mut build = cxx_build::bridges(sources);
     build.file("tests.cc");
-    build.flag_if_supported(cxxbridge_flags::STD);
+    build.std(cxxbridge_flags::STD);
     build.warnings_into_errors(cfg!(deny_warnings));
     if cfg!(not(target_env = "msvc")) {
         build.define("CXX_TEST_INSTANTIATIONS", None);

--- a/third-party/Cargo.toml
+++ b/third-party/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 path = "/dev/null"
 
 [dependencies]
-cc = "1.0.49"
+cc = "1.0.83"
 clap = { version = "4", default-features = false, features = ["error-context", "help", "std", "usage"] }
 codespan-reporting = "0.11.1"
 once_cell = "1.9"


### PR DESCRIPTION
Based on https://github.com/dtolnay/cxx/pull/1321.

I am not certain whether this is better. For example, would this change be problematic if someone has been using a C++ compiler that does not support `-std=c++20`, but had enabled our `"cxx/c++20"` Cargo feature, yet was not using any C++20 features in their headers? It would have silently worked before by noop-ing the `flag_if_supported`, but maybe it shouldn't have.