### PR TITLE
Add `_Enum!` macros to replace `_` arms when matching shared enums

### DIFF
--- a/book/src/shared.md
+++ b/book/src/shared.md
@@ -78,14 +78,19 @@ impl Suit {
     pub const Hearts: Self = Suit { repr: 2 };
     pub const Spades: Self = Suit { repr: 3 };
 }
+macro_rules! _Suit {
+    () => { Suit{ repr: 4.. } };
+    ($i:ident) => { Suit { repr: $i @ 4.. } };
+}
 ```
 
 Notice you're free to treat the enum as an integer in Rust code via the public
 `repr` field.
 
-Pattern matching with `match` still works but will require you to write wildcard
-arms to handle the situation of an enum value that is not one of the listed
-variants.
+Pattern matching with `match` still works but will require you to write a
+fallback arm to handle the situation of an enum value that is not one of the
+listed variants. A convenience `_Enum!` macro is generated to statically ensure
+that all listed variants are covered:
 
 ```rust,noplayground
 fn main() {
@@ -95,7 +100,7 @@ fn main() {
         Suit::Diamonds => ...,
         Suit::Hearts => ...,
         Suit::Spades => ...,
-        _ => ...,  // fallback arm
+        _Suit!(unlisted) => ...,  // fallback arm
     }
 }
 ```

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -80,23 +80,33 @@ fn test_c_return() {
     assert_eq!(2021, ffi::c_return_sum(2020, 1));
     match ffi::c_return_enum(0) {
         enm @ ffi::Enum::AVal => assert_eq!(0, enm.repr),
-        _ => assert!(false),
+        ffi::Enum::BVal => assert!(false),
+        ffi::Enum::LastVal => assert!(false),
+        cxx_test_suite::_Enum!() => assert!(false),
     }
     match ffi::c_return_enum(1) {
+        ffi::Enum::AVal => assert!(false),
         enm @ ffi::Enum::BVal => assert_eq!(2020, enm.repr),
-        _ => assert!(false),
+        ffi::Enum::LastVal => assert!(false),
+        cxx_test_suite::_Enum!() => assert!(false),
     }
     match ffi::c_return_enum(2021) {
+        ffi::Enum::AVal => assert!(false),
+        ffi::Enum::BVal => assert!(false),
         enm @ ffi::Enum::LastVal => assert_eq!(2021, enm.repr),
-        _ => assert!(false),
+        cxx_test_suite::_Enum!() => assert!(false),
     }
     match ffi::c_return_ns_enum(0) {
         enm @ ffi::AEnum::AAVal => assert_eq!(0, enm.repr),
-        _ => assert!(false),
+        ffi::AEnum::ABVal => assert!(false),
+        ffi::AEnum::ACVal => assert!(false),
+        cxx_test_suite::_AEnum!() => assert!(false),
     }
     match ffi::c_return_nested_ns_enum(0) {
         enm @ ffi::ABEnum::ABAVal => assert_eq!(0, enm.repr),
-        _ => assert!(false),
+        ffi::ABEnum::ABBVal => assert!(false),
+        ffi::ABEnum::ABCVal => assert!(false),
+        cxx_test_suite::_ABEnum!() => assert!(false),
     }
 }
 


### PR DESCRIPTION
As the docs currently state about shared enums:
> Pattern matching with match still works but will require you to write wildcard arms to handle the situation of an enum value that is not one of the listed variants.

This is unfortunate as there is no way to check that all listed enum variants are actually handled. IOW this code does not even warn:
```
mod ffi {
    enum Enum {
        A,
        B,
        C = 5,
    }
}

match t {
    Enum::A => {},
    Enum::B => {},
    _ => {},
}
```

This generates an extra `_Enum!` macro that matches all the ranges that are _not_ listed by the enum. When using that macro instead of the `_` catch-all, we get compile-time errors if we forget to match variants:
```
match t {
    Enum::A => {},
    Enum::B => {},
    _Enum!() => {},
}
// Error Enum{ repr: 5 } case not covered
```

The generated macro looks like:
```
macro_rules! _Enum {
    () => { Enum{ repr: 4..5 | 6.. } };
    ($i:ident) => { Enum { repr: $i @ 4..5 | 6.. } };
}
```

It can also be used to ergonomically retrieve the inner value in the unlisted case:
```
match t {
    Enum::A => {},
    Enum::B => {},
    Enum::C => {},
    _Enum!(value) => panic!("Unexpected Enum value {value}"),
}
```

I would have preferred something like `Enum::unlisted!`, but macro definitions are not supported in `impl`s. I think `_Enum` carries the meaning of `_` specific  to `Enum`, but I'm open to other naming/namespacing ideas.