### PR TITLE
Update iterator_category of Vec iterators in doc

### DIFF
--- a/book/src/binding/vec.md
+++ b/book/src/binding/vec.md
@@ -66,7 +66,11 @@ public:
 ...template <typename T>
 ...class Vec<T>::iterator final {
 ...public:
+...#if __cplusplus >= 202002L
+...  using iterator_category = std::contiguous_iterator_tag;
+...#else
 ...  using iterator_category = std::random_access_iterator_tag;
+...#endif
 ...  using value_type = T;
 ...  using pointer = T *;
 ...  using reference = T &;
@@ -97,7 +101,11 @@ public:
 ...template <typename T>
 ...class Vec<T>::const_iterator final {
 ...public:
+...#if __cplusplus >= 202002L
+...  using iterator_category = std::contiguous_iterator_tag;
+...#else
 ...  using iterator_category = std::random_access_iterator_tag;
+...#endif
 ...  using value_type = const T;
 ...  using pointer = const T *;
 ...  using reference = const T &;


### PR DESCRIPTION
rust::Vec uses the same iterators as rust::Slice, which changed in https://github.com/dtolnay/cxx/pull/1432.

https://github.com/dtolnay/cxx/blob/c6bb3b9996090777c081dfb3b4f3c58f739dcd4a/include/cxx.h#L356

https://github.com/dtolnay/cxx/blob/c6bb3b9996090777c081dfb3b4f3c58f739dcd4a/include/cxx.h#L360