### PR TITLE
Add support for `rust::Option<Box<T>>`

### DIFF
--- a/gen/src/builtin.rs
+++ b/gen/src/builtin.rs
@@ -10,6 +10,7 @@ pub(crate) struct Builtins<'a> {
     pub rust_slice: bool,
     pub rust_box: bool,
     pub rust_vec: bool,
+    pub rust_option: bool,
     pub rust_fn: bool,
     pub rust_isize: bool,
     pub opaque: bool,

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -214,6 +214,7 @@ fn pick_includes_and_builtins(out: &mut OutFile, apis: &[Api]) {
             },
             Type::RustBox(_) => out.builtin.rust_box = true,
             Type::RustVec(_) => out.builtin.rust_vec = true,
+            Type::RustOption(_) => out.builtin.rust_option = true,
             Type::UniquePtr(_) => out.include.memory = true,
             Type::SharedPtr(_) | Type::WeakPtr(_) => out.include.memory = true,
             Type::Str(_) => out.builtin.rust_str = true,
@@ -1235,6 +1236,11 @@ fn write_type(out: &mut OutFile, ty: &Type) {
             write_type(out, &ty.inner);
             write!(out, ">");
         }
+        Type::RustOption(ty) => {
+            write!(out, "::rust::Option<");
+            write_type(out, &ty.inner);
+            write!(out, ">");
+        }
         Type::UniquePtr(ptr) => {
             write!(out, "::std::unique_ptr<");
             write_type(out, &ptr.inner);
@@ -1340,6 +1346,7 @@ fn write_space_after_type(out: &mut OutFile, ty: &Type) {
         | Type::Str(_)
         | Type::CxxVector(_)
         | Type::RustVec(_)
+        | Type::RustOption(_)
         | Type::SliceRef(_)
         | Type::Fn(_)
         | Type::Array(_) => write!(out, " "),

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -47,6 +47,7 @@ fn do_typecheck(cx: &mut Check) {
             Type::Ident(ident) => check_type_ident(cx, ident),
             Type::RustBox(ptr) => check_type_box(cx, ptr),
             Type::RustVec(ty) => check_type_rust_vec(cx, ty),
+            Type::RustOption(ty) => check_type_rust_option(cx, ty),
             Type::UniquePtr(ptr) => check_type_unique_ptr(cx, ptr),
             Type::SharedPtr(ptr) => check_type_shared_ptr(cx, ptr),
             Type::WeakPtr(ptr) => check_type_weak_ptr(cx, ptr),
@@ -136,6 +137,15 @@ fn check_type_rust_vec(cx: &mut Check, ty: &Ty1) {
     }
 
     cx.error(ty, "unsupported element type of Vec");
+}
+
+fn check_type_rust_option(cx: &mut Check, ty: &Ty1) {
+    match &ty.inner {
+        Type::RustBox(_) => return,
+        _ => {}
+    }
+
+    cx.error(ty, "unsupported element type of Option");
 }
 
 fn check_type_unique_ptr(cx: &mut Check, ptr: &Ty1) {
@@ -650,6 +660,7 @@ fn is_unsized(cx: &mut Check, ty: &Type) -> bool {
         Type::CxxVector(_) | Type::Fn(_) | Type::Void(_) => true,
         Type::RustBox(_)
         | Type::RustVec(_)
+        | Type::RustOption(_)
         | Type::UniquePtr(_)
         | Type::SharedPtr(_)
         | Type::WeakPtr(_)
@@ -724,6 +735,7 @@ fn describe(cx: &mut Check, ty: &Type) -> String {
         }
         Type::RustBox(_) => "Box".to_owned(),
         Type::RustVec(_) => "Vec".to_owned(),
+        Type::RustOption(_) => "Option".to_owned(),
         Type::UniquePtr(_) => "unique_ptr".to_owned(),
         Type::SharedPtr(_) => "shared_ptr".to_owned(),
         Type::WeakPtr(_) => "weak_ptr".to_owned(),

--- a/syntax/impls.rs
+++ b/syntax/impls.rs
@@ -52,6 +52,7 @@ impl Hash for Type {
             Type::Ptr(t) => t.hash(state),
             Type::Str(t) => t.hash(state),
             Type::RustVec(t) => t.hash(state),
+            Type::RustOption(t) => t.hash(state),
             Type::CxxVector(t) => t.hash(state),
             Type::Fn(t) => t.hash(state),
             Type::SliceRef(t) => t.hash(state),

--- a/syntax/improper.rs
+++ b/syntax/improper.rs
@@ -24,6 +24,7 @@ impl<'a> Types<'a> {
             }
             Type::RustBox(_)
             | Type::RustVec(_)
+            | Type::RustOption(_)
             | Type::Str(_)
             | Type::Fn(_)
             | Type::Void(_)

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -264,6 +264,7 @@ pub(crate) enum Type {
     Ident(NamedType),
     RustBox(Box<Ty1>),
     RustVec(Box<Ty1>),
+    RustOption(Box<Ty1>),
     UniquePtr(Box<Ty1>),
     SharedPtr(Box<Ty1>),
     WeakPtr(Box<Ty1>),

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -1060,6 +1060,7 @@ fn parse_impl(cx: &mut Errors, imp: ItemImpl) -> Result<Api> {
     let ty_generics = match &ty {
         Type::RustBox(ty)
         | Type::RustVec(ty)
+        | Type::RustOption(ty)
         | Type::UniquePtr(ty)
         | Type::SharedPtr(ty)
         | Type::WeakPtr(ty)
@@ -1288,6 +1289,16 @@ fn parse_type_path(ty: &TypePath) -> Result<Type> {
                                 Some((pin_token, generic.lt_token, generic.gt_token));
                             return Ok(Type::Ref(inner));
                         }
+                    }
+                } else if ident == "Option" && generic.args.len() == 1 {
+                    if let GenericArgument::Type(arg) = &generic.args[0] {
+                        let inner = parse_type(arg)?;
+                        return Ok(Type::RustOption(Box::new(Ty1 {
+                            name: ident,
+                            langle: generic.lt_token,
+                            inner,
+                            rangle: generic.gt_token,
+                        })));
                     }
                 } else {
                     let mut lifetimes = Punctuated::new();

--- a/syntax/pod.rs
+++ b/syntax/pod.rs
@@ -24,6 +24,7 @@ impl<'a> Types<'a> {
             }
             Type::RustBox(_)
             | Type::RustVec(_)
+            | Type::RustOption(_)
             | Type::UniquePtr(_)
             | Type::SharedPtr(_)
             | Type::WeakPtr(_)

--- a/syntax/tokens.rs
+++ b/syntax/tokens.rs
@@ -28,7 +28,8 @@ impl ToTokens for Type {
             | Type::SharedPtr(ty)
             | Type::WeakPtr(ty)
             | Type::CxxVector(ty)
-            | Type::RustVec(ty) => ty.to_tokens(tokens),
+            | Type::RustVec(ty)
+            | Type::RustOption(ty) => ty.to_tokens(tokens),
             Type::Ref(r) | Type::Str(r) => r.to_tokens(tokens),
             Type::Ptr(p) => p.to_tokens(tokens),
             Type::Array(a) => a.to_tokens(tokens),

--- a/syntax/visit.rs
+++ b/syntax/visit.rs
@@ -17,7 +17,8 @@ where
         | Type::SharedPtr(ty)
         | Type::WeakPtr(ty)
         | Type::CxxVector(ty)
-        | Type::RustVec(ty) => visitor.visit_type(&ty.inner),
+        | Type::RustVec(ty)
+        | Type::RustOption(ty) => visitor.visit_type(&ty.inner),
         Type::Ref(r) => visitor.visit_type(&r.inner),
         Type::Ptr(p) => visitor.visit_type(&p.inner),
         Type::Array(a) => visitor.visit_type(&a.inner),

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -160,6 +160,8 @@ pub mod ffi {
         fn c_take_rust_vec_shared_clear(v: Vec<Shared>);
         fn c_take_rust_vec_shared_forward_iterator(v: Vec<Shared>);
         fn c_take_rust_vec_shared_sort(v: Vec<Shared>);
+    // TODO: move down
+        fn c_take_rust_option_boxed(v: Option<Box<Shared>>, some: bool);
         fn c_take_ref_rust_vec(v: &Vec<u8>);
         fn c_take_ref_rust_vec_string(v: &Vec<String>);
         fn c_take_ref_rust_vec_index(v: &Vec<u8>);
@@ -279,6 +281,7 @@ pub mod ffi {
         fn r_return_rust_vec_extern_struct() -> Vec<Job>;
         fn r_return_ref_rust_vec(shared: &Shared) -> &Vec<u8>;
         fn r_return_mut_rust_vec(shared: &mut Shared) -> &mut Vec<u8>;
+        fn r_return_rust_option_box() -> Option<Box<R>>;
         fn r_return_identity(_: usize) -> usize;
         fn r_return_sum(_: usize, _: usize) -> usize;
         fn r_return_enum(n: u32) -> Enum;
@@ -534,6 +537,10 @@ fn r_return_ref_rust_vec(shared: &ffi::Shared) -> &Vec<u8> {
 
 fn r_return_mut_rust_vec(shared: &mut ffi::Shared) -> &mut Vec<u8> {
     let _ = shared;
+    unimplemented!()
+}
+
+fn r_return_rust_option_box() -> Option<Box<R>> {
     unimplemented!()
 }
 

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -449,6 +449,18 @@ void c_take_rust_vec_shared_sort(rust::Vec<Shared> v) {
   }
 }
 
+void c_take_rust_option_boxed(rust::Option<rust::Box<Shared>> v, bool some) {
+  if (some) {
+    if (v.is_some() && (*v)->z == 13) {
+      cxx_test_suite_set_correct();
+    }
+  } else {
+    if (v.is_none()) {
+      cxx_test_suite_set_correct();
+    }
+  }
+}
+
 void c_take_rust_vec_shared_index(rust::Vec<Shared> v) {
   if (v[0].z == 1010 && v.at(0).z == 1010 && v.front().z == 1010 &&
       v[1].z == 1011 && v.at(1).z == 1011 && v.back().z == 1011) {

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -160,6 +160,7 @@ void c_take_rust_vec_shared_truncate(rust::Vec<Shared> v);
 void c_take_rust_vec_shared_clear(rust::Vec<Shared> v);
 void c_take_rust_vec_shared_forward_iterator(rust::Vec<Shared> v);
 void c_take_rust_vec_shared_sort(rust::Vec<Shared> v);
+void c_take_rust_option_boxed(rust::Option<rust::Box<Shared>> v, bool some);
 void c_take_ref_rust_vec(const rust::Vec<uint8_t> &v);
 void c_take_ref_rust_vec_string(const rust::Vec<rust::String> &v);
 void c_take_ref_rust_vec_index(const rust::Vec<uint8_t> &v);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -199,6 +199,9 @@ fn test_c_take() {
         nested_ns_shared_test_vec
     ));
 
+    check!(ffi::c_take_rust_option_boxed(None, false));
+    check!(ffi::c_take_rust_option_boxed(Some(Box::new(ffi::Shared { z: 13 })), true));
+
     check!(ffi::c_take_enum(ffi::Enum::AVal));
     check!(ffi::c_take_ns_enum(ffi::AEnum::AAVal));
     check!(ffi::c_take_nested_ns_enum(ffi::ABEnum::ABAVal));


### PR DESCRIPTION
While general support for `Option<T>` is difficult, `Option<Box<T>>` has a well-known layout due to the [NPO](https://doc.rust-lang.org/std/option/#representation), so we can replicate that layout in C++.

---

This is a very early draft!