### PR TITLE
Consistently use github.event.release.tag_name over github.ref_name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Package sources into tar.gz
-        run: git ls-tree -r -z --name-only HEAD | tar --null --files-from=- --transform="flags=r;s:^:${{github.event.repository.name}}-${{github.event.release.tag_name}}/:" --sort=name --mtime=2030-01-01T00:00:00Z --owner=0 --group=0 --numeric-owner --create --gzip --file=${{github.event.repository.name}}-${{github.ref_name}}.tar.gz
+        run: git ls-tree -r -z --name-only HEAD | tar --null --files-from=- --transform="flags=r;s:^:${{github.event.repository.name}}-${{github.event.release.tag_name}}/:" --sort=name --mtime=2030-01-01T00:00:00Z --owner=0 --group=0 --numeric-owner --create --gzip --file=${{github.event.repository.name}}-${{github.event.release.tag_name}}.tar.gz
       - name: Upload release archive
-        run: gh release upload ${{github.ref_name}} ${{github.event.repository.name}}-${{github.ref_name}}.tar.gz
+        run: gh release upload ${{github.event.release.tag_name}} ${{github.event.repository.name}}-${{github.event.release.tag_name}}.tar.gz
         env:
           GH_TOKEN: ${{github.token}}


### PR DESCRIPTION
These are _probably_ identical for any `on: release:` triggered workflow run. In this repository, based on https://github.com/dtolnay/cxx/actions/runs/14095301876/job/39481323116, they are definitely identical. But there is no reason to mix and match. "Tag name" has the more obviously correct name.