### PR TITLE
Add special case for Rust fn main

### DIFF
--- a/syntax/namespace.rs
+++ b/syntax/namespace.rs
@@ -9,7 +9,7 @@ mod kw {
     syn::custom_keyword!(namespace);
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, PartialEq)]
 pub(crate) struct Namespace {
     segments: Vec<Ident>,
 }


### PR DESCRIPTION
When a `main` function from a Rust library is linked into a C++ binary, previously one had to apply one of the following workarounds:

1. Wrap the Rust main in a C++ main:

    ```rust
    // main.rs

    fn rust_main() {...}

    #[cxx::bridge]
    mod ffi {
        extern "Rust" {
            fn rust_main();
        }
    }
    ```
    ```cpp
    // main.cpp

    #include "path/to/src/main.rs.h"

    int main() {
      rust_main();
    }
    ```

2. Declare an i32 return type for main in Rust:

    ```rust
    fn main() -> i32 {
        ...
        0
    }

    #[cxx::bridge]
    mod ffi {
        extern "Rust" {
            fn main() -> i32;
        }
    }
    ```

Otherwise the C++ compilation would fail trying to compile a cxx-generated source file like this:

```cpp
extern "C" {
void cxxbridge1$main() noexcept;
} // extern "C"

void main() noexcept {
  cxxbridge1$main();
}
```

```console
<source>:5:1: error: 'main' must return 'int'
    5 | void main() noexcept {
      | ^~~~
      | int
1 error generated.
```

This PR makes cxx recognize `fn main()` as a special case so that a Rust main can be directly linked as a C++ binary's main.

```rust
fn main() {...}

#[cxx::bridge]
mod ffi {
    extern "Rust" {
        fn main();
    }
}
```