### PR TITLE
Give char the if_unique treatment too to handle possible collisions with [u]int8_t definitions.

### DIFF
--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -532,6 +532,11 @@ using isize_if_unique =
     typename std::conditional<std::is_same<rust::isize, int64_t>::value ||
                                   std::is_same<rust::isize, int32_t>::value,
                               struct isize_ignore, rust::isize>::type;
+// Similarly, on some platforms char may just be an alias for [u]int8_t
+using char_if_unique =
+    typename std::conditional<std::is_same<char, uint8_t>::value ||
+                                  std::is_same<char, int8_t>::value,
+                              struct char_ignore, char>::type;
 
 class Fail final {
   repr::PtrLen &throw$;
@@ -770,7 +775,7 @@ static_assert(sizeof(std::string) <= kMaxExpectedWordsInString * sizeof(void *),
 #define FOR_EACH_RUST_VEC(MACRO)                                               \
   FOR_EACH_NUMERIC(MACRO)                                                      \
   MACRO(bool, bool)                                                            \
-  MACRO(char, char)                                                            \
+  MACRO(char, rust::detail::char_if_unique)                                    \
   MACRO(usize, rust::detail::usize_if_unique)                                  \
   MACRO(isize, rust::detail::isize_if_unique)                                  \
   MACRO(string, rust::String)                                                  \


### PR DESCRIPTION
On illumos at least you have `std::is_same<char, int8_t> = true` which means a whole bunch of duplicate definition errors.