### PR TITLE
Meson, with handwritten meson.build for deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,23 @@ jobs:
         run: git diff --exit-code
         if: matrix.os == 'ubuntu' || matrix.os == 'macos'
 
+  meson:
+    name: Meson
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: mesonbuild/meson
+          path: meson
+      - run: sudo apt-get install lld ninja-build
+      - run: meson/meson.py setup --native-file=tools/meson/native.ini build
+      - run: meson/meson.py compile -C build
+      - run: build/demo/demo
+      - run: meson/meson.py test -C build
+
   minimal:
     name: Minimal versions
     needs: pre_ci

--- a/demo/meson.build
+++ b/demo/meson.build
@@ -1,0 +1,23 @@
+demo_bridge = static_library(
+    'demo_bridge',
+    implicit_include_directories: false,
+    include_directories: project_root,
+    sources: cxxbridge_generator.process(
+        files('src/main.rs'),
+        preserve_path_from: meson.project_source_root(),
+    ),
+)
+
+demo_blobstore = static_library(
+    'demo_blobstore',
+    implicit_include_directories: false,
+    include_directories: [demo_bridge.private_dir_include(), project_root],
+    link_with: demo_bridge,
+    sources: [files('src/blobstore.cc'), cxx_header],
+)
+
+executable(
+    'demo',
+    link_with: [demo_blobstore, cxx_library],
+    sources: files('src/main.rs'),
+)

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,73 @@
+project(
+    'cxx',
+    default_options: ['rust_std=2021'],
+    license: 'MIT OR Apache-2.0',
+    license_files: ['LICENSE-APACHE', 'LICENSE-MIT'],
+    meson_version: '>= 1.3.0',
+)
+
+add_languages('rust', native: true)
+add_languages('rust', 'cpp', native: false)
+
+subdir('tools/meson')
+subdir('third-party')
+
+rust = import('rust')
+
+project_root = include_directories('.')
+
+cxx_core = static_library(
+    'cxx_core',
+    implicit_include_directories: false,
+    sources: files('src/cxx.cc'),
+)
+
+cxxbridge_macro = rust.proc_macro(
+    'cxxbridge_macro',
+    dependencies: [
+        third_party['proc-macro2'],
+        third_party['quote'],
+        third_party['syn'],
+    ],
+    sources: files('macro/src/lib.rs'),
+)
+
+cxx_library = static_library(
+    'cxx',
+    link_with: [cxx_core, cxxbridge_macro],
+    rust_args: [
+        '--cfg=feature="alloc"',
+        '--cfg=feature="default"',
+        '--cfg=feature="std"',
+    ],
+    sources: files('src/lib.rs'),
+)
+
+cxxbridge_cmd = executable(
+    'cxxbridge',
+    dependencies: [
+        third_party['clap'],
+        third_party['codespan-reporting'],
+        third_party['proc-macro2'],
+        third_party['quote'],
+        third_party['syn'],
+    ],
+    native: true,
+    sources: files('gen/cmd/src/main.rs'),
+)
+
+cxxbridge_generator = generator(
+    cxxbridge_cmd,
+    arguments: ['@INPUT@', '-o', '@OUTPUT0@', '-o', '@OUTPUT1@'],
+    output: ['@PLAINNAME@.h', '@PLAINNAME@.cc'],
+)
+
+cxx_header = custom_target(
+    'cxx_header',
+    command: ['bash', '-c', 'mkdir -p rust; cp @INPUT@ rust'],
+    input: files('include/cxx.h'),
+    output: 'rust',
+)
+
+subdir('demo')
+subdir('tests')

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,0 +1,4 @@
+/*
+!/.gitignore
+!/packagefiles/
+!/*.wrap

--- a/subprojects/anstyle.wrap
+++ b/subprojects/anstyle.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = anstyle-1.0.9
+source_url = https://static.crates.io/crates/anstyle/1.0.9/download
+source_filename = anstyle-1.0.9.tar.gz
+source_hash = 8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56
+patch_directory = anstyle

--- a/subprojects/clap.wrap
+++ b/subprojects/clap.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = clap-4.5.20
+source_url = https://static.crates.io/crates/clap/4.5.20/download
+source_filename = clap-4.5.20.tar.gz
+source_hash = b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8
+patch_directory = clap

--- a/subprojects/clap_builder.wrap
+++ b/subprojects/clap_builder.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = clap_builder-4.5.20
+source_url = https://static.crates.io/crates/clap_builder/4.5.20/download
+source_filename = clap_builder-4.5.20.tar.gz
+source_hash = 19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54
+patch_directory = clap_builder

--- a/subprojects/clap_lex.wrap
+++ b/subprojects/clap_lex.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = clap_lex-0.7.2
+source_url = https://static.crates.io/crates/clap_lex/0.7.2/download
+source_filename = clap_lex-0.7.2.tar.gz
+source_hash = 1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97
+patch_directory = clap_lex

--- a/subprojects/codespan-reporting.wrap
+++ b/subprojects/codespan-reporting.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = codespan-reporting-0.11.1
+source_url = https://static.crates.io/crates/codespan-reporting/0.11.1/download
+source_filename = codespan-reporting-0.11.1.tar.gz
+source_hash = 3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e
+patch_directory = codespan-reporting

--- a/subprojects/packagefiles/anstyle/meson.build
+++ b/subprojects/packagefiles/anstyle/meson.build
@@ -1,0 +1,17 @@
+project(
+    'anstyle',
+    'rust',
+    default_options: ['rust_std=2021'],
+    license: 'MIT OR Apache-2.0',
+    version: '1.0.9',
+)
+
+lib = static_library(
+    'anstyle',
+    native: true,
+    rust_args: ['--cfg=feature="default"', '--cfg=feature="std"'],
+    sources: files('src/lib.rs'),
+)
+
+dep = declare_dependency(link_with: lib)
+meson.override_dependency('anstyle', dep)

--- a/subprojects/packagefiles/clap/meson.build
+++ b/subprojects/packagefiles/clap/meson.build
@@ -1,0 +1,23 @@
+project(
+    'clap',
+    'rust',
+    default_options: ['rust_std=2021'],
+    license: 'MIT OR Apache-2.0',
+    version: '4.5.20',
+)
+
+lib = static_library(
+    'clap',
+    dependencies: [dependency('clap_builder', version: ['= 4.5.20'])],
+    native: true,
+    rust_args: [
+        '--cfg=feature="error-context"',
+        '--cfg=feature="help"',
+        '--cfg=feature="std"',
+        '--cfg=feature="usage"',
+    ],
+    sources: files('src/lib.rs'),
+)
+
+dep = declare_dependency(link_with: lib)
+meson.override_dependency('clap', dep)

--- a/subprojects/packagefiles/clap_builder/meson.build
+++ b/subprojects/packagefiles/clap_builder/meson.build
@@ -1,0 +1,26 @@
+project(
+    'clap_builder',
+    'rust',
+    default_options: ['rust_std=2021'],
+    license: 'MIT OR Apache-2.0',
+    version: '4.5.20',
+)
+
+lib = static_library(
+    'clap_builder',
+    dependencies: [
+        dependency('anstyle', version: ['>= 1.0.8', '< 2']),
+        dependency('clap_lex', version: ['>= 0.7.0', '< 0.8']),
+    ],
+    native: true,
+    rust_args: [
+        '--cfg=feature="error-context"',
+        '--cfg=feature="help"',
+        '--cfg=feature="std"',
+        '--cfg=feature="usage"',
+    ],
+    sources: files('src/lib.rs'),
+)
+
+dep = declare_dependency(link_with: lib)
+meson.override_dependency('clap_builder', dep)

--- a/subprojects/packagefiles/clap_lex/meson.build
+++ b/subprojects/packagefiles/clap_lex/meson.build
@@ -1,0 +1,12 @@
+project(
+    'clap_lex',
+    'rust',
+    default_options: ['rust_std=2021'],
+    license: 'MIT OR Apache-2.0',
+    version: '0.7.2',
+)
+
+lib = static_library('clap_lex', native: true, sources: files('src/lib.rs'))
+
+dep = declare_dependency(link_with: lib)
+meson.override_dependency('clap_lex', dep)

--- a/subprojects/packagefiles/codespan-reporting/meson.build
+++ b/subprojects/packagefiles/codespan-reporting/meson.build
@@ -1,0 +1,20 @@
+project(
+    'codespan-reporting',
+    'rust',
+    default_options: ['rust_std=2018'],
+    license: 'Apache-2.0',
+    version: '0.11.1',
+)
+
+lib = static_library(
+    'codespan_reporting',
+    dependencies: [
+        dependency('termcolor', version: ['>= 1', '< 2']),
+        dependency('unicode-width', version: ['>= 0.1', '< 0.2']),
+    ],
+    native: true,
+    sources: files('src/lib.rs'),
+)
+
+dep = declare_dependency(link_with: lib)
+meson.override_dependency('codespan-reporting', dep)

--- a/subprojects/packagefiles/proc-macro2/meson.build
+++ b/subprojects/packagefiles/proc-macro2/meson.build
@@ -1,0 +1,56 @@
+project(
+    'proc-macro2',
+    'rust',
+    default_options: ['rust_std=2021'],
+    license: 'MIT OR Apache-2.0',
+    version: '1.0.89',
+)
+
+build = executable(
+    'build_script',
+    native: true,
+    rust_args: [
+        '--cfg=feature="default"',
+        '--cfg=feature="proc-macro"',
+        '--cfg=feature="span-locations"',
+    ],
+    sources: files('build.rs'),
+)
+
+rustc_args = custom_target(
+    command: [
+        find_program('python3'),
+        '@SOURCE_ROOT@/tools/meson/buildscript_run.py',
+        '--buildscript',
+        build,
+        '--manifest-dir',
+        '@CURRENT_SOURCE_DIR@',
+        '--rustc-wrapper',
+        '@BUILD_ROOT@/tools/meson/rustc_wrapper.sh',
+        '--out-dir',
+        '@PRIVATE_DIR@',
+        '--rustc-args',
+        '@OUTPUT@',
+    ],
+    # Hack: any extension other than .rs causes a failure "ERROR: Rust target
+    # proc_macro2 contains a non-rust source file" below, and forces the use of
+    # `structured_sources` which would mean listing out every source file in the
+    # crate, instead of just the crate root lib.rs.
+    output: 'rustc_args.out.rs',
+)
+
+lib = static_library(
+    'proc_macro2',
+    dependencies: [dependency('unicode-ident', version: ['>= 1', '< 2'])],
+    native: true,
+    rust_args: [
+        '--cfg=feature="default"',
+        '--cfg=feature="proc-macro"',
+        '--cfg=feature="span-locations"',
+        '@' + rustc_args.full_path(),
+    ],
+    sources: [files('src/lib.rs'), rustc_args],
+)
+
+dep = declare_dependency(link_with: lib)
+meson.override_dependency('proc-macro2', dep)

--- a/subprojects/packagefiles/quote/meson.build
+++ b/subprojects/packagefiles/quote/meson.build
@@ -1,0 +1,18 @@
+project(
+    'quote',
+    'rust',
+    default_options: ['rust_std=2018'],
+    license: 'MIT OR Apache-2.0',
+    version: '1.0.37',
+)
+
+lib = static_library(
+    'quote',
+    dependencies: [dependency('proc-macro2', version: ['>= 1.0.80', '< 2'])],
+    native: true,
+    rust_args: ['--cfg=feature="default"', '--cfg=feature="proc-macro"'],
+    sources: files('src/lib.rs'),
+)
+
+dep = declare_dependency(link_with: lib)
+meson.override_dependency('quote', dep)

--- a/subprojects/packagefiles/syn/meson.build
+++ b/subprojects/packagefiles/syn/meson.build
@@ -1,0 +1,30 @@
+project(
+    'syn',
+    'rust',
+    default_options: ['rust_std=2021'],
+    license: 'MIT OR Apache-2.0',
+    version: '2.0.85',
+)
+
+lib = static_library(
+    'syn',
+    dependencies: [
+        dependency('proc-macro2', version: ['>= 1.0.83', '< 2']),
+        dependency('quote', version: ['>= 1.0.35', '< 2']),
+        dependency('unicode-ident', version: ['>= 1', '< 2']),
+    ],
+    native: true,
+    rust_args: [
+        '--cfg=feature="clone-impls"',
+        '--cfg=feature="default"',
+        '--cfg=feature="derive"',
+        '--cfg=feature="full"',
+        '--cfg=feature="parsing"',
+        '--cfg=feature="printing"',
+        '--cfg=feature="proc-macro"',
+    ],
+    sources: files('src/lib.rs'),
+)
+
+dep = declare_dependency(link_with: lib)
+meson.override_dependency('syn', dep)

--- a/subprojects/packagefiles/termcolor/meson.build
+++ b/subprojects/packagefiles/termcolor/meson.build
@@ -1,0 +1,12 @@
+project(
+    'termcolor',
+    'rust',
+    default_options: ['rust_std=2018'],
+    license: 'Unlicense OR MIT',
+    version: '1.4.1',
+)
+
+lib = static_library('termcolor', native: true, sources: files('src/lib.rs'))
+
+dep = declare_dependency(link_with: lib)
+meson.override_dependency('termcolor', dep)

--- a/subprojects/packagefiles/unicode-ident/meson.build
+++ b/subprojects/packagefiles/unicode-ident/meson.build
@@ -1,0 +1,12 @@
+project(
+    'unicode-ident',
+    'rust',
+    default_options: ['rust_std=2018'],
+    license: '(MIT OR Apache-2.0) AND Unicode-DFS-2016',
+    version: '1.0.13',
+)
+
+lib = static_library('unicode_ident', native: true, sources: files('src/lib.rs'))
+
+dep = declare_dependency(link_with: lib)
+meson.override_dependency('unicode-ident', dep)

--- a/subprojects/packagefiles/unicode-width/meson.build
+++ b/subprojects/packagefiles/unicode-width/meson.build
@@ -1,0 +1,17 @@
+project(
+    'unicode-width',
+    'rust',
+    default_options: ['rust_std=2021'],
+    license: 'MIT OR Apache-2.0',
+    version: '0.1.14',
+)
+
+lib = static_library(
+    'unicode_width',
+    native: true,
+    rust_args: ['--cfg=feature="cjk"', '--cfg=feature="default"'],
+    sources: files('src/lib.rs'),
+)
+
+dep = declare_dependency(link_with: lib)
+meson.override_dependency('unicode-width', dep)

--- a/subprojects/proc-macro2.wrap
+++ b/subprojects/proc-macro2.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = proc-macro2-1.0.89
+source_url = https://static.crates.io/crates/proc-macro2/1.0.89/download
+source_filename = unicode-ident-1.0.89.tar.gz
+source_hash = f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e
+patch_directory = proc-macro2

--- a/subprojects/quote.wrap
+++ b/subprojects/quote.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = quote-1.0.37
+source_url = https://static.crates.io/crates/quote/1.0.37/download
+source_filename = quote-1.0.37.tar.gz
+source_hash = b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af
+patch_directory = quote

--- a/subprojects/syn.wrap
+++ b/subprojects/syn.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = syn-2.0.85
+source_url = https://static.crates.io/crates/syn/2.0.85/download
+source_filename = syn-2.0.85.tar.gz
+source_hash = 5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56
+patch_directory = syn

--- a/subprojects/termcolor.wrap
+++ b/subprojects/termcolor.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = termcolor-1.4.1
+source_url = https://static.crates.io/crates/termcolor/1.4.1/download
+source_filename = termcolor-1.4.1.tar.gz
+source_hash = 06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755
+patch_directory = termcolor

--- a/subprojects/unicode-ident.wrap
+++ b/subprojects/unicode-ident.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = unicode-ident-1.0.13
+source_url = https://static.crates.io/crates/unicode-ident/1.0.13/download
+source_filename = unicode-ident-1.0.13.tar.gz
+source_hash = e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe
+patch_directory = unicode-ident

--- a/subprojects/unicode-width.wrap
+++ b/subprojects/unicode-width.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = unicode-width-0.1.14
+source_url = https://static.crates.io/crates/unicode-width/0.1.14/download
+source_filename = unicode-width-0.1.14.tar.gz
+source_hash = 7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af
+patch_directory = unicode-width

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,51 @@
+test_module_bridge = static_library(
+    'test_module',
+    implicit_include_directories: false,
+    include_directories: project_root,
+    sources: cxxbridge_generator.process(
+        files('ffi/module.rs'),
+        preserve_path_from: meson.project_source_root(),
+    ),
+)
+
+test_bridge = static_library(
+    'test_bridge',
+    implicit_include_directories: false,
+    include_directories: [
+        project_root,
+        test_module_bridge.private_dir_include(),
+    ],
+    sources: cxxbridge_generator.process(
+        files('ffi/lib.rs'),
+        preserve_path_from: meson.project_source_root(),
+    ),
+)
+
+cxx_test_suite = static_library(
+    'cxx_test_suite',
+    link_with: [
+        cxx_library,
+        static_library(
+            'cxx_test_suite_impl',
+            implicit_include_directories: false,
+            include_directories: [
+                project_root,
+                test_bridge.private_dir_include(),
+                test_module_bridge.private_dir_include(),
+            ],
+            link_with: [test_bridge, test_module_bridge],
+            sources: [files('ffi/tests.cc'), cxx_header],
+        ),
+    ],
+    sources: files('ffi/lib.rs'),
+)
+
+rust.test(
+    'tests',
+    static_library(
+        'tests_lib',
+        link_with: [cxx_library, cxx_test_suite],
+        rust_args: ['-Aunused_imports', '-Aunused_macros'],
+        sources: files('test.rs'),
+    ),
+)

--- a/third-party/meson.build
+++ b/third-party/meson.build
@@ -1,0 +1,14 @@
+# Must be sorted topologically, not alphabetically.
+third_party = {
+    'unicode_ident': subproject('unicode-ident').get_variable('dep'),
+    'proc-macro2': subproject('proc-macro2').get_variable('dep'),
+    'quote': subproject('quote').get_variable('dep'),
+    'syn': subproject('syn').get_variable('dep'),
+    'termcolor': subproject('termcolor').get_variable('dep'),
+    'unicode_width': subproject('unicode-width').get_variable('dep'),
+    'codespan-reporting': subproject('codespan-reporting').get_variable('dep'),
+    'anstyle': subproject('anstyle').get_variable('dep'),
+    'clap_lex': subproject('clap_lex').get_variable('dep'),
+    'clap_builder': subproject('clap_builder').get_variable('dep'),
+    'clap': subproject('clap').get_variable('dep'),
+}

--- a/tools/meson/buildscript_run.py
+++ b/tools/meson/buildscript_run.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, IO, NamedTuple
+
+
+def eprint(*args: Any, **kwargs: Any) -> None:
+    print(*args, end="\n", file=sys.stderr, flush=True, **kwargs)
+
+
+def run_buildscript(
+    buildscript: str,
+    env: Dict[str, str],
+    cwd: Path,
+) -> str:
+    try:
+        return subprocess.check_output(
+            os.path.abspath(buildscript),
+            encoding="utf-8",
+            env=env,
+            cwd=cwd,
+        )
+    except OSError as ex:
+        eprint(f"Failed to run {buildscript} because {ex}", file=sys.stderr)
+        sys.exit(1)
+    except subprocess.CalledProcessError as ex:
+        sys.exit(ex.returncode)
+
+
+class Args(NamedTuple):
+    buildscript: str
+    manifest_dir: Path
+    rustc_wrapper: Path
+    out_dir: Path
+    rustc_args: IO[str]
+
+
+def arg_parse() -> Args:
+    parser = argparse.ArgumentParser(description="Run Rust build script")
+    parser.add_argument("--buildscript", type=str, required=True)
+    parser.add_argument("--manifest-dir", type=Path, required=True)
+    parser.add_argument("--rustc-wrapper", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--rustc-args", type=argparse.FileType("w"), required=True)
+
+    return Args(**vars(parser.parse_args()))
+
+
+def main():
+    args = arg_parse()
+
+    env = dict(
+        os.environ,
+        CARGO_MANIFEST_DIR=os.path.abspath(args.manifest_dir),
+        OUT_DIR=os.path.abspath(args.out_dir),
+        RUSTC=os.path.abspath(args.rustc_wrapper),
+    )
+
+    script_output = run_buildscript(
+        args.buildscript,
+        env=env,
+        cwd=args.manifest_dir,
+    )
+
+    cargo_rustc_cfg_pattern = re.compile("^cargo:rustc-cfg=(.*)")
+    flags = ""
+    for line in script_output.split("\n"):
+        cargo_rustc_cfg_match = cargo_rustc_cfg_pattern.match(line)
+        if cargo_rustc_cfg_match:
+            flags += "--cfg={}\n".format(cargo_rustc_cfg_match.group(1))
+    args.rustc_args.write(flags)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/meson/meson.build
+++ b/tools/meson/meson.build
@@ -1,0 +1,5 @@
+configure_file(
+    configuration: {'RUSTC': ' '.join(meson.get_compiler('rust').cmd_array())},
+    input: 'rustc_wrapper.sh',
+    output: 'rustc_wrapper.sh',
+)

--- a/tools/meson/native.ini
+++ b/tools/meson/native.ini
@@ -1,0 +1,3 @@
+[binaries]
+c_ld = 'lld'
+cpp_ld = 'lld'

--- a/tools/meson/rustc_wrapper.sh
+++ b/tools/meson/rustc_wrapper.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+@RUSTC@ "$@"


### PR DESCRIPTION
Per https://github.com/dtolnay/cxx/pull/1386, I gave up on using Meson's built-in automatic `method = cargo` support for importing crates.io libraries.

Now that this works, there may be something useful to feed back into improving Meson's automatic generation of meson.build for Rust crates.