### PR TITLE
gen: allow for cfg_evaluator to be set in cxx_gen

### DIFF
--- a/gen/lib/src/lib.rs
+++ b/gen/lib/src/lib.rs
@@ -47,7 +47,7 @@ mod syntax;
 
 pub use crate::error::Error;
 pub use crate::gen::include::{Include, HEADER};
-pub use crate::gen::{GeneratedCode, Opt};
+pub use crate::gen::{CfgEvaluator, CfgResult, GeneratedCode, Opt};
 pub use crate::syntax::IncludeKind;
 use proc_macro2::TokenStream;
 

--- a/gen/src/mod.rs
+++ b/gen/src/mod.rs
@@ -54,22 +54,32 @@ pub struct Opt {
     /// Rust code from one shared object or executable depends on these C++
     /// functions in another.
     pub cxx_impl_annotations: Option<String>,
+    /// Optional [`CfgEvaluator`] for handling cfg attributes
+    pub cfg_evaluator: Box<dyn CfgEvaluator>,
 
     pub(super) gen_header: bool,
     pub(super) gen_implementation: bool,
     pub(super) allow_dot_includes: bool,
-    pub(super) cfg_evaluator: Box<dyn CfgEvaluator>,
     pub(super) doxygen: bool,
 }
 
-pub(super) trait CfgEvaluator {
+/// An evaluator which parses cfg attributes
+pub trait CfgEvaluator {
+    /// For a given cfg name and value return a [`CfgResult`] indicating if it's enabled
     fn eval(&self, name: &str, value: Option<&str>) -> CfgResult;
 }
 
-pub(super) enum CfgResult {
+/// Results of a [`CfgEvaluator`]
+pub enum CfgResult {
+    /// cfg option is enabled
     True,
+    /// cfg option is disabled
     False,
-    Undetermined { msg: String },
+    /// cfg option is not enabled or disabled
+    Undetermined {
+        /// Custom message explaining why the cfg option is undetermined
+        msg: String,
+    },
 }
 
 /// Results of code generation.


### PR DESCRIPTION
This allows for users of cxx_gen to choose a cfg_evaluator, otherwise they cannot have cfg attributes in bridges.