### PR TITLE
Prevent buck-out interfering with Bazel target patterns

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,2 +1,3 @@
+buck-out/
 target/
 tools/buck/buck2/


### PR DESCRIPTION
For example in this failure, Bazel is picking up some unexpected BUILD.bazel files inside of buck-out:

```console
$ bazel build ...
ERROR: /git/cxx/buck-out/v2/gen/root/904931f735703749/third-party/__cxx-1.0.158__/__srcs/cxx-631cdb11b2eb5c73/demo/BUILD.bazel:22:11: Compiling buck-out/v2/gen/root/904931f735703749/third-party/__cxx-1.0.158__/__srcs/cxx-631cdb11b2eb5c73/demo/src/blobstore.cc failed: (Exit 1): gcc failed: error executing CppCompile command (from target //buck-out/v2/gen/root/904931f735703749/third-party/__cxx-1.0.158__/__srcs/cxx-631cdb11b2eb5c73/demo:blobstore-sys) /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer '-std=c++17' -MD -MF ... (remaining 18 arguments skipped)
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
buck-out/v2/gen/root/904931f735703749/third-party/__cxx-1.0.158__/__srcs/cxx-631cdb11b2eb5c73/demo/src/blobstore.cc:1:10: fatal error: demo/include/blobstore.h: No such file or directory
    1 | #include "demo/include/blobstore.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```