### PR TITLE
Clear integrity value in source.template.json

### DIFF
--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
-  "integrity": "**leave this alone**",
+  "integrity": "",
   "strip_prefix": "{REPO}-{VERSION}",
   "url": "https://github.com/{OWNER}/{REPO}/releases/download/{VERSION}/{REPO}-{VERSION}.tar.gz"
 }


### PR DESCRIPTION
The string value is no longer present in recent version of the publish-to-bcr template.
https://github.com/bazel-contrib/publish-to-bcr/blob/65d4f0c00357d50ba19165993f673e56a7ddb500/templates/.bcr/source.template.json