### PR TITLE
add -fPIC for cxx_cc so that it can link in clang properly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ cc_library(
     include_prefix = "rust",
     includes = ["include"],
     linkstatic = True,
+    copts = ["-fPIC"],
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Fixes linking in clang toolchains, e.g. https://github.com/dtolnay/cxx/issues/1399