### PR TITLE
`impl<T> Read for UniquePtr<T> where ... Pin<&a mut T> : Read`.

### DIFF
--- a/src/unique_ptr.rs
+++ b/src/unique_ptr.rs
@@ -10,6 +10,9 @@ use core::mem::{self, MaybeUninit};
 use core::ops::{Deref, DerefMut};
 use core::pin::Pin;
 
+#[cfg(feature = "std")]
+use std::io::Read;
+
 /// Binding to C++ `std::unique_ptr<T, std::default_delete<T>>`.
 #[repr(C)]
 pub struct UniquePtr<T>
@@ -179,6 +182,38 @@ where
             Some(value) => Display::fmt(value, formatter),
         }
     }
+}
+
+/// Forwarding `Read` trait implementation in a manner similar to `Box<T>`.  Note that the
+/// implementation will panic for null `UniquePtr<T>`.
+#[cfg(feature = "std")]
+impl<T> Read for UniquePtr<T>
+where
+    for<'a> Pin<&'a mut T>: Read,
+    T: UniquePtrTarget,
+{
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.pin_mut().read(buf)
+    }
+
+    #[inline]
+    fn read_to_end(&mut self, buf: &mut std::vec::Vec<u8>) -> std::io::Result<usize> {
+        self.pin_mut().read_to_end(buf)
+    }
+
+    #[inline]
+    fn read_to_string(&mut self, buf: &mut std::string::String) -> std::io::Result<usize> {
+        self.pin_mut().read_to_string(buf)
+    }
+
+    #[inline]
+    fn read_exact(&mut self, buf: &mut [u8]) -> std::io::Result<()> {
+        self.pin_mut().read_exact(buf)
+    }
+
+    // TODO: Foward other `Read` trait methods when they get stabilized (e.g.
+    // `read_buf` and/or `is_read_vectored`).
 }
 
 /// Trait bound for types which may be used as the `T` inside of a


### PR DESCRIPTION
This commit implements forwarding of `Read` trait implementation from `UniquePtr<T>` to the pointee type.  This is quite similar to how `Box<T>` also forwards - see
https://doc.rust-lang.org/std/boxed/struct.Box.html#impl-Read-for-Box%3CR%3E

Just as with `Box<T>`, the `impl` cannot be provided in the crate introducing `T`, because this violates the orphan rule.  This means that before this commit a wrapper newtype would be required to work around the orphan rule - e.g.:

    ```
    struct UniquePtrOfReadTrait(cxx::UniquePtr<ffi::ReadTrait>);
    impl Read for UniquePtrOfReadTrait { … }
    ```

After this commit, one can provide an `impl` that works more directly with the C++ type `T` (the FFI will typically require passing `self: Pin<&mut ffi::ReadTrait>`):

    ```
    impl<'a> Read for Pin<&'a mut ffi::ReadTrait> { … }
    ```

For a more specific motivating example, please see: https://docs.google.com/document/d/1EPn1Ss-hfOC6Ki_B5CC6GA_UFnY3TmoDLCP2HjP7bms