### PR TITLE
Raise required compiler to Rust 1.70

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable, 1.67.0, 1.70.0, 1.74.0]
+        rust: [nightly, beta, stable, 1.70.0, 1.74.0]
         os: [ubuntu]
         include:
           - name: Cargo on macOS
@@ -60,7 +60,6 @@ jobs:
         shell: bash
       - run: cargo run --manifest-path demo/Cargo.toml
       - run: cargo test --workspace ${{steps.testsuite.outputs.exclude}}
-        if: matrix.rust != '1.67.0'
       - run: cargo check --no-default-features --features alloc
         env:
           RUSTFLAGS: --cfg compile_error_if_std ${{env.RUSTFLAGS}}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["ffi", "c++"]
 license = "MIT OR Apache-2.0"
 links = "cxxbridge1"
 repository = "https://github.com/dtolnay/cxx"
-rust-version = "1.67"
+rust-version = "1.70"
 
 [features]
 default = ["std", "cxxbridge-flags/default"] # c++11

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ cxx = "1.0"
 cxx-build = "1.0"
 ```
 
-*Compiler support: requires rustc 1.67+ and c++11 or newer*<br>
+*Compiler support: requires rustc 1.70+ and c++11 or newer*<br>
 *[Release notes](https://github.com/dtolnay/cxx/releases)*
 
 <br>

--- a/build.rs
+++ b/build.rs
@@ -36,8 +36,8 @@ fn main() {
             println!("cargo:rustc-check-cfg=cfg(skip_ui_tests)");
         }
 
-        if rustc.minor < 67 {
-            println!("cargo:warning=The cxx crate requires a rustc version 1.67.0 or newer.");
+        if rustc.minor < 70 {
+            println!("cargo:warning=The cxx crate requires a rustc version 1.70.0 or newer.");
             println!(
                 "cargo:warning=You appear to be building with: {}",
                 rustc.version,

--- a/flags/Cargo.toml
+++ b/flags/Cargo.toml
@@ -7,7 +7,7 @@ description = "Compiler configuration of the `cxx` crate (implementation detail)
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/cxx"
-rust-version = "1.67"
+rust-version = "1.70"
 
 [features]
 default = [] # c++11

--- a/gen/build/Cargo.toml
+++ b/gen/build/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://cxx.rs"
 keywords = ["ffi", "build-dependencies"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/cxx"
-rust-version = "1.67"
+rust-version = "1.70"
 
 [features]
 parallel = ["cc/parallel"]

--- a/gen/lib/Cargo.toml
+++ b/gen/lib/Cargo.toml
@@ -10,7 +10,7 @@ exclude = ["build.rs"]
 keywords = ["ffi"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/cxx"
-rust-version = "1.67"
+rust-version = "1.70"
 
 [dependencies]
 codespan-reporting = "0.11.1"

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cxx.rs"
 keywords = ["ffi"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/cxx"
-rust-version = "1.67"
+rust-version = "1.70"
 
 [lib]
 proc-macro = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! <br>
 //!
-//! *Compiler support: requires rustc 1.67+ and c++11 or newer*<br>
+//! *Compiler support: requires rustc 1.70+ and c++11 or newer*<br>
 //! *[Release notes](https://github.com/dtolnay/cxx/releases)*
 //!
 //! <br>


### PR DESCRIPTION
Required for dropping a once_cell dependency in favor of standard library `std::sync::OnceLock` and `std::sync::LazyLock` in an upcoming PR.