### PR TITLE
Generate indirect placement for shared structs containing improper ctype

### DIFF
--- a/syntax/types.rs
+++ b/syntax/types.rs
@@ -242,9 +242,15 @@ impl<'a> Types<'a> {
 
     pub(crate) fn needs_indirect_abi(&self, ty: &Type) -> bool {
         match ty {
-            Type::RustBox(_) | Type::UniquePtr(_) => false,
+            Type::RustBox(_)
+            | Type::UniquePtr(_)
+            | Type::Ref(_)
+            | Type::Ptr(_)
+            | Type::Str(_)
+            | Type::Fn(_)
+            | Type::SliceRef(_) => false,
             Type::Array(_) => true,
-            _ => !self.is_guaranteed_pod(ty),
+            _ => !self.is_guaranteed_pod(ty) || self.is_considered_improper_ctype(ty),
         }
     }
 


### PR DESCRIPTION
Fixes #1027.