### PR TITLE
Introducing CXX Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ CXX &mdash; safe FFI between Rust and C++
 [<img alt="crates.io" src="https://img.shields.io/crates/v/cxx.svg?style=for-the-badge&color=fc8d62&logo=rust" height="20">](https://crates.io/crates/cxx)
 [<img alt="docs.rs" src="https://img.shields.io/badge/docs.rs-cxx-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" height="20">](https://docs.rs/cxx)
 [<img alt="build status" src="https://img.shields.io/github/actions/workflow/status/dtolnay/cxx/ci.yml?branch=master&style=for-the-badge" height="20">](https://github.com/dtolnay/cxx/actions?query=branch%3Amaster)
+[<img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20CXX%20Guru-006BFF?style=for-the-badge" height="20">](https://gurubase.io/g/cxx)
 
 This library provides a **safe** mechanism for calling C++ code from Rust and
 Rust code from C++, not subject to the many ways that things can go wrong when


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [CXX Guru](https://gurubase.io/g/cxx) to Gurubase. CXX Guru uses the data from this repo and data from the [docs](https://cxx.rs) to answer questions by leveraging the LLM.

In this PR, I showcased the "CXX Guru", which highlights that CXX now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable CXX Guru in Gurubase, just let me know that's totally fine.
