### PR TITLE
Generalize tgz workflow to v-prefixed tag names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Determine version from tag name
+        id: vars
+        run: echo version="${tag_name#v}" >> $GITHUB_OUTPUT
+        env:
+          tag_name: ${{github.event.release.tag_name}}
       - name: Package sources into tar.gz
-        run: git ls-tree -r -z --name-only HEAD | tar --null --files-from=- --transform="flags=r;s:^:${{github.event.repository.name}}-${{github.event.release.tag_name}}/:" --sort=name --mtime=2030-01-01T00:00:00Z --owner=0 --group=0 --numeric-owner --create --gzip --file=${{github.event.repository.name}}-${{github.event.release.tag_name}}.tar.gz
+        run: git ls-tree -r -z --name-only HEAD | tar --null --files-from=- --transform="flags=r;s:^:${{github.event.repository.name}}-${{steps.vars.outputs.version}}/:" --sort=name --mtime=2030-01-01T00:00:00Z --owner=0 --group=0 --numeric-owner --create --gzip --file=${{github.event.repository.name}}-${{steps.vars.outputs.version}}.tar.gz
       - name: Upload release archive
-        run: gh release upload ${{github.event.release.tag_name}} ${{github.event.repository.name}}-${{github.event.release.tag_name}}.tar.gz
+        run: gh release upload ${{github.event.release.tag_name}} ${{github.event.repository.name}}-${{steps.vars.outputs.version}}.tar.gz
         env:
           GH_TOKEN: ${{github.token}}


### PR DESCRIPTION
I want to contribute this workflow into the project template in https://github.com/bazel-contrib/publish-to-bcr. For that, it needs to accommodate tag names like `v1.0.0`.
https://github.com/bazel-contrib/publish-to-bcr/blob/65d4f0c00357d50ba19165993f673e56a7ddb500/src/domain/ruleset-repository.ts#L225-L230