### PR TITLE
Update rules_cc to 0.1.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 module(name = "cxx.rs")
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
-bazel_dep(name = "rules_cc", version = "0.0.17")
+bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "rules_rust", version = "0.58.0")
 
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")


### PR DESCRIPTION
rules_cc@0.1.0 was yanked from [BCR](https://registry.bazel.build/modules/rules_cc) due to prematurely removing cc_proto_library, with the maintainers recommending remaining on 0.0.17. See https://github.com/dtolnay/cxx/pull/1422.

But recently 0.1.1 has been released and is being adopted in cxx's dependency graph, leading to the following warning from certain bazel commands:

> WARNING: For repository 'rules_cc', the root module requires module version rules_cc@0.0.17, but got rules_cc@0.1.1 in the resolved dependency graph. Please update the version in your MODULE.bazel or set --check_direct_dependencies=off

This PR updates to 0.1.1 as recommended in warning and [bazelbuild/rules_cc#268](https://github.com/bazelbuild/rules_cc/issues/268#issuecomment-2651269117).