### PR TITLE
Add support for Bazel common attributes [1] in `rust_cxx_bridge`.

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -25,6 +25,7 @@ rust_library(
         ":impl",
         "//:cxx",
     ],
+    testonly = True,
 )
 
 cc_library(
@@ -40,16 +41,19 @@ cc_library(
         ":module/include",
         "//:core",
     ],
+    testonly = True,
 )
 
 rust_cxx_bridge(
     name = "bridge",
     src = "ffi/lib.rs",
     deps = [":impl"],
+    testonly = True,
 )
 
 rust_cxx_bridge(
     name = "module",
     src = "ffi/module.rs",
     deps = [":impl"],
+    testonly = True,
 )

--- a/tools/bazel/rust_cxx_bridge.bzl
+++ b/tools/bazel/rust_cxx_bridge.bzl
@@ -2,22 +2,25 @@
 load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
-def rust_cxx_bridge(name, src, deps = []):
+def rust_cxx_bridge(name, src, deps = [], **kwargs):
     """A macro defining a cxx bridge library
 
     Args:
         name (string): The name of the new target
         src (string): The rust source file to generate a bridge for
         deps (list, optional): A list of dependencies for the underlying cc_library. Defaults to [].
+        **kwargs: Common arguments to pass through to underlying rules.
     """
     native.alias(
         name = "%s/header" % name,
         actual = src + ".h",
+        **kwargs,
     )
 
     native.alias(
         name = "%s/source" % name,
         actual = src + ".cc",
+        **kwargs,
     )
 
     run_binary(
@@ -35,15 +38,18 @@ def rust_cxx_bridge(name, src, deps = []):
             "$(location %s.cc)" % src,
         ],
         tool = "@cxx.rs//:codegen",
+        **kwargs,
     )
 
     cc_library(
         name = name,
         srcs = [src + ".cc"],
         deps = deps + [":%s/include" % name],
+        **kwargs,
     )
 
     cc_library(
         name = "%s/include" % name,
         hdrs = [src + ".h"],
+        **kwargs,
     )


### PR DESCRIPTION
This enables support for `visibility`, `testonly`, etc.

[1] https://bazel.build/reference/be/common-definitions#common-attributes