### PR TITLE
Add permission for release_tgz workflow to write attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,9 @@ on:
     types: [released]
 
 permissions:
+  attestations: write
   contents: write
+  id-token: write
 
 jobs:
   upload:


### PR DESCRIPTION
In order to adopt the new publish-to-bcr based on a reusable workflow (https://github.com/bazel-contrib/publish-to-bcr) instead of the deprecated app (https://github.com/apps/publish-to-bcr) we need not just the sources tgz published, but also a corresponding .tar.gz.intoto.jsonl like seen in https://github.com/aspect-build/rules_lint/releases/tag/v1.3.4.