### PR TITLE
Friendlier message when `cxx::CxxString` is used in a `#[cxx::bridge]`.

### DIFF
--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -1320,6 +1320,13 @@ fn parse_type_path(ty: &TypePath) -> Result<Type> {
         }
     }
 
+    if ty.qself.is_none() && path.segments.len() == 2 && path.segments[0].ident == "cxx" {
+        return Err(Error::new_spanned(
+            ty,
+            "unexpected `cxx::` qualifier found in a `#[cxx::bridge]`",
+        ));
+    }
+
     Err(Error::new_spanned(ty, "unsupported type"))
 }
 

--- a/tests/ui/cxx_crate_name_qualified_cxx_string.rs
+++ b/tests/ui/cxx_crate_name_qualified_cxx_string.rs
@@ -1,0 +1,17 @@
+#[cxx::bridge]
+mod ffi {
+    extern "Rust" {
+        fn foo(x: CxxString);
+        fn bar(x: &cxx::CxxString);
+    }
+}
+
+fn foo(_: &cxx::CxxString) {
+    todo!()
+}
+
+fn bar(_: &cxx::CxxString) {
+    todo!()
+}
+
+fn main() {}

--- a/tests/ui/cxx_crate_name_qualified_cxx_string.stderr
+++ b/tests/ui/cxx_crate_name_qualified_cxx_string.stderr
@@ -1,0 +1,5 @@
+error: unexpected `cxx::` qualifier found in a `#[cxx::bridge]`
+ --> tests/ui/cxx_crate_name_qualified_cxx_string.rs:5:20
+  |
+5 |         fn bar(x: &cxx::CxxString);
+  |                    ^^^^^^^^^^^^^^


### PR DESCRIPTION
One gotcha that sometimes trips new users of `cxx` is that `cxx::CxxString` works outside of `cxx::bridge`, but not within. 
 This PR tries to improve this by providing a custom error message in this scenario.

Notes:

* I think that _any_ custom error message is a minor improvement over the status quo (with a generic "unsupported type" error message).  Additional improvements may be possible, but it's probably okay to do them incrementally later, in separate PRs.
    - Feel free to tweak the error message as needed.  I wasn't sure if it's okay to call `cxx::` a "qualifier" but it seems okay (FWIW paths containing `::` are [called "qualified paths" in Rust reference](https://doc.rust-lang.org/reference/paths.html#qualified-paths)).
    - Ideally the error message would also provide a hint (i.e. a fix suggestion) that enables automating removal of `cxx::`.  Unfortunately, I wasn't able to figure out how to do it.  It seems that [`syn::Error`](https://docs.rs/syn/latest/syn/struct.Error.html) doesn't support fix hints.  And it seems that compiler folks [say](https://internals.rust-lang.org/t/crate-for-outputting-rust-compiler-style-errors/20573/2) that [`annotate_snippets`](https://docs.rs/annotate-snippets/latest/annotate_snippets/) may be one option, but adopting this in `cxx` seems like a potentially bigger work item?
* FWIW an alternative fix here would be to accept both `cxx::CxxString` and `CxxString`.  I _think_ that having a single spelling is somewhat more desirable (for `grep`ping, etc.), but I am open to implementing the alternative fix.

/cc @zetafunction, @adetaylor 