### PR TITLE
Move ranges header to cxx.h

### DIFF
--- a/gen/src/include.rs
+++ b/gen/src/include.rs
@@ -157,7 +157,7 @@ pub(super) fn write(out: &mut OutFile) {
     if vector && !cxx_header {
         writeln!(out, "#include <vector>");
     }
-    if ranges {
+    if ranges && !cxx_header {
         writeln!(out, "#if __cplusplus >= 202002L");
         writeln!(out, "#include <ranges>");
         writeln!(out, "#endif");

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -9,6 +9,9 @@
 #include <iosfwd>
 #include <iterator>
 #include <new>
+#if __cplusplus >= 202002L
+#include <ranges>
+#endif
 #include <stdexcept>
 #include <string>
 #include <type_traits>


### PR DESCRIPTION
This is needed for `std::ranges::contiguous_range`.

https://github.com/dtolnay/cxx/blob/0243229850588838dadaaee6e954195b7014b847/include/cxx.h#L265