### PR TITLE
Synchronize reference qualification of `operator=` to docs

### DIFF
--- a/book/src/binding/box.md
+++ b/book/src/binding/box.md
@@ -24,7 +24,7 @@ public:
   explicit Box(const T &);
   explicit Box(T &&);
 
-  Box &operator=(Box &&) noexcept;
+  Box &operator=(Box &&) & noexcept;
 
   const T *operator->() const noexcept;
   const T &operator*() const noexcept;

--- a/book/src/binding/result.md
+++ b/book/src/binding/result.md
@@ -66,8 +66,8 @@ public:
   Error(Error &&) noexcept;
   ~Error() noexcept;
 
-  Error &operator=(const Error &);
-  Error &operator=(Error &&) noexcept;
+  Error &operator=(const Error &) &;
+  Error &operator=(Error &&) & noexcept;
 
   const char *what() const noexcept override;
 };

--- a/book/src/binding/slice.md
+++ b/book/src/binding/slice.md
@@ -26,8 +26,8 @@ public:
   template <typename C>
   explicit Slice(C &c) : Slice(c.data(), c.size());
 
-  Slice &operator=(Slice<T> &&) noexcept;
-  Slice &operator=(const Slice<T> &) noexcept
+  Slice &operator=(Slice<T> &&) & noexcept;
+  Slice &operator=(const Slice<T> &) & noexcept
     requires std::is_const_v<T>;
 
   T *data() const noexcept;

--- a/book/src/binding/str.md
+++ b/book/src/binding/str.md
@@ -22,7 +22,7 @@ public:
   Str(const char *);
   Str(const char *, size_t);
 
-  Str &operator=(const Str &) noexcept;
+  Str &operator=(const Str &) & noexcept;
 
   explicit operator std::string() const;
 

--- a/book/src/binding/string.md
+++ b/book/src/binding/string.md
@@ -36,8 +36,8 @@ public:
   static String lossy(const char16_t *) noexcept;
   static String lossy(const char16_t *, size_t) noexcept;
 
-  String &operator=(const String &) noexcept;
-  String &operator=(String &&) noexcept;
+  String &operator=(const String &) & noexcept;
+  String &operator=(String &&) & noexcept;
 
   explicit operator std::string() const;
 

--- a/book/src/binding/vec.md
+++ b/book/src/binding/vec.md
@@ -23,8 +23,8 @@ public:
   Vec(Vec &&) noexcept;
   ~Vec() noexcept;
 
-  Vec &operator=(Vec &&) noexcept;
-  Vec &operator=(const Vec &);
+  Vec &operator=(Vec &&) & noexcept;
+  Vec &operator=(const Vec &) &;
 
   size_t size() const noexcept;
   bool empty() const noexcept;


### PR DESCRIPTION
Changes from https://github.com/dtolnay/cxx/pull/714.