### PR TITLE
Delete redundant moduleRoots from bcr config

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,5 +1,3 @@
 fixedReleaser:
   login: dtolnay
   email: dtolnay@gmail.com
-moduleRoots:
-  - "."


### PR DESCRIPTION
`["."]` is the default according to https://github.com/bazel-contrib/publish-to-bcr/tree/fa7d3c8ad241c2c0cde639eb2225be55816e9565/templates#optional-configyml