### PR TITLE
build-sys: Drop cxxbridge-cmd out of build-dependencies

### DIFF
--- a/gen/cmd/Cargo.toml
+++ b/gen/cmd/Cargo.toml
@@ -16,6 +16,9 @@ rust-version = "1.73"
 name = "cxxbridge"
 path = "src/main.rs"
 
+[lib]
+path = "src/lib.rs"
+
 [features]
 # incomplete features that are not covered by a compatibility guarantee:
 experimental-async-fn = []

--- a/gen/cmd/src/lib.rs
+++ b/gen/cmd/src/lib.rs
@@ -1,0 +1,2 @@
+//! This is an empty stub in order to satisfy cargo's dependency
+//! resolver. This project should not be used as a library.


### PR DESCRIPTION
xref https://github.com/coreos/cargo-vendor-filterer/issues/111

This was part of an attempt to avoid lockfile skew (which has bit me) but right now cargo says this is actually an invalid dependency:

```
$ cargo metadata --format-version=1
warning: cxx v1.0.136 (/var/home/walters/src/github/dtolnay/cxx) ignoring invalid dependency `cxxbridge-cmd` which is missing a lib target
```

Yet the problem appears to be that other times cargo doesn't ignore it.