### PR TITLE
Drop "readonly" LLVM attribute from references to opaque C++ types

### DIFF
--- a/src/opaque.rs
+++ b/src/opaque.rs
@@ -1,6 +1,7 @@
 #![allow(missing_docs)]
 
 use crate::void;
+use core::cell::UnsafeCell;
 use core::marker::{PhantomData, PhantomPinned};
 use core::mem;
 
@@ -14,6 +15,7 @@ use core::mem;
 pub struct Opaque {
     _private: [*const void; 0],
     _pinned: PhantomData<PhantomPinned>,
+    _mutable: UnsafeCell<()>,
 }
 
 const_assert_eq!(0, mem::size_of::<Opaque>());

--- a/src/opaque.rs
+++ b/src/opaque.rs
@@ -15,7 +15,7 @@ use core::mem;
 pub struct Opaque {
     _private: [*const void; 0],
     _pinned: PhantomData<PhantomPinned>,
-    _mutable: SyncUnsafeCell<()>,
+    _mutable: SyncUnsafeCell<PhantomData<()>>,
 }
 
 // TODO: https://github.com/rust-lang/rust/issues/95439

--- a/src/opaque.rs
+++ b/src/opaque.rs
@@ -15,8 +15,14 @@ use core::mem;
 pub struct Opaque {
     _private: [*const void; 0],
     _pinned: PhantomData<PhantomPinned>,
-    _mutable: UnsafeCell<()>,
+    _mutable: SyncUnsafeCell<()>,
 }
+
+// TODO: https://github.com/rust-lang/rust/issues/95439
+#[repr(transparent)]
+struct SyncUnsafeCell<T>(UnsafeCell<T>);
+
+unsafe impl<T> Sync for SyncUnsafeCell<T> {}
 
 const_assert_eq!(0, mem::size_of::<Opaque>());
 const_assert_eq!(1, mem::align_of::<Opaque>());

--- a/tests/ui/opaque_autotraits.stderr
+++ b/tests/ui/opaque_autotraits.stderr
@@ -22,6 +22,29 @@ note: required by a bound in `assert_send`
 8  | fn assert_send<T: Send>() {}
    |                   ^^^^ required by this bound in `assert_send`
 
+error[E0277]: `UnsafeCell<()>` cannot be shared between threads safely
+  --> tests/ui/opaque_autotraits.rs:14:19
+   |
+14 |     assert_sync::<ffi::Opaque>();
+   |                   ^^^^^^^^^^^ `UnsafeCell<()>` cannot be shared between threads safely
+   |
+   = help: within `ffi::Opaque`, the trait `Sync` is not implemented for `UnsafeCell<()>`, which is required by `ffi::Opaque: Sync`
+note: required because it appears within the type `cxx::private::Opaque`
+  --> src/opaque.rs
+   |
+   | pub struct Opaque {
+   |            ^^^^^^
+note: required because it appears within the type `ffi::Opaque`
+  --> tests/ui/opaque_autotraits.rs:4:14
+   |
+4  |         type Opaque;
+   |              ^^^^^^
+note: required by a bound in `assert_sync`
+  --> tests/ui/opaque_autotraits.rs:9:19
+   |
+9  | fn assert_sync<T: Sync>() {}
+   |                   ^^^^ required by this bound in `assert_sync`
+
 error[E0277]: `*const cxx::void` cannot be shared between threads safely
   --> tests/ui/opaque_autotraits.rs:14:19
    |

--- a/tests/ui/opaque_autotraits.stderr
+++ b/tests/ui/opaque_autotraits.stderr
@@ -22,29 +22,6 @@ note: required by a bound in `assert_send`
 8  | fn assert_send<T: Send>() {}
    |                   ^^^^ required by this bound in `assert_send`
 
-error[E0277]: `UnsafeCell<()>` cannot be shared between threads safely
-  --> tests/ui/opaque_autotraits.rs:14:19
-   |
-14 |     assert_sync::<ffi::Opaque>();
-   |                   ^^^^^^^^^^^ `UnsafeCell<()>` cannot be shared between threads safely
-   |
-   = help: within `ffi::Opaque`, the trait `Sync` is not implemented for `UnsafeCell<()>`, which is required by `ffi::Opaque: Sync`
-note: required because it appears within the type `cxx::private::Opaque`
-  --> src/opaque.rs
-   |
-   | pub struct Opaque {
-   |            ^^^^^^
-note: required because it appears within the type `ffi::Opaque`
-  --> tests/ui/opaque_autotraits.rs:4:14
-   |
-4  |         type Opaque;
-   |              ^^^^^^
-note: required by a bound in `assert_sync`
-  --> tests/ui/opaque_autotraits.rs:9:19
-   |
-9  | fn assert_sync<T: Sync>() {}
-   |                   ^^^^ required by this bound in `assert_sync`
-
 error[E0277]: `*const cxx::void` cannot be shared between threads safely
   --> tests/ui/opaque_autotraits.rs:14:19
    |


### PR DESCRIPTION
@capickett noticed that passing a cxx-generated opaque C++ type by reference gets annotated with an unwanted, incorrect `readonly` attribute. We have observed miscompiles that arise from this in real-world code when using cross-language ThinLTO.

According to https://llvm.org/docs/LangRef.html:

> **readonly**
>
> This attribute indicates that the function does not write through this pointer argument, even though it may write to the memory that the pointer points to.
>
> If a function writes to a readonly pointer argument, the behavior is undefined.

For the following repro:

```rust
#[no_mangle]
pub fn repro(opaque: &cxx::private::Opaque) {
    extern "C" {
        fn do_repro(opaque: *const cxx::private::Opaque);
    }
    unsafe { do_repro(opaque) }
}
```

this is the LLVM IR generated before this PR:

```llvm
; Function Attrs: nounwind nonlazybind uwtable
define void @repro(ptr noalias noundef nonnull readonly align 1 %opaque) unnamed_addr #0 {
start:
  tail call void @do_repro(ptr noundef nonnull %opaque) #1
  ret void
}
```

and after:

```llvm
; Function Attrs: nounwind nonlazybind uwtable
define void @repro(ptr noundef nonnull align 1 %opaque) unnamed_addr #0 {
start:
  tail call void @do_repro(ptr noundef nonnull %opaque) #1
  ret void
}
```

```diff
< define void @repro(ptr noalias noundef nonnull readonly align 1 %opaque) unnamed_addr #0 {
---
> define void @repro(ptr noundef nonnull align 1 %opaque) unnamed_addr #0 {
```