### PR TITLE
Add strip_prefix to unblock automated Bazel module publish

### DIFF
--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "**leave this alone**",
-  "strip_prefix": "",
+  "strip_prefix": "cxx-{VERSION}",
   "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{VERSION}.zip"
 }

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "**leave this alone**",
-  "strip_prefix": "cxx-{VERSION}",
+  "strip_prefix": "{REPO}-{VERSION}",
   "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{VERSION}.zip"
 }


### PR DESCRIPTION
Automated publishing of this module to the Bazel Central Registry is currently blocked with an error stating that MODULE.bazel can not be found. When I try to use `archive_override` to consume the published artifact for 1.0.146 I need to add `strip_prefix = "cxx-1.0.146"` to get around this same error. Adding that to the source.json template should fix the issue.