### PR TITLE
Avoid further trycatch and throw when exceptions are disabled

### DIFF
--- a/book/src/binding/result.md
+++ b/book/src/binding/result.md
@@ -137,10 +137,16 @@ you'd like for the Rust error to have.
 ...namespace behavior {
 ...
 template <typename Try, typename Fail>
-static void trycatch(Try &&func, Fail &&fail) noexcept try {
+static void trycatch(Try &&func, Fail &&fail) noexcept {
+#if defined(RUST_CXX_NO_EXCEPTIONS)
   func();
-} catch (const std::exception &e) {
-  fail(e.what());
+#else
+  try {
+    func();
+  } catch (const std::exception &e) {
+    fail(e.what());
+  }
+#endif
 }
 ...
 ...} // namespace behavior

--- a/gen/src/builtin.rs
+++ b/gen/src/builtin.rs
@@ -410,10 +410,16 @@ pub(super) fn write(out: &mut OutFile) {
             "    ::std::is_same<decltype(trycatch(::std::declval<Try>(), ::std::declval<Fail>())),",
         );
         writeln!(out, "                 missing>::value>::type");
-        writeln!(out, "trycatch(Try &&func, Fail &&fail) noexcept try {{");
+        writeln!(out, "trycatch(Try &&func, Fail &&fail) noexcept {{");
+        writeln!(out, "#if defined(RUST_CXX_NO_EXCEPTIONS)");
         writeln!(out, "  func();");
-        writeln!(out, "}} catch (::std::exception const &e) {{");
-        writeln!(out, "  fail(e.what());");
+        writeln!(out, "#else");
+        writeln!(out, "  try {{");
+        writeln!(out, "    func();");
+        writeln!(out, "  }} catch (::std::exception const &e) {{");
+        writeln!(out, "    fail(e.what());");
+        writeln!(out, "  }}");
+        writeln!(out, "#endif");
         writeln!(out, "}}");
         out.end_block(Block::Namespace("behavior"));
     }

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1123,7 +1123,19 @@ fn write_rust_function_shim_impl(
     if sig.throws {
         out.builtin.rust_error = true;
         writeln!(out, "  if (error$.ptr) {{");
+        writeln!(out, "#if defined(RUST_CXX_NO_EXCEPTIONS)");
+        writeln!(
+            out,
+            "    const auto msg = static_cast<char const *>(error$.ptr);"
+        );
+        writeln!(
+            out,
+            "    std::fprintf(stderr, \"Error: %s Aborting.\\n\", msg);"
+        );
+        writeln!(out, "    std::abort();");
+        writeln!(out, "#else");
         writeln!(out, "    throw ::rust::impl<::rust::Error>::error(error$);");
+        writeln!(out, "#endif");
         writeln!(out, "  }}");
     }
     if indirect_return {


### PR DESCRIPTION
For WASM targets the `cc` crate changed to always set `-fno-exceptions`,
before only `-fignore-exceptions` was being set elsewhere, so now programs
fail to build when using `cxx` if any `throw` or `try ... catch` are used.

> error: cannot use 'try' with exceptions disabled

Instead for trycatch just call `func()`, if the inner code has thrown it will instead abort.

> error: cannot use 'throw' with exceptions disabled

Instead of throwing just print the error and abort, any previous code that was trying to catch can't exist anyway.

Any suggestions on better routes are welcome :-)