### PR TITLE
Fill in GitHub user ID for BCR publisher

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -3,6 +3,7 @@
   "maintainers": [
     {
       "github": "dtolnay",
+      "github_user_id": 1940490,
       "email": "dtolnay@gmail.com",
       "name": "David Tolnay"
     }


### PR DESCRIPTION
https://github.com/bazelbuild/bazel-central-registry/blob/d561ba93f5ef84a15e5fbe086052f68e56fcea1b/metadata.schema.json

If the dtolnay user is deleted from GitHub, this PR prevents someone who takes over that username from publishing releases of this crate to Bazel Central Registry.