### PR TITLE
Use a shorter Bazel output base for Windows CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,21 @@
+###############################################################################
+## Bazel Configuration Flags
+##
+## `.bazelrc` is a Bazel configuration file.
+## https://bazel.build/docs/best-practices#bazelrc-file
+###############################################################################
+
 build --enable_platform_specific_config
 build:linux --@rules_rust//:extra_rustc_flags=-Clink-arg=-fuse-ld=lld
 build:linux --cxxopt=-std=c++17
 build:macos --cxxopt=-std=c++17
+
+###############################################################################
+## Custom user flags
+##
+## This should always be the last thing in the `.bazelrc` file to ensure
+## consistent behavior when setting flags in that file as `.bazelrc` files are
+## evaluated top to bottom.
+###############################################################################
+
+try-import %workspace%/user.bazelrc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,11 +120,13 @@ jobs:
       - name: Install lld
         run: sudo apt-get install lld
         if: matrix.os == 'ubuntu'
+      - name: Setup Bazelrc (Windows)
+        run: |
+          echo "startup --output_user_root=D:/bzl" > ./user.bazelrc
+        if: startswith(runner.os, 'Windows')
       - run: bazel --version
       - run: bazel run demo --verbose_failures --noshow_progress ${{matrix.os == 'macos' && '--xcode_version_config=tools/bazel:github_actions_xcodes' || ''}}
-        continue-on-error: ${{matrix.os == 'windows'}}  # https://github.com/bazelbuild/bazel/issues/18592
       - run: bazel test ... --verbose_failures --noshow_progress ${{matrix.os == 'macos' && '--xcode_version_config=tools/bazel:github_actions_xcodes' || ''}}
-        continue-on-error: ${{matrix.os == 'windows'}}  # https://github.com/bazelbuild/bazel/issues/18592
       - name: Check MODULE.bazel.lock up to date
         run: git diff --exit-code
         if: matrix.os == 'ubuntu' || matrix.os == 'macos'

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /bazel-cxx
 /bazel-out
 /bazel-testlogs
+/user.bazelrc
 /buck-out
 /expand.cc
 /expand.rs

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "cxx.rs",
-    version = "1.0.145",
+    version = "0.0.0",
     bazel_compatibility = [">=7.2.1"],
     compatibility_level = 1,
 )


