### PR TITLE
Rely on docs.rs to define --cfg=docsrs by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = ["demo", "flags", "gen/build", "gen/cmd", "gen/lib", "macro", "tests/f
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
-rustdoc-args = ["--cfg", "doc_cfg", "--generate-link-to-definition"]
+rustdoc-args = ["--generate-link-to-definition"]
 
 [package.metadata.bazel]
 additive_build_file_content = """

--- a/build.rs
+++ b/build.rs
@@ -32,7 +32,6 @@ fn main() {
             println!("cargo:rustc-check-cfg=cfg(compile_error_if_alloc)");
             println!("cargo:rustc-check-cfg=cfg(compile_error_if_std)");
             println!("cargo:rustc-check-cfg=cfg(cxx_experimental_no_alloc)");
-            println!("cargo:rustc-check-cfg=cfg(doc_cfg)");
             println!("cargo:rustc-check-cfg=cfg(no_core_ffi_c_char)");
             println!("cargo:rustc-check-cfg=cfg(skip_ui_tests)");
         }

--- a/src/cxx_string.rs
+++ b/src/cxx_string.rs
@@ -148,7 +148,7 @@ impl CxxString {
     ///
     /// [replacement character]: https://doc.rust-lang.org/std/char/constant.REPLACEMENT_CHARACTER.html
     #[cfg(feature = "alloc")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn to_string_lossy(&self) -> Cow<str> {
         String::from_utf8_lossy(self.as_bytes())
     }

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -4,7 +4,7 @@ use alloc::boxed::Box;
 use core::fmt::{self, Display};
 
 /// Exception thrown from an `extern "C++"` function.
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[derive(Debug)]
 pub struct Exception {
     pub(crate) what: Box<str>,
@@ -17,7 +17,7 @@ impl Display for Exception {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "std")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for Exception {}
 
 impl Exception {

--- a/src/extern_type.rs
+++ b/src/extern_type.rs
@@ -217,7 +217,7 @@ impl_extern_type! {
     f64 = "double"
 
     #[cfg(feature = "alloc")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     String = "rust::String"
 
     [Opaque]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,7 +365,7 @@
 
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/cxx/1.0.122")]
-#![cfg_attr(doc_cfg, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(
     improper_ctypes,
     improper_ctypes_definitions,
@@ -477,7 +477,7 @@ mod weak_ptr;
 
 pub use crate::cxx_vector::CxxVector;
 #[cfg(feature = "alloc")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "alloc")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub use crate::exception::Exception;
 pub use crate::extern_type::{kind, ExternType};
 pub use crate::shared_ptr::SharedPtr;


### PR DESCRIPTION
As of recently, docs.rs defines a `docsrs` configuration for all builds, so we no longer need to do it using our own `package.metadata.docs.rs.rustdoc-args`.