### PR TITLE
Meson experiment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,21 @@ jobs:
         run: git diff --exit-code
         if: matrix.os == 'ubuntu' || matrix.os == 'macos'
 
+  meson:
+    name: Meson
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: mesonbuild/meson
+          path: meson
+      - run: sudo apt-get install ninja-build
+      - run: meson/meson.py setup build
+      - run: meson/meson.py compile -C build
+
   minimal:
     name: Minimal versions
     needs: pre_ci

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,27 @@
+project(
+  'cxx',
+  default_options : ['rust_std=2021'],
+  license : 'MIT OR Apache-2.0',
+  license_files : ['LICENSE-APACHE', 'LICENSE-MIT'],
+  meson_version : '>= 1.3.0',
+)
+
+add_languages('rust', native : true)
+add_languages('rust', 'cpp', native : false)
+
+rust = import('rust')
+
+unicode_ident = subproject('unicode-ident-1-rs')
+proc_macro2 = subproject('proc-macro2-1-rs')
+quote = subproject('quote-1-rs')
+syn = subproject('syn-2-rs')
+
+rust.proc_macro(
+  'cxxbridge_macro',
+  sources : 'macro/src/lib.rs',
+  dependencies : [
+    proc_macro2.get_variable('dep'),
+    quote.get_variable('dep'),
+    syn.get_variable('dep'),
+  ],
+)

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,0 +1,4 @@
+/*
+!/.gitignore
+!/packagefiles/
+!/*.wrap

--- a/subprojects/packagefiles/proc-macro2.patch
+++ b/subprojects/packagefiles/proc-macro2.patch
@@ -1,0 +1,10 @@
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -19,7 +19,6 @@
+     "Alex Crichton <alex@alexcrichton.com>",
+ ]
+ build = "build.rs"
+-autolib = false
+ autobins = false
+ autoexamples = false
+ autotests = false

--- a/subprojects/packagefiles/syn.patch
+++ b/subprojects/packagefiles/syn.patch
@@ -1,0 +1,10 @@
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -25,7 +25,6 @@
+     "/src/**",
+     "/tests/**",
+ ]
+-autolib = false
+ autobins = false
+ autoexamples = false
+ autotests = false

--- a/subprojects/proc-macro2-1-rs.wrap
+++ b/subprojects/proc-macro2-1-rs.wrap
@@ -1,0 +1,8 @@
+[wrap-file]
+directory = proc-macro2-1.0.89
+source_url = https://static.crates.io/crates/proc-macro2/1.0.89/download
+source_filename = unicode-ident-1.0.89.tar.gz
+source_hash = f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e
+method = cargo
+# https://github.com/mesonbuild/meson/issues/13826
+diff_files = proc-macro2.patch

--- a/subprojects/quote-1-rs.wrap
+++ b/subprojects/quote-1-rs.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = quote-1.0.37
+source_url = https://static.crates.io/crates/quote/1.0.37/download
+source_filename = quote-1.0.37.tar.gz
+source_hash = b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af
+method = cargo

--- a/subprojects/syn-2-rs.wrap
+++ b/subprojects/syn-2-rs.wrap
@@ -1,0 +1,8 @@
+[wrap-file]
+directory = syn-2.0.85
+source_url = https://static.crates.io/crates/syn/2.0.85/download
+source_filename = syn-2.0.85.tar.gz
+source_hash = 5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56
+method = cargo
+# https://github.com/mesonbuild/meson/issues/13826
+diff_files = syn.patch

--- a/subprojects/unicode-ident-1-rs.wrap
+++ b/subprojects/unicode-ident-1-rs.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = unicode-ident-1.0.13
+source_url = https://static.crates.io/crates/unicode-ident/1.0.13/download
+source_filename = unicode-ident-1.0.13.tar.gz
+source_hash = e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe
+method = cargo


### PR DESCRIPTION
Did not get very far. Obstacles:

- Meson's crates.io dependency support is not compatible with packages published by 1.83-beta or newer versions of Cargo. https://github.com/mesonbuild/meson/issues/13826. This is easy to work around by patching the published Cargo.toml files.

- I did not find any way to enable non-default features on a wrap-file crates.io subproject, other than handwriting the entire meson.build for it. We would need this for syn's "full" features.

- Subprojects are always only compiled for the "host machine". For dependencies of a procedural macro, such as cxxbridge-macro's dependency on syn, we need them compiled for the "build machine" which is not supported. There is recent progress on this in https://github.com/mesonbuild/meson/pull/12994.