### PR TITLE
Added support for 'publish-to-bcr' tool

### DIFF
--- a/.bcr/README.md
+++ b/.bcr/README.md
@@ -1,0 +1,9 @@
+# Bazel Central Registry
+
+When the ruleset is released, we want it to be published to the
+Bazel Central Registry automatically:
+<https://registry.bazel.build>
+
+This folder contains configuration files to automate the publish step.
+See <https://github.com/bazel-contrib/publish-to-bcr/blob/main/templates/README.md>
+for authoritative documentation about these files.

--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,0 +1,5 @@
+fixedReleaser:
+  login: dtolnay
+  email: 1940490+dtolnay@users.noreply.github.com
+moduleRoots:
+  - "."

--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,15 @@
+{
+  "homepage": "https://cxx.rs/",
+  "maintainers": [
+      {
+          "email": "1940490+dtolnay@users.noreply.github.com",
+          "github": "dtolnay",
+          "name": "dtolnay"
+      }
+  ],
+  "repository": [
+      "github:dtolnay/cxx"
+  ],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,15 @@
+matrix:
+  platform:
+    - macos_arm64
+    - ubuntu2404
+    - windows
+  bazel: [7.x, 8.x]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - '//...'
+    test_targets:
+      - '//...'

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "**leave this alone**",
+  "strip_prefix": "",
+  "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{VERSION}.zip"
+}

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "cxx.rs",
-    version = "1.0.145",
+    version = "0.0.0",
     bazel_compatibility = [">=7.2.1"],
     compatibility_level = 1,
 )


### PR DESCRIPTION
This change should add all the necessary components to support [bazel-contrib/publish-to-bcr](https://github.com/bazel-contrib/publish-to-bcr). All @dtolnay would need to do is follow the directions for that tool to setup automatic Bazel Central Registry deploys. Which I think is forking https://github.com/bazelbuild/bazel-central-registry and adding the app to their github account.

closes https://github.com/dtolnay/cxx/issues/1095