### PR TITLE
Disallow incompatible cxxbridge-cmd version appearing in the same lockfile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,10 @@ cxx-test-suite = { version = "0", path = "tests/ffi" }
 rustversion = "1.0.13"
 trybuild = { version = "1.0.81", features = ["diff"] }
 
+# Disallow incompatible cxxbridge-cmd version appearing in the same lockfile.
+[target.'cfg(any())'.dependencies]
+cxxbridge-cmd = { version = "=1.0.131", path = "gen/cmd" }
+
 [lib]
 doc-scrape-examples = false
 


### PR DESCRIPTION
This has the same effect as https://github.com/dtolnay/cxx/issues/1407#issuecomment-2509136343 and allows a tool like Corrosion to read a locked set of dependencies for cxxbridge-cmd out of any lockfile that contains cxx.