### PR TITLE
Use libcore's c_char if available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           - rust: beta
           - rust: stable
           - rust: 1.60.0
+          - rust: 1.64.0
           - rust: 1.70.0
           - rust: 1.74.0
           - name: Cargo on macOS
@@ -64,7 +65,7 @@ jobs:
         shell: bash
       - run: cargo run --manifest-path demo/Cargo.toml
       - run: cargo test --workspace ${{steps.testsuite.outputs.exclude}}
-        if: matrix.rust != '1.60.0'
+        if: matrix.rust != '1.60.0' && matrix.rust != '1.64.0'
       - run: cargo check --no-default-features --features alloc
         env:
           RUSTFLAGS: --cfg compile_error_if_std ${{env.RUSTFLAGS}}

--- a/build.rs
+++ b/build.rs
@@ -31,6 +31,11 @@ fn main() {
                 rustc.version,
             );
         }
+
+        if rustc.minor < 64 {
+            // core::ffi::c_char
+            println!("cargo:rustc-cfg=no_core_ffi_c_char");
+        }
     }
 }
 

--- a/src/c_char.rs
+++ b/src/c_char.rs
@@ -8,6 +8,12 @@ pub type c_char = c_char_definition::c_char;
 #[cfg(all(test, feature = "std"))]
 const _: self::c_char = 0 as std::os::raw::c_char;
 
+#[cfg(not(no_core_ffi_c_char))]
+mod c_char_definition {
+    pub use core::ffi::c_char;
+}
+
+#[cfg(no_core_ffi_c_char)]
 #[allow(dead_code)]
 mod c_char_definition {
     // These are the targets on which c_char is unsigned.


### PR DESCRIPTION
`core::ffi::c_char` became available in Rust 1.64.0.
<https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html#stabilized-apis>