### PR TITLE
macro: ensure that cfg attrs are set for type alias verify generation

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1264,6 +1264,7 @@ fn expand_type_alias(alias: &TypeAlias) -> TokenStream {
 }
 
 fn expand_type_alias_verify(alias: &TypeAlias, types: &Types) -> TokenStream {
+    let attrs = &alias.attrs;
     let ident = &alias.name.rust;
     let type_id = type_id(&alias.name);
     let begin_span = alias.type_token.span;
@@ -1272,12 +1273,14 @@ fn expand_type_alias_verify(alias: &TypeAlias, types: &Types) -> TokenStream {
     let end = quote_spanned!(end_span=> >);
 
     let mut verify = quote! {
+        #attrs
         const _: fn() = #begin #ident, #type_id #end;
     };
 
     if types.required_trivial.contains_key(&alias.name.rust) {
         let begin = quote_spanned!(begin_span=> ::cxx::private::verify_extern_kind::<);
         verify.extend(quote! {
+            #attrs
             const _: fn() = #begin #ident, ::cxx::kind::Trivial #end;
         });
     }


### PR DESCRIPTION
```rust
mod ffi {
  unsafe extern "C++" {
    #[cfg(enabled)]
    type A = crate::A;
  }
}
```

When using the bridge above we need to ensure that all generated code also has the cfg attribute set. Before this change the following error would occur `cannot find type A in this scope`. This appears to be due to the generated verify block below that was not copying the attributes from the original type.

```rust
const _: fn() = ::cxx::private::verify_external_type::<A, ...>;
````

After this change the attributes are copied and therefore when the type is not compiled the verify block is also not compiled.