### PR TITLE
Move cxxbridge-cmd from dependencies to build-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ rustversion = "1.0.13"
 trybuild = { version = "1.0.81", features = ["diff"] }
 
 # Disallow incompatible cxxbridge-cmd version appearing in the same lockfile.
-[target.'cfg(any())'.dependencies]
+[target.'cfg(any())'.build-dependencies]
 cxxbridge-cmd = { version = "=1.0.132", path = "gen/cmd" }
 
 [lib]


### PR DESCRIPTION
I don't think this makes any difference for generating a lockfile or Cargo feature unification or building anything, since the dependency is not enabled on any target platform. The only intended effect is cosmetically to move cxxbridge-cmd from "Dependencies" to "Build-Dependencies" in https://crates.io/crates/cxx/1.0.132/dependencies, as it is never something that would be built for the target platform, only the host platform.