### PR TITLE
Tweak `rust::Slice` to become a C++20 `contiguous_range`.

### DIFF
--- a/book/src/binding/slice.md
+++ b/book/src/binding/slice.md
@@ -50,7 +50,11 @@ public:
 ...template <typename T>
 ...class Slice<T>::iterator final {
 ...public:
+...#if __cplusplus >= 202002L
+...  using iterator_category = std::contiguous_iterator_tag;
+...#else
 ...  using iterator_category = std::random_access_iterator_tag;
+...#endif
 ...  using value_type = T;
 ...  using pointer = T *;
 ...  using reference = T &;

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -216,7 +216,11 @@ private:
 template <typename T>
 class Slice<T>::iterator final {
 public:
+#if __cplusplus >= 202002L
+  using iterator_category = std::contiguous_iterator_tag;
+#else
   using iterator_category = std::random_access_iterator_tag;
+#endif
   using value_type = T;
   using difference_type = std::ptrdiff_t;
   using pointer = typename std::add_pointer<T>::type;
@@ -234,6 +238,9 @@ public:
   iterator &operator+=(difference_type) noexcept;
   iterator &operator-=(difference_type) noexcept;
   iterator operator+(difference_type) const noexcept;
+  friend inline iterator operator+(difference_type lhs, iterator rhs) {
+    return rhs + lhs;
+  }
   iterator operator-(difference_type) const noexcept;
   difference_type operator-(const iterator &) const noexcept;
 
@@ -249,6 +256,12 @@ private:
   void *pos;
   std::size_t stride;
 };
+
+#if __cplusplus >= 202002L
+static_assert(std::ranges::contiguous_range<rust::Slice<const uint8_t>>);
+static_assert(std::contiguous_iterator<rust::Slice<const uint8_t>::iterator>);
+#endif
+
 #endif // CXXBRIDGE1_RUST_SLICE
 
 #ifndef CXXBRIDGE1_RUST_BOX


### PR DESCRIPTION
The main missing piece was that
https://en.cppreference.com/w/cpp/iterator/random_access_iterator requires that "`(a + n)` is equal to `(n + a)`", but `Slice::iterator` only supported `a + n` and didn't support `n + a`.