### PR TITLE
Add Clang coverage to GitHub CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         rust: [nightly, beta, stable, 1.82.0, 1.80.0, 1.77.0, 1.74.0, 1.73.0]
         os: [ubuntu]
+        cc: ['']
         flags: ['']
         include:
           - name: Cargo on macOS
@@ -32,6 +33,11 @@ jobs:
             rust: nightly-x86_64-pc-windows-msvc
             os: windows
             flags: /EHsc
+          - name: Clang
+            rust: nightly
+            cc: clang++
+            os: ubuntu
+            flags: -std=c++20 -Werror -Wall
           - name: C++14
             rust: nightly
             os: ubuntu
@@ -45,6 +51,7 @@ jobs:
             os: ubuntu
             flags: -std=c++20 -Werror -Wall
     env:
+      CXX: ${{matrix.cc}}
       CXXFLAGS: ${{matrix.flags}}
       RUSTFLAGS: --cfg deny_warnings -Dwarnings
     timeout-minutes: 45


### PR DESCRIPTION
PTAL?

* I have temporarily reverted the fix at 1e10e24e6e4eceaf5776ee542dc4393bcd7f5b06 and verified that in that case the new CI has failed in my fork as expected: https://github.com/anforowicz/cxx/actions/runs/14339249757/job/40194179128
* It seems that the new CI step works without explicitly asking GitHub to install Clang.  I assume that `os: ubuntu` already includes pre-installed Clang.
* I made some arbitrary choices in this PR that I think don't matter that much in the end:
    * For now I kept the old/current behavior in most steps where the `cc` crate picks a default compiler _somehow_ (by keeping the new `matrix.cc` empty for most of the matrix).  I guess I could have also preserved the old behavior by explicitly setting `cc` to `c++`.
    * I only added a single Clang test step / matrix entry for C++20 - I think this will give reasonable coverage (hopefully a superset of coverage we would get from targeting C++14).