### PR TITLE
`Slice<T>::iterator` to be `contiguous` and `random_access`

### DIFF
--- a/include/cxx.h
+++ b/include/cxx.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <algorithm>
 #include <array>
+#include <concepts>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -217,6 +218,7 @@ template <typename T>
 class Slice<T>::iterator final {
 public:
   using iterator_category = std::random_access_iterator_tag;
+  using iterator_concept = std::contiguous_iterator_tag;
   using value_type = T;
   using difference_type = std::ptrdiff_t;
   using pointer = typename std::add_pointer<T>::type;
@@ -244,6 +246,10 @@ public:
   bool operator>(const iterator &) const noexcept;
   bool operator>=(const iterator &) const noexcept;
 
+  template <std::integral N>
+  friend iterator operator+(N n, const iterator& it) noexcept {
+      return it + n;
+  }
 private:
   friend class Slice;
   void *pos;


### PR DESCRIPTION
`rust::Vec` fails `std::ranges::contiguous_range` checks as those have to satisfy `random_access_range`, and `contiguous_iterator`. This has caused mismatches with certain `span` types in other codebases.

This PR adds the necessary increment and concept category to `Slice<T>::iterator`, to correct this issue.

Bug: https://github.com/dtolnay/cxx/issues/1392