### PR TITLE
Support static member functions & c++ constructor of shared type

### DIFF
--- a/syntax/attrs.rs
+++ b/syntax/attrs.rs
@@ -35,6 +35,7 @@ pub(crate) struct Parser<'a> {
     pub namespace: Option<&'a mut Namespace>,
     pub cxx_name: Option<&'a mut Option<ForeignName>>,
     pub rust_name: Option<&'a mut Option<Ident>>,
+    pub self_type: Option<&'a mut Option<Ident>>,
     pub variants_from_header: Option<&'a mut Option<Attribute>>,
     pub ignore_unrecognized: bool,
 
@@ -121,6 +122,19 @@ pub(crate) fn parse(cx: &mut Errors, attrs: Vec<Attribute>, mut parser: Parser) 
                 Ok(attr) => {
                     if let Some(rust_name) = &mut parser.rust_name {
                         **rust_name = Some(attr);
+                        continue;
+                    }
+                }
+                Err(err) => {
+                    cx.push(err);
+                    break;
+                }
+            }
+        } else if attr_path.is_ident("Self") {
+            match parse_rust_name_attribute(&attr.meta) {
+                Ok(attr) => {
+                    if let Some(namespace) = &mut parser.self_type {
+                        **namespace = Some(attr);
                         continue;
                     }
                 }

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -498,6 +498,19 @@ fn check_api_fn(cx: &mut Check, efn: &ExternFn) {
     if efn.lang == Lang::Cxx {
         check_mut_return_restriction(cx, efn);
     }
+
+    if let Some(self_type) = &efn.self_type {
+        if !cx.types.structs.contains_key(self_type)
+            && !cx.types.cxx.contains(self_type)
+            && !cx.types.rust.contains(self_type)
+        {
+            let msg = format!("unrecognized self type: {}", self_type);
+            cx.error(self_type, msg);
+        }
+        if efn.receiver.is_some() {
+            cx.error(efn, "self type and receiver are mutually exclusive");
+        }
+    }
 }
 
 fn check_api_type_alias(cx: &mut Check, alias: &TypeAlias) {

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -510,6 +510,10 @@ fn check_api_fn(cx: &mut Check, efn: &ExternFn) {
         if efn.receiver.is_some() {
             cx.error(efn, "self type and receiver are mutually exclusive");
         }
+
+        if efn.sig.constructor && !cx.types.structs.contains_key(self_type) {
+            cx.error(efn, "constructor is only allowed for shared structure");
+        }
     }
 }
 

--- a/syntax/impls.rs
+++ b/syntax/impls.rs
@@ -319,6 +319,7 @@ impl PartialEq for Signature {
             throws,
             paren_token: _,
             throws_tokens: _,
+            constructor: _,
         } = self;
         let Signature {
             asyncness: asyncness2,
@@ -331,6 +332,7 @@ impl PartialEq for Signature {
             throws: throws2,
             paren_token: _,
             throws_tokens: _,
+            constructor: _,
         } = other;
         asyncness.is_some() == asyncness2.is_some()
             && unsafety.is_some() == unsafety2.is_some()
@@ -375,6 +377,7 @@ impl Hash for Signature {
             throws,
             paren_token: _,
             throws_tokens: _,
+            constructor: _,
         } = self;
         asyncness.is_some().hash(state);
         unsafety.is_some().hash(state);

--- a/syntax/mangle.rs
+++ b/syntax/mangle.rs
@@ -85,8 +85,8 @@ macro_rules! join {
 }
 
 pub(crate) fn extern_fn(efn: &ExternFn, types: &Types) -> Symbol {
-    match &efn.receiver {
-        Some(receiver) => {
+    match (&efn.receiver, &efn.self_type) {
+        (Some(receiver), None) => {
             let receiver_ident = types.resolve(&receiver.ty);
             join!(
                 efn.name.namespace,
@@ -95,7 +95,17 @@ pub(crate) fn extern_fn(efn: &ExternFn, types: &Types) -> Symbol {
                 efn.name.rust,
             )
         }
-        None => join!(efn.name.namespace, CXXBRIDGE, efn.name.rust),
+        (None, Some(self_type)) => {
+            let self_type_ident = types.resolve(self_type);
+            join!(
+                efn.name.namespace,
+                CXXBRIDGE,
+                self_type_ident.name.cxx,
+                efn.name.rust,
+            )
+        }
+        (None, None) => join!(efn.name.namespace, CXXBRIDGE, efn.name.rust),
+        _ => unreachable!("receiver and self_type are mutually exclusive"),
     }
 }
 

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -218,6 +218,7 @@ pub(crate) struct Signature {
     pub throws: bool,
     pub paren_token: Paren,
     pub throws_tokens: Option<(kw::Result, Token![<], Token![>])>,
+    pub constructor: bool,
 }
 
 pub(crate) struct Var {

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -162,6 +162,7 @@ pub(crate) struct ExternFn {
     pub sig: Signature,
     pub semi_token: Token![;],
     pub trusted: bool,
+    pub self_type: Option<Ident>,
 }
 
 pub(crate) struct TypeAlias {

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -525,6 +525,7 @@ fn parse_extern_fn(
     let mut namespace = namespace.clone();
     let mut cxx_name = None;
     let mut rust_name = None;
+    let mut self_type = None;
     let mut attrs = attrs.clone();
     attrs.extend(attrs::parse(
         cx,
@@ -535,6 +536,7 @@ fn parse_extern_fn(
             namespace: Some(&mut namespace),
             cxx_name: Some(&mut cxx_name),
             rust_name: Some(&mut rust_name),
+            self_type: Some(&mut self_type),
             ..Default::default()
         },
     ));
@@ -694,6 +696,7 @@ fn parse_extern_fn(
         },
         semi_token,
         trusted,
+        self_type,
     }))
 }
 

--- a/syntax/pod.rs
+++ b/syntax/pod.rs
@@ -13,11 +13,12 @@ impl<'a> Types<'a> {
                         CxxString | RustString => false,
                     }
                 } else if let Some(strct) = self.structs.get(ident) {
-                    derive::contains(&strct.derives, Trait::Copy)
+                    (derive::contains(&strct.derives, Trait::Copy)
                         || strct
                             .fields
                             .iter()
-                            .all(|field| self.is_guaranteed_pod(&field.ty))
+                            .all(|field| self.is_guaranteed_pod(&field.ty)))
+                        && !self.structs_with_constructors.contains(ident)
                 } else {
                     self.enums.contains_key(ident)
                 }

--- a/syntax/resolve.rs
+++ b/syntax/resolve.rs
@@ -1,5 +1,5 @@
 use crate::syntax::instantiate::NamedImplKey;
-use crate::syntax::{Lifetimes, NamedType, Pair, Types};
+use crate::syntax::{Lifetimes, NamedType, Pair, Type, Types};
 use proc_macro2::Ident;
 
 #[derive(Copy, Clone)]
@@ -20,6 +20,15 @@ impl<'a> Types<'a> {
     pub(crate) fn try_resolve(&self, ident: &impl UnresolvedName) -> Option<Resolution<'a>> {
         let ident = ident.ident();
         self.resolutions.get(ident).copied()
+    }
+}
+
+impl Into<Type> for Resolution<'_> {
+    fn into(self) -> Type {
+        Type::Ident(NamedType {
+            rust: self.name.rust.clone(),
+            generics: self.generics.clone(),
+        })
     }
 }
 

--- a/syntax/tokens.rs
+++ b/syntax/tokens.rs
@@ -264,6 +264,7 @@ impl ToTokens for Signature {
             throws: _,
             paren_token,
             throws_tokens,
+            constructor: _,
         } = self;
         fn_token.to_tokens(tokens);
         paren_token.surround(tokens, |tokens| {

--- a/syntax/types.rs
+++ b/syntax/types.rs
@@ -25,6 +25,7 @@ pub(crate) struct Types<'a> {
     pub resolutions: UnorderedMap<&'a Ident, Resolution<'a>>,
     pub struct_improper_ctypes: UnorderedSet<&'a Ident>,
     pub toposorted_structs: Vec<&'a Struct>,
+    pub structs_with_constructors: UnorderedSet<&'a Ident>,
 }
 
 impl<'a> Types<'a> {
@@ -38,6 +39,7 @@ impl<'a> Types<'a> {
         let mut untrusted = UnorderedMap::new();
         let mut impls = OrderedMap::new();
         let mut resolutions = UnorderedMap::new();
+        let mut structs_with_constructors = UnorderedSet::new();
         let struct_improper_ctypes = UnorderedSet::new();
         let toposorted_structs = Vec::new();
 
@@ -151,6 +153,9 @@ impl<'a> Types<'a> {
                     if let Some(ret) = &efn.ret {
                         visit(&mut all, ret);
                     }
+                    if efn.sig.constructor {
+                        structs_with_constructors.insert(efn.self_type.as_ref().unwrap());
+                    }
                 }
                 Api::TypeAlias(alias) => {
                     let ident = &alias.name.rust;
@@ -209,6 +214,7 @@ impl<'a> Types<'a> {
             resolutions,
             struct_improper_ctypes,
             toposorted_structs,
+            structs_with_constructors,
         };
 
         types.toposorted_structs = toposort::sort(cx, apis, &types);

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -29,6 +29,10 @@ pub mod ffi {
         z: usize,
     }
 
+    struct SharedWithConstructor {
+        z: usize,
+    }
+
     #[derive(PartialEq, PartialOrd)]
     struct SharedString {
         msg: String,
@@ -223,6 +227,11 @@ pub mod ffi {
 
         #[Self = "C"]
         fn c_static_method() -> usize;
+
+        #[Self = "SharedWithConstructor"]
+        fn c_new(x: usize, y: usize) -> Self;
+
+        fn c_return_shared_with_constructor() -> SharedWithConstructor;
     }
 
     extern "C++" {
@@ -326,6 +335,11 @@ pub mod ffi {
 
         #[Self = "R"]
         fn r_static_method() -> usize;
+
+        #[Self = "SharedWithConstructor"]
+        fn new(x: usize, y: usize, z: usize) -> Self;
+
+        fn r_return_shared_with_constructor() -> SharedWithConstructor;
     }
 
     struct Dag0 {
@@ -434,6 +448,12 @@ impl ffi::Shared {
     }
 }
 
+impl ffi::SharedWithConstructor {
+    fn new(x: usize, y: usize, z: usize) -> Self {
+        Self { z: x + y - z }
+    }
+}
+
 impl ffi::Array {
     pub fn r_get_array_sum(&self) -> i32 {
         self.a.iter().sum()
@@ -466,6 +486,12 @@ fn r_return_primitive() -> usize {
 
 fn r_return_shared() -> ffi::Shared {
     ffi::Shared { z: 2020 }
+}
+
+fn r_return_shared_with_constructor() -> ffi::SharedWithConstructor {
+    ffi::SharedWithConstructor {
+        z: 2020,
+    }
 }
 
 fn r_return_box() -> Box<R> {

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -203,6 +203,8 @@ pub mod ffi {
         fn c_method_on_shared(self: &Shared) -> usize;
         fn c_method_ref_on_shared(self: &Shared) -> &usize;
         fn c_method_mut_on_shared(self: &mut Shared) -> &mut usize;
+        #[Self = "Shared"]
+        fn c_static_method_on_shared() -> usize;
         fn c_set_array(self: &mut Array, value: i32);
 
         fn c_get_use_count(weak: &WeakPtr<C>) -> usize;
@@ -218,6 +220,9 @@ pub mod ffi {
 
         #[namespace = "other"]
         fn ns_c_take_ns_shared(shared: AShared);
+
+        #[Self = "C"]
+        fn c_static_method() -> usize;
     }
 
     extern "C++" {
@@ -315,6 +320,12 @@ pub mod ffi {
 
         #[cxx_name = "rAliasedFunction"]
         fn r_aliased_function(x: i32) -> String;
+
+        #[Self = "Shared"]
+        fn r_static_method_on_shared() -> usize;
+
+        #[Self = "R"]
+        fn r_static_method() -> usize;
     }
 
     struct Dag0 {
@@ -406,6 +417,10 @@ impl R {
         self.0 = n;
         n
     }
+
+    fn r_static_method() -> usize {
+        2024
+    }
 }
 
 pub struct Reference<'a>(pub &'a String);
@@ -413,6 +428,9 @@ pub struct Reference<'a>(pub &'a String);
 impl ffi::Shared {
     fn r_method_on_shared(&self) -> String {
         "2020".to_owned()
+    }
+    fn r_static_method_on_shared() -> usize {
+        2023
     }
 }
 

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -44,6 +44,8 @@ const size_t &Shared::c_method_ref_on_shared() const noexcept {
 
 size_t &Shared::c_method_mut_on_shared() noexcept { return this->z; }
 
+size_t Shared::c_static_method_on_shared() noexcept { return 2025; }
+
 void Array::c_set_array(int32_t val) noexcept {
   this->a = {val, val, val, val};
 }
@@ -627,6 +629,8 @@ rust::String cOverloadedFunction(rust::Str x) {
   return rust::String(std::string(x));
 }
 
+size_t C::c_static_method() { return 2026; }
+
 void c_take_trivial_ptr(std::unique_ptr<D> d) {
   if (d->d == 30) {
     cxx_test_suite_set_correct();
@@ -786,6 +790,8 @@ extern "C" const char *cxx_run_test() noexcept {
   ASSERT(r_return_enum(0) == Enum::AVal);
   ASSERT(r_return_enum(1) == Enum::BVal);
   ASSERT(r_return_enum(2021) == Enum::CVal);
+  ASSERT(Shared::r_static_method_on_shared() == 2023);
+  ASSERT(R::r_static_method() == 2024);
 
   r_take_primitive(2020);
   r_take_shared(Shared{2020});

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -38,6 +38,8 @@ size_t C::get_fail() { throw std::runtime_error("unimplemented"); }
 
 size_t Shared::c_method_on_shared() const noexcept { return 2021; }
 
+SharedWithConstructor::SharedWithConstructor(size_t x, size_t y) noexcept : z(x + y) {}
+
 const size_t &Shared::c_method_ref_on_shared() const noexcept {
   return this->z;
 }
@@ -57,6 +59,8 @@ std::vector<uint8_t> &C::get_v() { return this->v; }
 size_t c_return_primitive() { return 2020; }
 
 Shared c_return_shared() { return Shared{2020}; }
+
+SharedWithConstructor c_return_shared_with_constructor() { return SharedWithConstructor{2019, 1}; }
 
 ::A::AShared c_return_ns_shared() { return ::A::AShared{2020}; }
 
@@ -792,6 +796,7 @@ extern "C" const char *cxx_run_test() noexcept {
   ASSERT(r_return_enum(2021) == Enum::CVal);
   ASSERT(Shared::r_static_method_on_shared() == 2023);
   ASSERT(R::r_static_method() == 2024);
+  ASSERT(SharedWithConstructor(2023, 2, 1).z == 2024);
 
   r_take_primitive(2020);
   r_take_shared(Shared{2020});

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -36,6 +36,7 @@ namespace tests {
 
 struct R;
 struct Shared;
+struct SharedWithConstructor;
 struct SharedString;
 enum class Enum : uint16_t;
 
@@ -89,6 +90,7 @@ typedef char Buffer[12];
 
 size_t c_return_primitive();
 Shared c_return_shared();
+SharedWithConstructor c_return_shared_with_constructor();
 ::A::AShared c_return_ns_shared();
 ::A::B::ABShared c_return_nested_ns_shared();
 rust::Box<R> c_return_box();

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -54,6 +54,7 @@ public:
   rust::String cOverloadedMethod(int32_t x) const;
   rust::String cOverloadedMethod(rust::Str x) const;
 
+  static size_t c_static_method();
 private:
   size_t n;
   std::vector<uint8_t> v;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -266,6 +266,7 @@ fn test_c_method_calls() {
     assert_eq!(2023, *ffi::Shared { z: 2023 }.c_method_mut_on_shared());
     assert_eq!(2025, ffi::Shared::c_static_method_on_shared());
     assert_eq!(2026, ffi::C::c_static_method());
+    assert_eq!(2027, ffi::SharedWithConstructor::c_new(2026, 1).z);
 
     let val = 42;
     let mut array = ffi::Array {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -264,6 +264,8 @@ fn test_c_method_calls() {
     assert_eq!(2021, ffi::Shared { z: 0 }.c_method_on_shared());
     assert_eq!(2022, *ffi::Shared { z: 2022 }.c_method_ref_on_shared());
     assert_eq!(2023, *ffi::Shared { z: 2023 }.c_method_mut_on_shared());
+    assert_eq!(2025, ffi::Shared::c_static_method_on_shared());
+    assert_eq!(2026, ffi::C::c_static_method());
 
     let val = 42;
     let mut array = ffi::Array {


### PR DESCRIPTION
Implement https://github.com/dtolnay/cxx/issues/447#issuecomment-725216634

- [x] cxx side static member functions
- [x] export as static member functions in rust side as well
- [x] rust side static member functions
- [x] when returns `Self` with `#[Self = ]`, it defined as constructor in c++

Close #1419, fix #464
