### PR TITLE
Account for source tar filepaths surpassing xargs size limit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Package sources into tar.gz
-        run: git ls-tree -r --name-only HEAD | xargs tar --transform "s#^#${{github.event.repository.name}}-${{github.event.release.tag_name}}/#" -czf ${{github.event.repository.name}}-${{github.ref_name}}.tar.gz
+        run: git ls-tree -r --name-only HEAD | tar --files-from=- --transform "s#^#${{github.event.repository.name}}-${{github.event.release.tag_name}}/#" -czf ${{github.event.repository.name}}-${{github.ref_name}}.tar.gz
       - name: Upload release archive
         run: gh release upload ${{github.ref_name}} ${{github.event.repository.name}}-${{github.ref_name}}.tar.gz
         env:


### PR DESCRIPTION
With `xargs tar`, xargs might decide to split stdin across multiple tar commands. Since each of those would have the same `-f`, the final tgz will contain only paths from the last tar invocation, and could be silently missing contents.