### PR TITLE
Supply GitHub token to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,3 +18,5 @@ jobs:
           export ASSET_NAME=${{github.event.repository.name}}-${{github.ref_name}}.tar.gz
           git ls-tree -r --name-only HEAD | xargs tar --transform "s#^#${{github.event.repository.name}}-${{github.event.release.tag_name}}/#" -czf $ASSET_NAME
           gh release upload ${{github.ref_name}} $ASSET_NAME
+        env:
+          GH_TOKEN: ${{github.token}}


### PR DESCRIPTION
https://github.com/dtolnay/cxx/actions/runs/13874499046/job/38825113504

```console
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
```