### PR TITLE
Delete #[automatically_derived] on impl blocks that are not trait impls

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -360,7 +360,6 @@ fn expand_enum(enm: &Enum) -> TokenStream {
         #[repr(transparent)]
         #enum_def
 
-        #[automatically_derived]
         #[allow(non_upper_case_globals)]
         impl #ident {
             #(#variants)*
@@ -777,7 +776,6 @@ fn expand_cxx_function_shim(efn: &ExternFn, types: &Types) -> TokenStream {
                 &elided_generics
             };
             quote_spanned! {ident.span()=>
-                #[automatically_derived]
                 impl #generics #receiver_ident #receiver_generics {
                     #doc
                     #attrs


### PR DESCRIPTION
Rustc nightly-2025-07-19 has begun warning about this. https://github.com/rust-lang/rust/pull/143845

```console
warning: `#[automatically_derived]` only has an effect on trait implementation blocks
  --> demo/src/main.rs:23:12
   |
23 |         fn put(&self, parts: &mut MultiBuf) -> u64;
   |            ^^^
   |
   = note: `#[warn(unused_attributes)]` on by default

warning: `#[automatically_derived]` only has an effect on trait implementation blocks
  --> demo/src/main.rs:24:12
   |
24 |         fn tag(&self, blobid: u64, tag: &str);
   |            ^^^

warning: `#[automatically_derived]` only has an effect on trait implementation blocks
  --> demo/src/main.rs:25:12
   |
25 |         fn metadata(&self, blobid: u64) -> BlobMetadata;
   |            ^^^^^^^^
```