### PR TITLE
Work around outdated lockfile parser used by rules_rust

### DIFF
--- a/third-party/Cargo.toml
+++ b/third-party/Cargo.toml
@@ -4,6 +4,7 @@ name = "third-party"
 version = "0.0.0"
 edition = "2021"
 publish = false
+rust-version = "1.77"
 
 [dependencies]
 cc = "1.0.83"


### PR DESCRIPTION
Without this, `cargo update` generates a v4 lockfile by default, which is not supported by the `cargo-lock` crate that is used by `cargo-bazel`. It looks like v4 support has been implemented in https://github.com/rustsec/rustsec/pull/1206 but not released to crates.io.

For now, this workaround avoids the following error.

```console
$ bazel run //third-party:vendor
INFO: Analyzed target //third-party:vendor (363 packages loaded, 10315 targets configured).
INFO: Found 1 target...
Target //third-party:vendor up-to-date:
  bazel-bin/third-party/vendor.sh
INFO: Elapsed time: 8.623s, Critical Path: 2.66s
INFO: 60 processes: 31 internal, 29 linux-sandbox.
INFO: Build completed successfully, 60 total actions
INFO: Running command line: bazel-bin/third-party/vendor.sh
Error: Failed to load lockfile: /tmp/.tmpRMDd3w/Cargo.lock

Caused by:
    parse error: parse error: invalid Cargo.lock format version: `4`
```