### PR TITLE
Add GitHub workflow to upload release archives with stable hash

### DIFF
--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "**leave this alone**",
   "strip_prefix": "{REPO}-{VERSION}",
-  "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{VERSION}.zip"
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{VERSION}/{REPO}-{VERSION}.tar.gz"
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Upload Release Archive
+        run: |
+          export ASSET_NAME=${{github.event.repository.name}}-${{github.ref_name}}.tar.gz
+          git ls-tree -r --name-only HEAD | xargs tar --transform "s#^#${{github.event.repository.name}}-${{github.event.release.tag_name}}/#" -czf $ASSET_NAME
+          gh release upload ${{github.ref_name}} $ASSET_NAME


### PR DESCRIPTION
This is required as mitigation for <https://blog.bazel.build/2023/02/15/github-archive-checksum.html>. The GitHub-generated `/archives/refs/tags` source archives are not guaranteed to have a stable checksum over time.