### PR TITLE
Introduce `CFG.change_detection` bool flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,12 +242,12 @@ cxx-build = "1.0"
 // build.rs
 
 fn main() {
+    cxx_build::CFG.change_detection = true;
     cxx_build::bridge("src/main.rs")  // returns a cc::Build
         .file("src/demo.cc")
         .std("c++11")
         .compile("cxxbridge-demo");
 
-    println!("cargo:rerun-if-changed=src/main.rs");
     println!("cargo:rerun-if-changed=src/demo.cc");
     println!("cargo:rerun-if-changed=include/demo.h");
 }

--- a/book/src/build/cargo.md
+++ b/book/src/build/cargo.md
@@ -36,12 +36,12 @@ set up any additional source files and compiler flags as normal.
 // build.rs
 
 fn main() {
+    cxx_build::CFG.change_detection = true;
     cxx_build::bridge("src/main.rs")  // returns a cc::Build
         .file("src/demo.cc")
         .std("c++11")
         .compile("cxxbridge-demo");
 
-    println!("cargo:rerun-if-changed=src/main.rs");
     println!("cargo:rerun-if-changed=src/demo.cc");
     println!("cargo:rerun-if-changed=include/demo.h");
 }

--- a/book/src/tutorial.md
+++ b/book/src/tutorial.md
@@ -201,11 +201,11 @@ build.
 // build.rs
 
 fn main() {
+    cxx_build::CFG.change_detection = true;
     cxx_build::bridge("src/main.rs")
         .file("src/blobstore.cc")
         .compile("cxx-demo");
 
-    println!("cargo:rerun-if-changed=src/main.rs");
     println!("cargo:rerun-if-changed=src/blobstore.cc");
     println!("cargo:rerun-if-changed=include/blobstore.h");
 }

--- a/demo/build.rs
+++ b/demo/build.rs
@@ -1,10 +1,10 @@
 fn main() {
+    cxx_build::CFG.change_detection = true;
     cxx_build::bridge("src/main.rs")
         .file("src/blobstore.cc")
         .std("c++14")
         .compile("cxxbridge-demo");
 
-    println!("cargo:rerun-if-changed=src/main.rs");
     println!("cargo:rerun-if-changed=src/blobstore.cc");
     println!("cargo:rerun-if-changed=include/blobstore.h");
 }

--- a/gen/build/src/cfg.rs
+++ b/gen/build/src/cfg.rs
@@ -14,6 +14,8 @@ pub struct Cfg<'a> {
     pub exported_header_links: Vec<&'a str>,
     /// See [`CFG.doxygen`][CFG#cfgdoxygen].
     pub doxygen: bool,
+    /// See [`CFG.change_detection`][CFG#cfgchange_detection].
+    pub change_detection: bool,
     marker: PhantomData<*const ()>, // !Send + !Sync
 }
 
@@ -312,6 +314,7 @@ pub static mut CFG: Cfg = Cfg {
     exported_header_prefixes: Vec::new(),
     exported_header_links: Vec::new(),
     doxygen: false,
+    change_detection: false,
     marker: PhantomData,
 };
 
@@ -323,6 +326,7 @@ impl<'a> Debug for Cfg<'a> {
             exported_header_prefixes,
             exported_header_links,
             doxygen,
+            change_detection,
             marker: _,
         } = self;
         formatter
@@ -332,6 +336,7 @@ impl<'a> Debug for Cfg<'a> {
             .field("exported_header_prefixes", exported_header_prefixes)
             .field("exported_header_links", exported_header_links)
             .field("doxygen", doxygen)
+            .field("change_detection", change_detection)
             .finish()
     }
 }
@@ -356,6 +361,7 @@ mod r#impl {
         exported_header_prefixes: Vec<InternedString>,
         exported_header_links: Vec<InternedString>,
         doxygen: bool,
+        change_detection: bool,
     }
 
     impl CurrentCfg {
@@ -367,12 +373,14 @@ mod r#impl {
             let exported_header_prefixes = Vec::new();
             let exported_header_links = Vec::new();
             let doxygen = false;
+            let change_detection = false;
             CurrentCfg {
                 include_prefix,
                 exported_header_dirs,
                 exported_header_prefixes,
                 exported_header_links,
                 doxygen,
+                change_detection,
             }
         }
     }
@@ -409,12 +417,14 @@ mod r#impl {
             let exported_header_prefixes = current.exported_header_prefixes.vec();
             let exported_header_links = current.exported_header_links.vec();
             let doxygen = current.doxygen;
+            let change_detection = current.change_detection;
             super::Cfg {
                 include_prefix,
                 exported_header_dirs,
                 exported_header_prefixes,
                 exported_header_links,
                 doxygen,
+                change_detection,
                 marker: PhantomData,
             }
         }
@@ -481,6 +491,7 @@ mod r#impl {
                     exported_header_prefixes,
                     exported_header_links,
                     doxygen,
+                    change_detection,
                     marker: _,
                 } = cfg;
                 let mut current = current().write().unwrap_or_else(PoisonError::into_inner);
@@ -489,6 +500,7 @@ mod r#impl {
                 current.exported_header_prefixes = vec::intern(exported_header_prefixes);
                 current.exported_header_links = vec::intern(exported_header_links);
                 current.doxygen = *doxygen;
+                current.change_detection = *change_detection;
             } else {
                 CONST_DEREFS.with(|derefs| derefs.borrow_mut().remove(&self.handle()));
             }

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -14,12 +14,12 @@
 //! // build.rs
 //!
 //! fn main() {
+//!     cxx_build::CFG.change_detection = true;
 //!     cxx_build::bridge("src/main.rs")
 //!         .file("src/demo.cc")
 //!         .std("c++11")
 //!         .compile("cxxbridge-demo");
 //!
-//!     println!("cargo:rerun-if-changed=src/main.rs");
 //!     println!("cargo:rerun-if-changed=src/demo.cc");
 //!     println!("cargo:rerun-if-changed=include/demo.h");
 //! }
@@ -397,6 +397,9 @@ fn generate_bridge(prj: &Project, build: &mut Build, rust_source_file: &Path) ->
         doxygen: CFG.doxygen,
         ..Opt::default()
     };
+    if CFG.change_detection {
+        println!("cargo:rerun-if-changed={}", rust_source_file.display());
+    }
     let generated = gen::generate_from_path(rust_source_file, &opt);
     let ref rel_path = paths::local_relative_path(rust_source_file);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,12 +249,12 @@
 //! // build.rs
 //!
 //! fn main() {
+//!     cxx_build::CFG.change_detection = true;
 //!     cxx_build::bridge("src/main.rs")  // returns a cc::Build
 //!         .file("src/demo.cc")
 //!         .std("c++11")
 //!         .compile("cxxbridge-demo");
 //!
-//!     println!("cargo:rerun-if-changed=src/main.rs");
 //!     println!("cargo:rerun-if-changed=src/demo.cc");
 //!     println!("cargo:rerun-if-changed=include/demo.h");
 //! }


### PR DESCRIPTION
Adds `cargo:rerun-if-changed=<path>` for all files used by the bridge if the `CFG.change_detection` is `true`.

Per https://github.com/dtolnay/cxx/pull/1462#issuecomment-2704977488 
Fixes #1461