### PR TITLE
Align Bazel preferred linkages with Buck

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -51,6 +51,7 @@ cc_library(
     name = "core-lib",
     srcs = ["src/cxx.cc"],
     hdrs = ["include/cxx.h"],
+    linkstatic = True,
 )
 
 rust_proc_macro(

--- a/demo/BUILD.bazel
+++ b/demo/BUILD.bazel
@@ -22,6 +22,7 @@ rust_cxx_bridge(
 cc_library(
     name = "blobstore-sys",
     srcs = ["src/blobstore.cc"],
+    linkstatic = True,
     deps = [
         ":blobstore-include",
         ":bridge/include",

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -37,6 +37,7 @@ cc_library(
         ":module/source",
     ],
     hdrs = ["ffi/tests.h"],
+    linkstatic = True,
     deps = [
         ":bridge/include",
         ":module/include",

--- a/tools/bazel/rust_cxx_bridge.bzl
+++ b/tools/bazel/rust_cxx_bridge.bzl
@@ -3,7 +3,7 @@
 load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
-def rust_cxx_bridge(name, src, deps = [], **kwargs):
+def rust_cxx_bridge(name, src, deps = [], linkstatic = True, **kwargs):
     """A macro defining a cxx bridge library
 
     Args:
@@ -46,6 +46,7 @@ def rust_cxx_bridge(name, src, deps = [], **kwargs):
         name = name,
         srcs = [src + ".cc"],
         deps = deps + [":%s/include" % name],
+        linkstatic = linkstatic,
         **kwargs
     )
 


### PR DESCRIPTION
Everywhere that Buck is using `preferred_linkage = "static"`, Bazel is going to need `linkstatic = True` for the same reason. This matches Cargo as well, which statically links C dependencies into the same crate whose build.rs builds them.