### PR TITLE
Add "C++-unwind" support

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -10,8 +10,8 @@ use crate::syntax::set::UnorderedSet;
 use crate::syntax::symbol::{self, Symbol};
 use crate::syntax::trivial::{self, TrivialReason};
 use crate::syntax::{
-    derive, mangle, Api, Doc, Enum, EnumRepr, ExternFn, ExternType, Pair, Signature, Struct, Trait,
-    Type, TypeAlias, Types, Var,
+    derive, mangle, Api, Doc, Enum, EnumRepr, ExternFn, ExternType, Lang, Pair, Signature, Struct,
+    Trait, Type, TypeAlias, Types, Var,
 };
 use proc_macro2::Ident;
 
@@ -779,7 +779,11 @@ fn write_cxx_function_shim<'a>(out: &mut OutFile<'a>, efn: &'a ExternFn) {
         write_indirect_return_type_space(out, efn.ret.as_ref().unwrap());
         write!(out, "*return$");
     }
-    writeln!(out, ") noexcept {{");
+    if efn.lang == Lang::CxxUnwind {
+        writeln!(out, ") {{");
+    } else {
+        writeln!(out, ") noexcept {{");
+    }
     write!(out, "  ");
     write_return_type(out, &efn.ret);
     match &efn.receiver {

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -383,7 +383,7 @@ fn check_api_type(cx: &mut Check, ety: &ExternType) {
         }
         let lang = match ety.lang {
             Lang::Rust => "Rust",
-            Lang::Cxx => "C++",
+            Lang::Cxx | Lang::CxxUnwind => "C++",
         };
         let msg = format!(
             "derive({}) on opaque {} type is not supported yet",
@@ -409,7 +409,7 @@ fn check_api_type(cx: &mut Check, ety: &ExternType) {
 
 fn check_api_fn(cx: &mut Check, efn: &ExternFn) {
     match efn.lang {
-        Lang::Cxx => {
+        Lang::Cxx | Lang::CxxUnwind => {
             if !efn.generics.params.is_empty() && !efn.trusted {
                 let ref span = span_for_generics_error(efn);
                 cx.error(span, "extern C++ function with lifetimes must be declared in `unsafe extern \"C++\"` block");

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -323,6 +323,7 @@ pub(crate) struct Array {
 #[derive(Copy, Clone, PartialEq)]
 pub(crate) enum Lang {
     Cxx,
+    CxxUnwind,
     Rust,
 }
 

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -353,7 +353,7 @@ fn parse_foreign_mod(
                 cx.error(span, "extern \"Rust\" block does not need to be unsafe");
             }
         }
-        Lang::Cxx => {}
+        Lang::Cxx | Lang::CxxUnwind => {}
     }
 
     let trusted = trusted || foreign_mod.unsafety.is_some();
@@ -445,6 +445,7 @@ fn parse_lang(abi: &Abi) -> Result<Lang> {
 
     match name.value().as_str() {
         "C++" => Ok(Lang::Cxx),
+        "C++-unwind" => Ok(Lang::CxxUnwind),
         "Rust" => Ok(Lang::Rust),
         _ => Err(Error::new_spanned(
             abi,
@@ -492,7 +493,7 @@ fn parse_extern_type(
     let semi_token = foreign_type.semi_token;
 
     (match lang {
-        Lang::Cxx => Api::CxxType,
+        Lang::Cxx | Lang::CxxUnwind => Api::CxxType,
         Lang::Rust => Api::RustType,
     })(ExternType {
         cfg,
@@ -671,7 +672,7 @@ fn parse_extern_fn(
     let semi_token = foreign_fn.semi_token;
 
     Ok(match lang {
-        Lang::Cxx => Api::CxxFunction,
+        Lang::Cxx | Lang::CxxUnwind => Api::CxxFunction,
         Lang::Rust => Api::RustFunction,
     }(ExternFn {
         cfg,
@@ -964,7 +965,7 @@ fn parse_extern_type_bounded(
     let name = pair(namespace, &ident, cxx_name, rust_name);
 
     Ok(match lang {
-        Lang::Cxx => Api::CxxType,
+        Lang::Cxx | Lang::CxxUnwind => Api::CxxType,
         Lang::Rust => Api::RustType,
     }(ExternType {
         cfg,


### PR DESCRIPTION
Closes #1526 

This PR allows C++ method to be declared as `extern "C++-unwind"`, and the trampolines won't be decorated by `noexcept`.