### PR TITLE
Ergonomics: allow constructing `rust::Slice` from any C++ container.

### DIFF
--- a/include/cxx.h
+++ b/include/cxx.h
@@ -176,6 +176,9 @@ public:
   Slice() noexcept;
   Slice(T *, std::size_t count) noexcept;
 
+  template <typename C>
+  explicit Slice(C& c) : Slice(c.data(), c.size()) {}
+
   Slice &operator=(const Slice<T> &) &noexcept = default;
   Slice &operator=(Slice<T> &&) &noexcept = default;
 

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -884,6 +884,12 @@ extern "C" const char *cxx_run_test() noexcept {
   rust::String bad_utf16_rstring = rust::String::lossy(bad_utf16_literal);
   ASSERT(bad_utf8_rstring == bad_utf16_rstring);
 
+  std::vector<int> cpp_vec{1, 2, 3};
+  rust::Slice<int> slice_of_cpp_vec(cpp_vec);
+  ASSERT(slice_of_cpp_vec.data() == cpp_vec.data());
+  ASSERT(slice_of_cpp_vec.size() == cpp_vec.size());
+  ASSERT(slice_of_cpp_vec[0] == 1);
+
   rust::Vec<int> vec1{1, 2};
   rust::Vec<int> vec2{3, 4};
   swap(vec1, vec2);


### PR DESCRIPTION
After this commit, it is possible to explicitly construct `rust::Slice` from a reference to any continguous C++ container (any container that exposes `data` and `size` accessors).

The new constructor results in a slightly more ergonomic code, by removing the need to explicit extract and pass `c.data()` and `c.size()` at a callsite of a `rust::Slice` constructor.  The callsites using the new constructor are also more obviously correct, because they doesn't require double-checking that the passed `data` and `size` match.

The implementation of the new constructor mimics `std::span` from C++20, but for C++11 compatibility reimplements `std::size` / `std::ranges::size` in a pedestrian way (same for `std::data` / `std::ranges::data`).