### PR TITLE
chore: cleanup a few format args

### DIFF
--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -48,7 +48,7 @@ fn main() {
     let chunks = vec![b"fearless".to_vec(), b"concurrency".to_vec()];
     let mut buf = MultiBuf { chunks, pos: 0 };
     let blobid = client.put(&mut buf);
-    println!("blobid = {}", blobid);
+    println!("blobid = {blobid}");
 
     // Add a tag.
     client.tag(blobid, "rust");

--- a/macro/src/derive.rs
+++ b/macro/src/derive.rs
@@ -262,7 +262,7 @@ fn enum_debug(enm: &Enum, span: Span) -> TokenStream {
             #ident::#variant => formatter.write_str(#name),
         }
     });
-    let fallback = format!("{}({{}})", ident);
+    let fallback = format!("{ident}({{}})");
 
     quote_spanned! {span=>
         #[automatically_derived]

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1301,9 +1301,9 @@ fn expand_rust_box(key: NamedImplKey, types: &Types, explicit_impl: Option<&Impl
     let ident = key.rust;
     let resolve = types.resolve(ident);
     let link_prefix = format!("cxxbridge1$box${}$", resolve.name.to_symbol());
-    let link_alloc = format!("{}alloc", link_prefix);
-    let link_dealloc = format!("{}dealloc", link_prefix);
-    let link_drop = format!("{}drop", link_prefix);
+    let link_alloc = format!("{link_prefix}alloc");
+    let link_dealloc = format!("{link_prefix}dealloc");
+    let link_drop = format!("{link_prefix}drop");
 
     let local_prefix = format_ident!("{}__box_", ident);
     let local_alloc = format_ident!("{}alloc", local_prefix);
@@ -1315,7 +1315,7 @@ fn expand_rust_box(key: NamedImplKey, types: &Types, explicit_impl: Option<&Impl
     let begin_span = explicit_impl.map_or(key.begin_span, |explicit| explicit.impl_token.span);
     let end_span = explicit_impl.map_or(key.end_span, |explicit| explicit.brace_token.span.join());
     let unsafe_token = format_ident!("unsafe", span = begin_span);
-    let prevent_unwind_drop_label = format!("::{} as Drop>::drop", ident);
+    let prevent_unwind_drop_label = format!("::{ident} as Drop>::drop");
 
     quote_spanned! {end_span=>
         #[automatically_derived]
@@ -1350,14 +1350,14 @@ fn expand_rust_vec(key: NamedImplKey, types: &Types, explicit_impl: Option<&Impl
     let elem = key.rust;
     let resolve = types.resolve(elem);
     let link_prefix = format!("cxxbridge1$rust_vec${}$", resolve.name.to_symbol());
-    let link_new = format!("{}new", link_prefix);
-    let link_drop = format!("{}drop", link_prefix);
-    let link_len = format!("{}len", link_prefix);
-    let link_capacity = format!("{}capacity", link_prefix);
-    let link_data = format!("{}data", link_prefix);
-    let link_reserve_total = format!("{}reserve_total", link_prefix);
-    let link_set_len = format!("{}set_len", link_prefix);
-    let link_truncate = format!("{}truncate", link_prefix);
+    let link_new = format!("{link_prefix}new");
+    let link_drop = format!("{link_prefix}drop");
+    let link_len = format!("{link_prefix}len");
+    let link_capacity = format!("{link_prefix}capacity");
+    let link_data = format!("{link_prefix}data");
+    let link_reserve_total = format!("{link_prefix}reserve_total");
+    let link_set_len = format!("{link_prefix}set_len");
+    let link_truncate = format!("{link_prefix}truncate");
 
     let local_prefix = format_ident!("{}__vec_", elem);
     let local_new = format_ident!("{}new", local_prefix);
@@ -1374,7 +1374,7 @@ fn expand_rust_vec(key: NamedImplKey, types: &Types, explicit_impl: Option<&Impl
     let begin_span = explicit_impl.map_or(key.begin_span, |explicit| explicit.impl_token.span);
     let end_span = explicit_impl.map_or(key.end_span, |explicit| explicit.brace_token.span.join());
     let unsafe_token = format_ident!("unsafe", span = begin_span);
-    let prevent_unwind_drop_label = format!("::{} as Drop>::drop", elem);
+    let prevent_unwind_drop_label = format!("::{elem} as Drop>::drop");
 
     quote_spanned! {end_span=>
         #[automatically_derived]
@@ -1452,12 +1452,12 @@ fn expand_unique_ptr(
     let name = ident.to_string();
     let resolve = types.resolve(ident);
     let prefix = format!("cxxbridge1$unique_ptr${}$", resolve.name.to_symbol());
-    let link_null = format!("{}null", prefix);
-    let link_uninit = format!("{}uninit", prefix);
-    let link_raw = format!("{}raw", prefix);
-    let link_get = format!("{}get", prefix);
-    let link_release = format!("{}release", prefix);
-    let link_drop = format!("{}drop", prefix);
+    let link_null = format!("{prefix}null");
+    let link_uninit = format!("{prefix}uninit");
+    let link_raw = format!("{prefix}raw");
+    let link_get = format!("{prefix}get");
+    let link_release = format!("{prefix}release");
+    let link_drop = format!("{prefix}drop");
 
     let (impl_generics, ty_generics) = generics::split_for_impl(key, explicit_impl, resolve);
 
@@ -1549,11 +1549,11 @@ fn expand_shared_ptr(
     let name = ident.to_string();
     let resolve = types.resolve(ident);
     let prefix = format!("cxxbridge1$shared_ptr${}$", resolve.name.to_symbol());
-    let link_null = format!("{}null", prefix);
-    let link_uninit = format!("{}uninit", prefix);
-    let link_clone = format!("{}clone", prefix);
-    let link_get = format!("{}get", prefix);
-    let link_drop = format!("{}drop", prefix);
+    let link_null = format!("{prefix}null");
+    let link_uninit = format!("{prefix}uninit");
+    let link_clone = format!("{prefix}clone");
+    let link_get = format!("{prefix}get");
+    let link_drop = format!("{prefix}drop");
 
     let (impl_generics, ty_generics) = generics::split_for_impl(key, explicit_impl, resolve);
 
@@ -1628,11 +1628,11 @@ fn expand_weak_ptr(key: NamedImplKey, types: &Types, explicit_impl: Option<&Impl
     let name = ident.to_string();
     let resolve = types.resolve(ident);
     let prefix = format!("cxxbridge1$weak_ptr${}$", resolve.name.to_symbol());
-    let link_null = format!("{}null", prefix);
-    let link_clone = format!("{}clone", prefix);
-    let link_downgrade = format!("{}downgrade", prefix);
-    let link_upgrade = format!("{}upgrade", prefix);
-    let link_drop = format!("{}drop", prefix);
+    let link_null = format!("{prefix}null");
+    let link_clone = format!("{prefix}clone");
+    let link_downgrade = format!("{prefix}downgrade");
+    let link_upgrade = format!("{prefix}upgrade");
+    let link_drop = format!("{prefix}drop");
 
     let (impl_generics, ty_generics) = generics::split_for_impl(key, explicit_impl, resolve);
 
@@ -1704,20 +1704,20 @@ fn expand_cxx_vector(
     let name = elem.to_string();
     let resolve = types.resolve(elem);
     let prefix = format!("cxxbridge1$std$vector${}$", resolve.name.to_symbol());
-    let link_new = format!("{}new", prefix);
-    let link_size = format!("{}size", prefix);
-    let link_get_unchecked = format!("{}get_unchecked", prefix);
-    let link_push_back = format!("{}push_back", prefix);
-    let link_pop_back = format!("{}pop_back", prefix);
+    let link_new = format!("{prefix}new");
+    let link_size = format!("{prefix}size");
+    let link_get_unchecked = format!("{prefix}get_unchecked");
+    let link_push_back = format!("{prefix}push_back");
+    let link_pop_back = format!("{prefix}pop_back");
     let unique_ptr_prefix = format!(
         "cxxbridge1$unique_ptr$std$vector${}$",
         resolve.name.to_symbol(),
     );
-    let link_unique_ptr_null = format!("{}null", unique_ptr_prefix);
-    let link_unique_ptr_raw = format!("{}raw", unique_ptr_prefix);
-    let link_unique_ptr_get = format!("{}get", unique_ptr_prefix);
-    let link_unique_ptr_release = format!("{}release", unique_ptr_prefix);
-    let link_unique_ptr_drop = format!("{}drop", unique_ptr_prefix);
+    let link_unique_ptr_null = format!("{unique_ptr_prefix}null");
+    let link_unique_ptr_raw = format!("{unique_ptr_prefix}raw");
+    let link_unique_ptr_get = format!("{unique_ptr_prefix}get");
+    let link_unique_ptr_release = format!("{unique_ptr_prefix}release");
+    let link_unique_ptr_drop = format!("{unique_ptr_prefix}drop");
 
     let (impl_generics, ty_generics) = generics::split_for_impl(key, explicit_impl, resolve);
 

--- a/macro/src/load.rs
+++ b/macro/src/load.rs
@@ -44,10 +44,7 @@ pub(crate) fn load(cx: &mut Errors, apis: &mut [Api]) {
     let ast_dump_path = match env::var_os(CXX_CLANG_AST) {
         Some(ast_dump_path) => PathBuf::from(ast_dump_path),
         None => {
-            let msg = format!(
-                "environment variable ${} has not been provided",
-                CXX_CLANG_AST,
-            );
+            let msg = format!("environment variable ${CXX_CLANG_AST} has not been provided");
             return cx.error(span, msg);
         }
     };
@@ -89,7 +86,7 @@ pub(crate) fn load(cx: &mut Errors, apis: &mut [Api]) {
         if enm.variants.is_empty() {
             let span = &enm.variants_from_header_attr;
             let name = CxxName(&enm.name);
-            let msg = format!("failed to find any C++ definition of enum {}", name);
+            let msg = format!("failed to find any C++ definition of enum {name}");
             cx.error(span, msg);
         }
     }
@@ -121,7 +118,7 @@ fn traverse<'a>(
                     if !enm.variants.is_empty() {
                         let span = &enm.variants_from_header_attr;
                         let qual_name = CxxName(&enm.name);
-                        let msg = format!("found multiple C++ definitions of enum {}", qual_name);
+                        let msg = format!("found multiple C++ definitions of enum {qual_name}");
                         cx.error(span, msg);
                         return;
                     }
@@ -130,8 +127,7 @@ fn traverse<'a>(
                         let name = &enm.name.cxx;
                         let qual_name = CxxName(&enm.name);
                         let msg = format!(
-                            "implicit implementation-defined repr for enum {} is not supported yet; consider changing its C++ definition to `enum {}: int {{...}}",
-                            qual_name, name,
+                            "implicit implementation-defined repr for enum {qual_name} is not supported yet; consider changing its C++ definition to `enum {name}: int {{...}}",
                         );
                         cx.error(span, msg);
                         return;
@@ -239,10 +235,7 @@ fn translate_qual_type(cx: &mut Errors, enm: &Enum, qual_type: &str) -> Path {
         unsupported => {
             let span = &enm.variants_from_header_attr;
             let qual_name = CxxName(&enm.name);
-            let msg = format!(
-                "unsupported underlying type for {}: {}",
-                qual_name, unsupported,
-            );
+            let msg = format!("unsupported underlying type for {qual_name}: {unsupported}");
             cx.error(span, msg);
             "c_int"
         }
@@ -302,7 +295,7 @@ struct CxxName<'a>(&'a Pair);
 impl<'a> Display for CxxName<'a> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         for namespace in &self.0.namespace {
-            write!(formatter, "{}::", namespace)?;
+            write!(formatter, "{namespace}::")?;
         }
         write!(formatter, "{}", self.0.cxx)
     }

--- a/src/cxx_vector.rs
+++ b/src/cxx_vector.rs
@@ -333,7 +333,7 @@ where
 /// {
 ///     println!("the vector elements are:");
 ///     for element in vector {
-///         println!("  • {}", element);
+///         println!("  • {element}");
 ///     }
 /// }
 /// ```

--- a/src/lossy.rs
+++ b/src/lossy.rs
@@ -56,7 +56,7 @@ pub(crate) fn debug(mut bytes: &[u8], f: &mut fmt::Formatter) -> fmt::Result {
                     bytes.len()
                 };
                 for b in &bytes[valid.len()..end_of_broken] {
-                    write!(f, "\\x{:02x}", b)?;
+                    write!(f, "\\x{b:02x}")?;
                 }
                 bytes = &bytes[end_of_broken..];
             }

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -87,7 +87,7 @@ fn check_type_ident(cx: &mut Check, name: &NamedType) {
         && !cx.types.cxx.contains(ident)
         && !cx.types.rust.contains(ident)
     {
-        let msg = format!("unsupported type: {}", ident);
+        let msg = format!("unsupported type: {ident}");
         cx.error(ident, msg);
     }
 }
@@ -237,8 +237,7 @@ fn check_type_ref(cx: &mut Check, ty: &Ref) {
             cx.error(
                 ty,
                 format!(
-                    "mutable reference to C++ type requires a pin -- use Pin<&mut {}>",
-                    requires_pin,
+                    "mutable reference to C++ type requires a pin -- use Pin<&mut {requires_pin}>",
                 ),
             );
         }
@@ -280,7 +279,7 @@ fn check_type_slice_ref(cx: &mut Check, ty: &SliceRef) {
 
     if !supported {
         let mutable = if ty.mutable { "mut " } else { "" };
-        let mut msg = format!("unsupported &{}[T] element type", mutable);
+        let mut msg = format!("unsupported &{mutable}[T] element type");
         if let Type::Ident(ident) = &ty.inner {
             if is_opaque_cxx(cx, &ident.rust) {
                 msg += ": opaque C++ type is not supported yet";
@@ -334,7 +333,7 @@ fn check_api_struct(cx: &mut Check, strct: &Struct) {
 
     for derive in &strct.derives {
         if derive.what == Trait::ExternType {
-            let msg = format!("derive({}) on shared struct is not supported", derive);
+            let msg = format!("derive({derive}) on shared struct is not supported");
             cx.error(derive, msg);
         }
     }
@@ -347,7 +346,7 @@ fn check_api_struct(cx: &mut Check, strct: &Struct) {
             );
         } else if is_unsized(cx, &field.ty) {
             let desc = describe(cx, &field.ty);
-            let msg = format!("using {} by value is not supported", desc);
+            let msg = format!("using {desc} by value is not supported");
             cx.error(field, msg);
         }
     }
@@ -367,7 +366,7 @@ fn check_api_enum(cx: &mut Check, enm: &Enum) {
 
     for derive in &enm.derives {
         if derive.what == Trait::Default || derive.what == Trait::ExternType {
-            let msg = format!("derive({}) on shared enum is not supported", derive);
+            let msg = format!("derive({derive}) on shared enum is not supported");
             cx.error(derive, msg);
         }
     }
@@ -385,10 +384,7 @@ fn check_api_type(cx: &mut Check, ety: &ExternType) {
             Lang::Rust => "Rust",
             Lang::Cxx => "C++",
         };
-        let msg = format!(
-            "derive({}) on opaque {} type is not supported yet",
-            derive, lang,
-        );
+        let msg = format!("derive({derive}) on opaque {lang} type is not supported yet");
         cx.error(derive, msg);
     }
 
@@ -480,7 +476,7 @@ fn check_api_fn(cx: &mut Check, efn: &ExternFn) {
             }
         } else if is_unsized(cx, &arg.ty) {
             let desc = describe(cx, &arg.ty);
-            let msg = format!("passing {} by value is not supported", desc);
+            let msg = format!("passing {desc} by value is not supported");
             cx.error(arg, msg);
         }
     }
@@ -490,7 +486,7 @@ fn check_api_fn(cx: &mut Check, efn: &ExternFn) {
             cx.error(ty, "returning a function pointer is not implemented yet");
         } else if is_unsized(cx, ty) {
             let desc = describe(cx, ty);
-            let msg = format!("returning {} by value is not supported", desc);
+            let msg = format!("returning {desc} by value is not supported");
             cx.error(ty, msg);
         }
     }
@@ -504,7 +500,7 @@ fn check_api_type_alias(cx: &mut Check, alias: &TypeAlias) {
     check_lifetimes(cx, &alias.generics);
 
     for derive in &alias.derives {
-        let msg = format!("derive({}) on extern type alias is not supported", derive);
+        let msg = format!("derive({derive}) on extern type alias is not supported");
         cx.error(derive, msg);
     }
 }

--- a/syntax/discriminant.rs
+++ b/syntax/discriminant.rs
@@ -44,8 +44,7 @@ impl DiscriminantSet {
                             continue;
                         }
                         let msg = format!(
-                            "discriminant value `{}` is outside the limits of {}",
-                            past, new_repr,
+                            "discriminant value `{past}` is outside the limits of {new_repr}",
                         );
                         return Err(Error::new(Span::call_site(), msg));
                     }
@@ -53,7 +52,7 @@ impl DiscriminantSet {
                 self.repr = Some(new_repr);
             }
             (Some(prev), Some(repr)) if prev != repr => {
-                let msg = format!("expected {}, found {}", prev, repr);
+                let msg = format!("expected {prev}, found {repr}");
                 return Err(Error::new(Span::call_site(), msg));
             }
             _ => {}
@@ -136,8 +135,7 @@ fn insert(set: &mut DiscriminantSet, discriminant: Discriminant) -> Result<Discr
         if let Some(limits) = Limits::of(expected_repr) {
             if discriminant < limits.min || limits.max < discriminant {
                 let msg = format!(
-                    "discriminant value `{}` is outside the limits of {}",
-                    discriminant, expected_repr,
+                    "discriminant value `{discriminant}` is outside the limits of {expected_repr}",
                 );
                 return Err(Error::new(Span::call_site(), msg));
             }
@@ -269,7 +267,7 @@ fn parse_int_suffix(suffix: &str) -> Result<Option<Atom>> {
             _ => {}
         }
     }
-    let msg = format!("unrecognized integer suffix: `{}`", suffix);
+    let msg = format!("unrecognized integer suffix: `{suffix}`");
     Err(Error::new(Span::call_site(), msg))
 }
 

--- a/syntax/namespace.rs
+++ b/syntax/namespace.rs
@@ -84,7 +84,7 @@ impl Parse for Namespace {
 impl Display for Namespace {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for segment in self {
-            write!(f, "{}$", segment)?;
+            write!(f, "{segment}$")?;
         }
         Ok(())
     }

--- a/syntax/qualified.rs
+++ b/syntax/qualified.rs
@@ -43,8 +43,7 @@ fn parse_unquoted(input: ParseStream, allow_raw: bool) -> Result<QualifiedName> 
         if let Some(unraw) = ident.to_string().strip_prefix("r#") {
             if !allow_raw {
                 let msg = format!(
-                    "raw identifier `{}` is not allowed in a quoted namespace; use `{}`, or remove quotes",
-                    ident, unraw,
+                    "raw identifier `{ident}` is not allowed in a quoted namespace; use `{unraw}`, or remove quotes",
                 );
                 return Err(Error::new(ident.span(), msg));
             }

--- a/syntax/resolve.rs
+++ b/syntax/resolve.rs
@@ -13,7 +13,7 @@ impl<'a> Types<'a> {
         let ident = ident.ident();
         match self.try_resolve(ident) {
             Some(resolution) => resolution,
-            None => panic!("Unable to resolve type `{}`", ident),
+            None => panic!("Unable to resolve type `{ident}`"),
         }
     }
 

--- a/syntax/symbol.rs
+++ b/syntax/symbol.rs
@@ -26,7 +26,7 @@ impl Symbol {
         if !self.0.is_empty() {
             self.0.push('$');
         }
-        self.0.write_fmt(format_args!("{}", segment)).unwrap();
+        self.0.write_fmt(format_args!("{segment}")).unwrap();
         assert!(self.0.len() > len_before);
     }
 

--- a/syntax/trivial.rs
+++ b/syntax/trivial.rs
@@ -271,12 +271,12 @@ pub(crate) fn as_what<'a>(name: &'a Pair, reasons: &'a [TrivialReason]) -> impl 
                     desc,
                     set,
                 } => {
-                    write!(f, "{} ", desc)?;
+                    write!(f, "{desc} ")?;
                     for (i, ident) in set.iter().take(3).enumerate() {
                         if i > 0 {
                             write!(f, ", ")?;
                         }
-                        write!(f, "`{}`", ident)?;
+                        write!(f, "`{ident}`")?;
                     }
                     Ok(())
                 }
@@ -292,7 +292,7 @@ pub(crate) fn as_what<'a>(name: &'a Pair, reasons: &'a [TrivialReason]) -> impl 
                     mutable,
                     param,
                 } => {
-                    write!(f, "{} ", desc)?;
+                    write!(f, "{desc} ")?;
                     if *shared {
                         write!(f, "&[{}]", param.rust)?;
                     }

--- a/syntax/types.rs
+++ b/syntax/types.rs
@@ -280,6 +280,6 @@ impl<'t, 'a> IntoIterator for &'t Types<'a> {
 }
 
 fn duplicate_name(cx: &mut Errors, sp: impl ToTokens, ident: &Ident) {
-    let msg = format!("the name `{}` is defined multiple times", ident);
+    let msg = format!("the name `{ident}` is defined multiple times");
     cx.error(sp, msg);
 }


### PR DESCRIPTION
Make some code a bit more readable with inlined format args (some code is already using them, so might as well do some more now that the 2021 edition is everywhere)

Some readability examples:

```rust
format!("{}({{}})", ident);   /* --> */  format!("{ident}({{}})");
```