### PR TITLE
Add rules_cc as bazel_dep

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,6 +2,7 @@ module(name = "cxx.rs")
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_rust", version = "0.54.1")
+bazel_dep(name = "rules_cc", version = "0.1.0")
 
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(


### PR DESCRIPTION
This fixed the error when using bazel build system for cxx as

https://github.com/dtolnay/cxx/blob/master/tools/bazel/rust_cxx_bridge.bzl#L3 using the `rules_cc`

```
ERROR: Skipping '//:cxx_helloworld': error loading package '': at /home/phongtran/.cache/bazel/_bazel_phongtran/2203687aa2e8f2dabc08191e61a17361/external/cxx.rs~/tools/bazel/rust_cxx_bridge.bzl:3:6: Unable to find package for @@[unknown repo 'rules_cc' requested from @@cxx.rs~]//cc:defs.bzl: The repository '@@[unknown repo 'rules_cc' requested from @@cxx.rs~]' could not be resolved: No repository visible as '@rules_cc' from repository '@@cxx.rs~'.
ERROR: error loading package '': at /home/phongtran/.cache/bazel/_bazel_phongtran/2203687aa2e8f2dabc08191e61a17361/external/cxx.rs~/tools/bazel/rust_cxx_bridge.bzl:3:6: Unable to find package for @@[unknown repo 'rules_cc' requested from @@cxx.rs~]//cc:defs.bzl: The repository '@@[unknown repo 'rules_cc' requested from @@cxx.rs~]' could not be resolved: No repository visible as '@rules_cc' from repository '@@cxx.rs~'.
INFO: Elapsed time: 2.428s
INFO: 0 processes.
ERROR: Build did NOT complete successfully
ERROR: Build failed. Not running target
```