### PR DESCRIPTION
This addresses the following build failure which is caused by file paths being too long for MSVC tools (see https://github.com/bazelbuild/rules_rust/issues/1120 for some extra context):
```
ERROR: C:/users/runneradmin/_bazel_runneradmin/dzh43mlk/external/rules_rust+/util/process_wrapper/BUILD.bazel:31:36: Compiling Rust (without process_wrapper) bin process_wrapper (6 files) [for tool] failed: (Exit 1): bootstrap_process_wrapper.bat failed: error executing Rustc command (from target @@rules_rust+//util/process_wrapper:process_wrapper) 
  cd /d C:/users/runneradmin/_bazel_runneradmin/dzh43mlk/execroot/_main
  SET CARGO_CFG_TARGET_ARCH=x86_64
    SET CARGO_CFG_TARGET_OS=windows
    SET CARGO_CRATE_NAME=process_wrapper
    SET CARGO_MANIFEST_DIR=${pwd}/external/rules_rust+/util/process_wrapper
    SET CARGO_PKG_AUTHORS=
    SET CARGO_PKG_DESCRIPTION=
    SET CARGO_PKG_HOMEPAGE=
    SET CARGO_PKG_NAME=process_wrapper
    SET CARGO_PKG_VERSION=0.0.0
    SET CARGO_PKG_VERSION_MAJOR=0
    SET CARGO_PKG_VERSION_MINOR=0
    SET CARGO_PKG_VERSION_PATCH=0
    SET CARGO_PKG_VERSION_PRE=
    SET LIB=C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\ATLMFC\lib\x64;C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\lib\x64;C:\Program Files (x86)\Windows Kits\NETFXSDK\4.8\lib\um\x64;C:\Program Files (x86)\Windows Kits\10\lib\10.0.26100.0\ucrt\x64;C:\Program Files (x86)\Windows Kits\10\\lib\10.0.26100.0\\um\x64
    SET PATH=C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\bin\HostX64\x64;C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\VC\VCPackages;C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TestWindow;C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer;C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\bin\Roslyn;C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\x64\;C:\Program Files (x86)\HTML Help Workshop;C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools;C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Team Tools\DiagnosticsHub\Collector;C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\Microsoft\CodeCoverage.Console;C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\\x64;C:\Program Files (x86)\Windows Kits\10\bin\\x64;C:\Program Files\Microsoft Visual Studio\2022\Enterprise\\MSBuild\Current\Bin\amd64;C:\Windows\Microsoft.NET\Framework64\v4.0.30319;C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\;C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\;;C:\Windows\system32;C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\Llvm\x64\bin;C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin;C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja;C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\VC\Linux\bin\ConnectionManagerExe;C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\vcpkg
    SET REPOSITORY_NAME=rules_rust+
    SET RUNFILES_MANIFEST_ONLY=1
    SET TEMP=C:\Users\RUNNER~1\AppData\Local\Temp
    SET TMP=C:\Users\RUNNER~1\AppData\Local\Temp
  bazel-out\x64_windows-opt-exec-ST-d57f47055a04\bin\external\rules_rust+\util\process_wrapper\bootstrap_process_wrapper.bat -- bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust++rust+rw-1704990954_tools/rust_toolchain/bin/rustc.exe external/rules_rust+/util/process_wrapper/main.rs --crate-name=process_wrapper --crate-type=bin --error-format=human --out-dir=bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust+/util/process_wrapper --codegen=opt-level=3 --codegen=debuginfo=0 --codegen=strip=debuginfo --remap-path-prefix=${pwd}= --emit=link=bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust+/util/process_wrapper/process_wrapper.exe --emit=dep-info --color=always --target=x86_64-pc-windows-msvc -L bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust++rust+rw-1704990954_tools/rust_toolchain/lib/rustlib/x86_64-pc-windows-msvc/lib --edition=2018 -Cembed-bitcode=no --codegen=linker=C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.43.34808/bin/HostX64/x64/link.exe --codegen=link-arg=/nologo --codegen=link-arg=/SUBSYSTEM:CONSOLE --codegen=link-arg=/MACHINE:X64 --codegen=link-arg=/DEFAULTLIB:msvcrt.lib --codegen=link-arg=/OPT:ICF --codegen=link-arg=/OPT:REF --extern=tinyjson=bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust++i+rules_rust_tinyjson/libtinyjson-1317710085.rlib -Ldependency=bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust++i+rules_rust_tinyjson --sysroot=bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust++rust+rw-1704990954_tools/rust_toolchain
# Configuration: d3f5906e58e6716477ba73843c9ef0c54d37ff25267289a42ff1cb6522f01dd9
# Execution platform: @@platforms//host:host
error: linking with `C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.43.34808/bin/HostX64/x64/link.exe` failed: exit code: 1181
  |
  = note: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.43.34808/bin/HostX64/x64/link.exe" "/NOLOGO" "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\rustcGz2Sfj\\symbols.o" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust+/util/process_wrapper\\process_wrapper.process_wrapper.767a69550c8d4a26-cgu.00.rcgu.o" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust+/util/process_wrapper\\process_wrapper.process_wrapper.767a69550c8d4a26-cgu.01.rcgu.o" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust+/util/process_wrapper\\process_wrapper.process_wrapper.767a69550c8d4a26-cgu.02.rcgu.o" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust+/util/process_wrapper\\process_wrapper.process_wrapper.767a69550c8d4a26-cgu.03.rcgu.o" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust+/util/process_wrapper\\process_wrapper.process_wrapper.767a69550c8d4a26-cgu.04.rcgu.o" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust+/util/process_wrapper\\process_wrapper.process_wrapper.767a69550c8d4a26-cgu.05.rcgu.o" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust+/util/process_wrapper\\process_wrapper.process_wrapper.767a69550c8d4a26-cgu.06.rcgu.o" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust+/util/process_wrapper\\process_wrapper.process_wrapper.767a69550c8d4a26-cgu.07.rcgu.o" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust+/util/process_wrapper\\process_wrapper.process_wrapper.767a69550c8d4a26-cgu.08.rcgu.o" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust+/util/process_wrapper\\process_wrapper.process_wrapper.767a69550c8d4a26-cgu.09.rcgu.o" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust+/util/process_wrapper\\process_wrapper.process_wrapper.767a69550c8d4a26-cgu.10.rcgu.o" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust+/util/process_wrapper\\process_wrapper.process_wrapper.767a69550c8d4a26-cgu.11.rcgu.o" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust+/util/process_wrapper\\process_wrapper.process_wrapper.767a69550c8d4a26-cgu.12.rcgu.o" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust+/util/process_wrapper\\process_wrapper.process_wrapper.767a69550c8d4a26-cgu.13.rcgu.o" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust+/util/process_wrapper\\process_wrapper.process_wrapper.767a69550c8d4a26-cgu.14.rcgu.o" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust+/util/process_wrapper\\process_wrapper.process_wrapper.767a69550c8d4a26-cgu.15.rcgu.o" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust+/util/process_wrapper\\process_wrapper.479b5e2tponqsko31tg7td3o0.rcgu.o" "C:\\Users\\runneradmin\\_bazel_runneradmin\\dzh43mlk\\execroot\\_main\\bazel-out\\x64_windows-opt-exec-ST-d57f47055a04\\bin\\external\\rules_rust++i+rules_rust_tinyjson\\libtinyjson-1317710085.rlib" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust++rust+rw-1704990954_tools/rust_toolchain\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\libstd-e874d2af854a1269.rlib" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust++rust+rw-1704990954_tools/rust_toolchain\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\libpanic_unwind-37750157ed47e215.rlib" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust++rust+rw-1704990954_tools/rust_toolchain\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\libwindows_targets-7e6fdb6e54c1cbdc.rlib" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust++rust+rw-1704990954_tools/rust_toolchain\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\librustc_demangle-cd9390cbc5edb100.rlib" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust++rust+rw-1704990954_tools/rust_toolchain\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\libstd_detect-dff6af350245e14e.rlib" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust++rust+rw-1704990954_tools/rust_toolchain\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\libhashbrown-941aa78eb62d6991.rlib" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust++rust+rw-1704990954_tools/rust_toolchain\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\librustc_std_workspace_alloc-2cc5ffc24865e22c.rlib" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust++rust+rw-1704990954_tools/rust_toolchain\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\libunwind-be7fc3551dfe972e.rlib" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust++rust+rw-1704990954_tools/rust_toolchain\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\libcfg_if-a64673ac839c7aad.rlib" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust++rust+rw-1704990954_tools/rust_toolchain\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\liballoc-25a1d317141d196e.rlib" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust++rust+rw-1704990954_tools/rust_toolchain\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\librustc_std_workspace_core-41d63ab94baafa04.rlib" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust++rust+rw-1704990954_tools/rust_toolchain\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\libcore-b553d9e1000b8b90.rlib" "bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust++rust+rw-1704990954_tools/rust_toolchain\\lib\\rustlib\\x86_64-pc-windows-msvc\\lib\\libcompiler_builtins-a1285e9d3fe56144.rlib" "kernel32.lib" "kernel32.lib" "advapi32.lib" "ntdll.lib" "userenv.lib" "ws2_32.lib" "dbghelp.lib" "/defaultlib:msvcrt" "/NXCOMPAT" "/LIBPATH:bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust++rust+rw-1704990954_tools/rust_toolchain/lib/rustlib/x86_64-pc-windows-msvc/lib" "/OUT:bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/rules_rust+/util/process_wrapper/process_wrapper.exe" "/OPT:REF,ICF" "/DEBUG" "/PDBALTPATH:%_PDB%" "/nologo" "/SUBSYSTEM:CONSOLE" "/MACHINE:X64" "/DEFAULTLIB:msvcrt.lib" "/OPT:ICF" "/OPT:REF"
  = note: LINK : fatal error LNK1181: cannot open input file 'bazel-out\x64_windows-opt-exec-ST-d57f47055a04\bin\external\rules_rust++rust+rw-1704990954_tools\rust_toolchain\lib\rustlib\x86_64-pc-windows-msvc\lib\librustc_std_workspace_alloc-2cc5ffc24865e22c.rlib'␍
```