### PR TITLE
Resolve uninlined_format_args clippy lint in demo

### DIFF
--- a/book/src/tutorial.md
+++ b/book/src/tutorial.md
@@ -426,7 +426,7 @@ fn main() {
     let chunks = vec![b"fearless".to_vec(), b"concurrency".to_vec()];
     let mut buf = MultiBuf { chunks, pos: 0 };
     let blobid = client.put(&mut buf);
-    println!("blobid = {}", blobid);
+    println!("blobid = {blobid}");
 }
 ```
 
@@ -552,7 +552,7 @@ fn main() {
     let chunks = vec![b"fearless".to_vec(), b"concurrency".to_vec()];
     let mut buf = MultiBuf { chunks, pos: 0 };
     let blobid = client.put(&mut buf);
-    println!("blobid = {}", blobid);
+    println!("blobid = {blobid}");
 
     // Add a tag.
     client.tag(blobid, "rust");

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::uninlined_format_args)]
-
 #[cxx::bridge(namespace = "org::blobstore")]
 mod ffi {
     // Shared structs with fields visible to both languages.
@@ -50,7 +48,7 @@ fn main() {
     let chunks = vec![b"fearless".to_vec(), b"concurrency".to_vec()];
     let mut buf = MultiBuf { chunks, pos: 0 };
     let blobid = client.put(&mut buf);
-    println!("blobid = {}", blobid);
+    println!("blobid = {blobid}");
 
     // Add a tag.
     client.tag(blobid, "rust");


### PR DESCRIPTION
```console
warning: variables can be used directly in the `format!` string
  --> demo/src/main.rs:51:5
   |
51 |     println!("blobid = {}", blobid);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
   = note: `-W clippy::uninlined-format-args` implied by `-W clippy::all`
   = help: to override `-W clippy::all` add `#[allow(clippy::uninlined_format_args)]`
help: change this to
   |
51 -     println!("blobid = {}", blobid);
51 +     println!("blobid = {blobid}");
   |
```