### PR TITLE
Auto-track all bridge files

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,6 @@ fn main() {
         .std("c++11")
         .compile("cxxbridge-demo");
 
-    println!("cargo:rerun-if-changed=src/main.rs");
     println!("cargo:rerun-if-changed=src/demo.cc");
     println!("cargo:rerun-if-changed=include/demo.h");
 }

--- a/book/src/build/cargo.md
+++ b/book/src/build/cargo.md
@@ -41,7 +41,6 @@ fn main() {
         .std("c++11")
         .compile("cxxbridge-demo");
 
-    println!("cargo:rerun-if-changed=src/main.rs");
     println!("cargo:rerun-if-changed=src/demo.cc");
     println!("cargo:rerun-if-changed=include/demo.h");
 }

--- a/book/src/tutorial.md
+++ b/book/src/tutorial.md
@@ -205,7 +205,6 @@ fn main() {
         .file("src/blobstore.cc")
         .compile("cxx-demo");
 
-    println!("cargo:rerun-if-changed=src/main.rs");
     println!("cargo:rerun-if-changed=src/blobstore.cc");
     println!("cargo:rerun-if-changed=include/blobstore.h");
 }

--- a/demo/build.rs
+++ b/demo/build.rs
@@ -4,7 +4,6 @@ fn main() {
         .std("c++14")
         .compile("cxxbridge-demo");
 
-    println!("cargo:rerun-if-changed=src/main.rs");
     println!("cargo:rerun-if-changed=src/blobstore.cc");
     println!("cargo:rerun-if-changed=include/blobstore.h");
 }

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -19,7 +19,6 @@
 //!         .std("c++11")
 //!         .compile("cxxbridge-demo");
 //!
-//!     println!("cargo:rerun-if-changed=src/main.rs");
 //!     println!("cargo:rerun-if-changed=src/demo.cc");
 //!     println!("cargo:rerun-if-changed=include/demo.h");
 //! }
@@ -397,6 +396,7 @@ fn generate_bridge(prj: &Project, build: &mut Build, rust_source_file: &Path) ->
         doxygen: CFG.doxygen,
         ..Opt::default()
     };
+    println!("cargo:rerun-if-changed={}", rust_source_file.display());
     let generated = gen::generate_from_path(rust_source_file, &opt);
     let ref rel_path = paths::local_relative_path(rust_source_file);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,7 +254,6 @@
 //!         .std("c++11")
 //!         .compile("cxxbridge-demo");
 //!
-//!     println!("cargo:rerun-if-changed=src/main.rs");
 //!     println!("cargo:rerun-if-changed=src/demo.cc");
 //!     println!("cargo:rerun-if-changed=include/demo.h");
 //! }


### PR DESCRIPTION
Adds `cargo:rerun-if-changed=<path>` for all files used by the bridge.

Note that when I went through all the `rerun-if-changed` cases, some of them did **not** include the .rs file - which may mean that even this repo is missing the needed tracking and this would fix those.

Fixes #1461