### PR TITLE
Resolve std_instead_of_alloc clippy restriction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
     timeout-minutes: 45
+    env:
+      RUSTFLAGS: -Dwarnings
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly

--- a/src/unique_ptr.rs
+++ b/src/unique_ptr.rs
@@ -3,6 +3,10 @@ use crate::fmt::display;
 use crate::kind::Trivial;
 use crate::string::CxxString;
 use crate::ExternType;
+#[cfg(feature = "std")]
+use alloc::string::String;
+#[cfg(feature = "std")]
+use alloc::vec::Vec;
 use core::ffi::c_void;
 use core::fmt::{self, Debug, Display};
 use core::marker::PhantomData;
@@ -198,12 +202,12 @@ where
     }
 
     #[inline]
-    fn read_to_end(&mut self, buf: &mut alloc::vec::Vec<u8>) -> io::Result<usize> {
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
         self.pin_mut().read_to_end(buf)
     }
 
     #[inline]
-    fn read_to_string(&mut self, buf: &mut alloc::string::String) -> io::Result<usize> {
+    fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
         self.pin_mut().read_to_string(buf)
     }
 

--- a/src/unique_ptr.rs
+++ b/src/unique_ptr.rs
@@ -198,12 +198,12 @@ where
     }
 
     #[inline]
-    fn read_to_end(&mut self, buf: &mut std::vec::Vec<u8>) -> io::Result<usize> {
+    fn read_to_end(&mut self, buf: &mut alloc::vec::Vec<u8>) -> io::Result<usize> {
         self.pin_mut().read_to_end(buf)
     }
 
     #[inline]
-    fn read_to_string(&mut self, buf: &mut std::string::String) -> io::Result<usize> {
+    fn read_to_string(&mut self, buf: &mut alloc::string::String) -> io::Result<usize> {
         self.pin_mut().read_to_string(buf)
     }
 


### PR DESCRIPTION
```console
warning: used import from `std` instead of `alloc`
   --> src/unique_ptr.rs:201:41
    |
201 |     fn read_to_end(&mut self, buf: &mut std::vec::Vec<u8>) -> io::Result<usize> {
    |                                         ^^^ help: consider importing the item from `alloc`: `alloc`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#std_instead_of_alloc
note: the lint level is defined here
   --> src/lib.rs:377:5
    |
377 |     clippy::std_instead_of_alloc,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: used import from `std` instead of `alloc`
   --> src/unique_ptr.rs:206:44
    |
206 |     fn read_to_string(&mut self, buf: &mut std::string::String) -> io::Result<usize> {
    |                                            ^^^ help: consider importing the item from `alloc`: `alloc`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#std_instead_of_alloc
```