### PR TITLE
Add an explicit conversion operator from `rust::Str` to `std::string_view`.

### DIFF
--- a/book/src/binding/str.md
+++ b/book/src/binding/str.md
@@ -25,6 +25,9 @@ public:
   Str &operator=(const Str &) & noexcept;
 
   explicit operator std::string() const;
+#if __cplusplus >= 201703L
+  explicit operator std::string_view() const;
+#endif
 
   // Note: no null terminator.
   const char *data() const noexcept;

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -9,9 +9,6 @@
 #include <iosfwd>
 #include <iterator>
 #include <new>
-#if __cplusplus >= 202002L
-#include <ranges>
-#endif
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -21,6 +18,14 @@
 #include <basetsd.h>
 #else
 #include <sys/types.h>
+#endif
+
+#if __cplusplus >= 201703L
+#include <string_view>
+#endif
+
+#if __cplusplus >= 202002L
+#include <ranges>
 #endif
 
 namespace rust {
@@ -123,6 +128,9 @@ public:
   Str &operator=(const Str &) & noexcept = default;
 
   explicit operator std::string() const;
+#if __cplusplus >= 201703L
+  explicit operator std::string_view() const;
+#endif
 
   // Note: no null terminator.
   const char *data() const noexcept;

--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -325,6 +325,12 @@ Str::operator std::string() const {
   return std::string(this->data(), this->size());
 }
 
+#if __cplusplus >= 201703L
+Str::operator std::string_view() const {
+  return std::string_view(this->data(), this->size());
+}
+#endif
+
 const char *Str::data() const noexcept { return cxxbridge1$str$ptr(this); }
 
 std::size_t Str::size() const noexcept { return cxxbridge1$str$len(this); }

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -874,6 +874,11 @@ extern "C" const char *cxx_run_test() noexcept {
     rust::Str out_param;
     r_return_str_via_out_param(Shared{2020}, out_param);
     ASSERT(out_param == "2020");
+
+#if __cplusplus >= 201703L
+    std::string_view out_param_as_string_view{out_param};
+    ASSERT(out_param_as_string_view == "2020");
+#endif
   }
 
   rust::Str cstr = "test";


### PR DESCRIPTION
PTAL?

I am aware of https://github.com/dtolnay/cxx/pull/80 (adding a way to construct `rust::Str` from `std::string_view`, using a custom C++17-detection mechanism) and https://github.com/dtolnay/cxx/pull/410 (adding a way to construct `rust::String` from `std::string_view`, also using a custom C++17 detection mechanism).  But maybe we can still proceed with this PR given that:

* This PR is relatively simple - just adds one member (a conversion operator) to `rust::Str`.  I _think_ that adding such an **explicit** operator has close to zero risk of breaking existing users (unlike the other PRs where new constructor overloads may risk ambiguity or other resolution problems)
* Since the other PRs were raised, we were able to proceed with other C++-version-dependent APIs:
    - https://github.com/dtolnay/cxx/pull/1432 added a (C++-20-specific) way to convert `rust::Slice` into Chromium's `base::span` (which needed `rust::Slice` to expose a different `iterator_category` in C++20 than in earlier versions).
    - https://github.com/dtolnay/cxx/pull/1437 added CI coverage for different C++ versions.

FWIW I've also noticed https://github.com/dtolnay/cxx/commit/5ae3a93b425abb2205e718302a033c688260f639 where `#if __cplusplus >= 202002L` was replaced with `#ifdef __cpp_char8_t`.  IIUC this is using https://en.cppreference.com/w/cpp/utility/feature_test which are available in C++20 and later.  So I think we can't do that in this PR.