### PR TITLE
Do not apply tar transform to symbolic link targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Package sources into tar.gz
-        run: git ls-tree -r --name-only HEAD | tar --files-from=- --transform="s:^:${{github.event.repository.name}}-${{github.event.release.tag_name}}/:" --create --gzip --file=${{github.event.repository.name}}-${{github.ref_name}}.tar.gz
+        run: git ls-tree -r --name-only HEAD | tar --files-from=- --transform="flags=r;s:^:${{github.event.repository.name}}-${{github.event.release.tag_name}}/:" --create --gzip --file=${{github.event.repository.name}}-${{github.ref_name}}.tar.gz
       - name: Upload release archive
         run: gh release upload ${{github.ref_name}} ${{github.event.repository.name}}-${{github.ref_name}}.tar.gz
         env:


### PR DESCRIPTION
Reference: https://www.gnu.org/software/tar/manual/html_section/transform.html
_"Default is ‘rsh’, which means to apply transformations to both archive members and targets of symbolic and hard links."_

**Before:**

```console
$ tar xf cxx-1.0.148.tar.gz 
$ readlink cxx-1.0.148/flags/LICENSE-MIT
cxx-1.0.148/../LICENSE-MIT
```

**After:**

```console
$ tar xf cxx-1.0.148.tar.gz 
$ readlink cxx-1.0.148/flags/LICENSE-MIT
../LICENSE-MIT
```

Fixes https://github.com/bazelbuild/bazel-central-registry/pull/4055#issuecomment-2730277281.