### PR TITLE
Add publish-to-bcr reusable workflow job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,3 +12,12 @@ permissions:
 jobs:
   upload:
     uses: dtolnay/.github/.github/workflows/release_tgz.yml@master
+
+  publish-to-bcr:
+    needs: upload
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@47913235f61615d02c989d652c4d10c45c0c4f0b
+    with:
+      tag_name: ${{github.event.release.tag_name}}
+      registry_fork: dtolnay-contrib/bazel-central-registry
+    secrets:
+      publish_token: ${{secrets.PUBLISH_TOKEN}}


### PR DESCRIPTION
This is the new recommended process in https://github.com/bazel-contrib/publish-to-bcr. The GitHub App that published our previous few releases is legacy.