### PR TITLE
Upload Cargo.lock artifact from just the default nightly job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         env:
           RUSTFLAGS: --cfg compile_error_if_alloc --cfg cxx_experimental_no_alloc ${{env.RUSTFLAGS}}
       - uses: actions/upload-artifact@v4
-        if: matrix.os == 'ubuntu' && matrix.rust == 'nightly' && always()
+        if: matrix.os == 'ubuntu' && matrix.rust == 'nightly' && matrix.cc == '' && matrix.flags == '' && always()
         with:
           name: Cargo.lock
           path: Cargo.lock


### PR DESCRIPTION
CI jobs have been succeeding anyway (because of the `continue-on-error: true`) but are producing the following alerts since https://github.com/dtolnay/cxx/pull/1437 and https://github.com/dtolnay/cxx/pull/1501.

![Screenshot from 2025-04-23 20-58-34](https://github.com/user-attachments/assets/9afed41d-c744-4b36-8350-1866061ea983)
