### PR TITLE
Reusing Rust type bindings / support for type aliases in the Rust section

### DIFF
--- a/book/package-lock.json
+++ b/book/package-lock.json
@@ -59,13 +59,12 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.1.tgz",
-      "integrity": "sha512-fo6Mtm5mWyKjA/Chy1BYTdn5mGJoDNjC7C64ug20ADsRDGrA85bN3uK3MaKbeRkRuuIEAR5N33Jr1pbm411/PA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.5",
+        "@eslint/object-schema": "^2.1.6",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
@@ -73,12 +72,20 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/core": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.10.0.tgz",
-      "integrity": "sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==",
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
+      "integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
       "dev": true,
-      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+      "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -87,11 +94,10 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
-      "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -110,47 +116,34 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@eslint/js": {
-      "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.19.0.tgz",
-      "integrity": "sha512-rbq9/g38qjfqFLOVPvwjIvFFdNziEC5S65jmjPw5r6A//QH+W91akh9irMwjDN8zKUTak6W9EsAv4m/7Wnw0UQ==",
+      "version": "9.31.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.31.0.tgz",
+      "integrity": "sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.5.tgz",
-      "integrity": "sha512-o0bhxnL89h5Bae5T318nFoFzGy+YE5i/gGkoPAgkmTVdRKTiv3p8JHevPiPaMwoloKfEiiaHlawCqaZMqRm+XQ==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.5.tgz",
-      "integrity": "sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
+      "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.10.0",
+        "@eslint/core": "^0.15.1",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -210,11 +203,10 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
-      "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
       },
@@ -234,15 +226,13 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -255,7 +245,6 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -265,7 +254,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -297,15 +285,13 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
+      "dev": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -314,11 +300,10 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -329,7 +314,6 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -417,8 +401,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -464,11 +447,10 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -582,22 +564,22 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.19.0.tgz",
-      "integrity": "sha512-ug92j0LepKlbbEv6hD911THhoRHmbdXt2gX+VDABAW/Ir7D3nqKdv5Pf5vtlyY6HQMTEP2skXY43ueqTCWssEA==",
+      "version": "9.31.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.31.0.tgz",
+      "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.0",
-        "@eslint/core": "^0.10.0",
-        "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.19.0",
-        "@eslint/plugin-kit": "^0.2.5",
+        "@eslint/config-array": "^0.21.0",
+        "@eslint/config-helpers": "^0.3.0",
+        "@eslint/core": "^0.15.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.31.0",
+        "@eslint/plugin-kit": "^0.3.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.1",
+        "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
@@ -605,9 +587,9 @@
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.2.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -642,11 +624,10 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
-      "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -659,11 +640,10 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -672,15 +652,14 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.0"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -707,7 +686,6 @@
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -739,15 +717,13 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -820,6 +796,18 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -882,17 +870,15 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -949,7 +935,6 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -968,8 +953,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -1030,7 +1014,6 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1042,8 +1025,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -1119,7 +1101,6 @@
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -1199,7 +1180,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -1209,7 +1189,6 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -1248,7 +1227,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -1283,10 +1261,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
-      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
-      "license": "MIT",
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
       "engines": {
         "node": ">=18.17"
       }
@@ -1296,7 +1273,6 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }

--- a/book/src/extern-rust.md
+++ b/book/src/extern-rust.md
@@ -194,3 +194,46 @@ mod ffi {
 
 Bounds on a lifetime (like `<'a, 'b: 'a>`) are not currently supported. Nor are
 type parameters or where-clauses.
+
+## Reusing existing binding types
+
+Extern Rust types support a syntax for declaring that a C++ binding of the
+given Rust type already exists outside of the current bridge module. This
+avoids generating a separate binding which would clash with the first one
+(e.g. one possible error is: "conflicting implementations of trait `RustType`").
+
+The snippet below illustrates how to unify references to a Rust type
+across bridges:
+
+```rs
+// file1.rs
+#[cxx::bridge(namespace = "example")]
+pub mod ffi {
+    extern "Rust" {
+        type Demo;
+
+        fn create_demo() -> Box<Demo>;
+    }
+}
+
+pub struct Demo;
+
+pub fn create_demo() -> Box<Demo> { todo!() }
+```
+
+```rs
+// file2.rs
+#[cxx::bridge(namespace = "example")]
+pub mod ffi {
+    extern "C++" {
+        include!("file1.rs.h");
+    }
+    extern "Rust" {
+        type Demo = crate::file1::Demo;
+
+        fn take_ref_demo(demo: &Demo);
+    }
+}
+
+pub fn take_ref_demo(demo: &crate::file1::Demo) { todo!() }
+```

--- a/gen/src/mod.rs
+++ b/gen/src/mod.rs
@@ -150,11 +150,11 @@ pub(super) fn generate(syntax: File, opt: &Opt) -> Result<GeneratedCode> {
     let ref mut apis = Vec::new();
     let ref mut errors = Errors::new();
     let ref mut cfg_errors = Set::new();
-    for bridge in syntax.modules {
+    for mut bridge in syntax.modules {
         let mut cfg = CfgExpr::Unconditional;
         attrs::parse(
             errors,
-            bridge.attrs,
+            std::mem::take(&mut bridge.attrs),
             attrs::Parser {
                 cfg: Some(&mut cfg),
                 ignore_unrecognized: true,
@@ -162,14 +162,7 @@ pub(super) fn generate(syntax: File, opt: &Opt) -> Result<GeneratedCode> {
             },
         );
         if cfg::eval(errors, cfg_errors, opt.cfg_evaluator.as_ref(), &cfg) {
-            let ref namespace = bridge.namespace;
-            let trusted = bridge.unsafety.is_some();
-            apis.extend(syntax::parse_items(
-                errors,
-                bridge.content,
-                trusted,
-                namespace,
-            ));
+            apis.extend(syntax::parse_items(errors, &mut bridge));
         }
     }
 

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -34,10 +34,7 @@ pub(crate) fn bridge(mut ffi: Module) -> Result<TokenStream> {
         },
     );
 
-    let content = mem::take(&mut ffi.content);
-    let trusted = ffi.unsafety.is_some();
-    let namespace = &ffi.namespace;
-    let ref mut apis = syntax::parse_items(errors, content, trusted, namespace);
+    let ref mut apis = syntax::parse_items(errors, &mut ffi);
     let ref types = Types::collect(errors, apis);
     errors.propagate()?;
 

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -58,7 +58,7 @@ use syn::parse_macro_input;
 pub fn bridge(args: TokenStream, input: TokenStream) -> TokenStream {
     let _ = syntax::error::ERRORS;
 
-    let namespace = match Namespace::parse_bridge_attr_namespace.parse(args) {
+    let namespace = match Namespace::parse_stream.parse(args) {
         Ok(namespace) => namespace,
         Err(err) => return err.to_compile_error().into(),
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -503,7 +503,7 @@ pub mod private {
     pub use crate::rust_str::RustStr;
     #[cfg(feature = "alloc")]
     pub use crate::rust_string::RustString;
-    pub use crate::rust_type::{ImplBox, ImplVec, RustType};
+    pub use crate::rust_type::{verify_rust_type, ImplBox, ImplVec, RustType};
     #[cfg(feature = "alloc")]
     pub use crate::rust_vec::RustVec;
     pub use crate::shared_ptr::SharedPtrTarget;

--- a/src/rust_type.rs
+++ b/src/rust_type.rs
@@ -3,3 +3,6 @@
 pub unsafe trait RustType {}
 pub unsafe trait ImplBox {}
 pub unsafe trait ImplVec {}
+
+#[doc(hidden)]
+pub fn verify_rust_type<T: RustType>() {}

--- a/syntax/attrs.rs
+++ b/syntax/attrs.rs
@@ -302,3 +302,15 @@ impl ToTokens for OtherAttrs {
         }
     }
 }
+
+/// This finds `#[cxx::bridge]` attribute if it has been spelled in exactly this way.  This means
+/// that it is appropriate to use from `gen/...` and tests, but not from `macro/...` (it seems
+/// somewhat prudent for the latter to handle the case where the attribute was imported under a
+/// different name).
+#[allow(dead_code)] // Only used from tests and cxx-build, but not from cxxbridge-macro
+pub(crate) fn find_cxx_bridge_attr(attrs: &[Attribute]) -> Option<&Attribute> {
+    attrs.iter().find(|attr| {
+        let path = &attr.path().segments;
+        path.len() == 2 && path[0].ident == "cxx" && path[1].ident == "bridge"
+    })
+}

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -726,7 +726,9 @@ fn describe(cx: &mut Check, ty: &Type) -> String {
             } else if cx.types.enums.contains_key(&ident.rust) {
                 "enum".to_owned()
             } else if cx.types.cxx_aliases.contains_key(&ident.rust) {
-                "C++ type".to_owned()
+                "aliased C++ type".to_owned()
+            } else if cx.types.rust_aliases.contains_key(&ident.rust) {
+                "aliased Rust type".to_owned()
             } else if cx.types.cxx.contains(&ident.rust) {
                 "opaque C++ type".to_owned()
             } else if cx.types.rust.contains(&ident.rust) {

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -95,7 +95,7 @@ fn check_type_ident(cx: &mut Check, name: &NamedType) {
 fn check_type_box(cx: &mut Check, ptr: &Ty1) {
     if let Type::Ident(ident) = &ptr.inner {
         if cx.types.cxx.contains(&ident.rust)
-            && !cx.types.aliases.contains_key(&ident.rust)
+            && !cx.types.cxx_aliases.contains_key(&ident.rust)
             && !cx.types.structs.contains_key(&ident.rust)
             && !cx.types.enums.contains_key(&ident.rust)
         {
@@ -114,7 +114,7 @@ fn check_type_rust_vec(cx: &mut Check, ty: &Ty1) {
     match &ty.inner {
         Type::Ident(ident) => {
             if cx.types.cxx.contains(&ident.rust)
-                && !cx.types.aliases.contains_key(&ident.rust)
+                && !cx.types.cxx_aliases.contains_key(&ident.rust)
                 && !cx.types.structs.contains_key(&ident.rust)
                 && !cx.types.enums.contains_key(&ident.rust)
             {
@@ -273,7 +273,8 @@ fn check_type_slice_ref(cx: &mut Check, ty: &SliceRef) {
     let supported = !is_unsized(cx, &ty.inner)
         || match &ty.inner {
             Type::Ident(ident) => {
-                cx.types.rust.contains(&ident.rust) || cx.types.aliases.contains_key(&ident.rust)
+                cx.types.rust.contains(&ident.rust)
+                    || cx.types.cxx_aliases.contains_key(&ident.rust)
             }
             _ => false,
         };
@@ -680,7 +681,7 @@ fn is_opaque_cxx(cx: &mut Check, ty: &Ident) -> bool {
     cx.types.cxx.contains(ty)
         && !cx.types.structs.contains_key(ty)
         && !cx.types.enums.contains_key(ty)
-        && !(cx.types.aliases.contains_key(ty) && cx.types.required_trivial.contains_key(ty))
+        && !(cx.types.cxx_aliases.contains_key(ty) && cx.types.required_trivial.contains_key(ty))
 }
 
 fn span_for_struct_error(strct: &Struct) -> TokenStream {
@@ -724,7 +725,7 @@ fn describe(cx: &mut Check, ty: &Type) -> String {
                 "struct".to_owned()
             } else if cx.types.enums.contains_key(&ident.rust) {
                 "enum".to_owned()
-            } else if cx.types.aliases.contains_key(&ident.rust) {
+            } else if cx.types.cxx_aliases.contains_key(&ident.rust) {
                 "C++ type".to_owned()
             } else if cx.types.cxx.contains(&ident.rust) {
                 "opaque C++ type".to_owned()

--- a/syntax/improper.rs
+++ b/syntax/improper.rs
@@ -19,7 +19,7 @@ impl<'a> Types<'a> {
                 } else if let Some(strct) = self.structs.get(ident) {
                     Depends(&strct.name.rust) // iterate to fixed-point
                 } else {
-                    Definite(self.rust.contains(ident) || self.aliases.contains_key(ident))
+                    Definite(self.rust.contains(ident) || self.cxx_aliases.contains_key(ident))
                 }
             }
             Type::RustBox(_)

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -327,7 +327,7 @@ pub(crate) struct Array {
     pub len_token: LitInt,
 }
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub(crate) enum Lang {
     Cxx,
     CxxUnwind,

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -164,6 +164,7 @@ pub(crate) struct ExternFn {
 pub(crate) struct TypeAlias {
     #[allow(dead_code)] // only used by cxx-build, not cxxbridge-macro
     pub cfg: CfgExpr,
+    pub lang: Lang,
     #[allow(dead_code)] // only used by cxxbridge-macro, not cxx-build
     pub doc: Doc,
     pub derives: Vec<Derive>,

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -27,6 +27,8 @@ pub(crate) mod resolve;
 pub(crate) mod set;
 mod signature;
 pub(crate) mod symbol;
+#[cfg(test)]
+pub(crate) mod test_support;
 mod tokens;
 mod toposort;
 pub(crate) mod trivial;

--- a/syntax/namespace.rs
+++ b/syntax/namespace.rs
@@ -1,7 +1,7 @@
 use crate::syntax::qualified::QualifiedName;
 use std::slice::Iter;
 use syn::parse::{Error, Parse, ParseStream, Result};
-use syn::{Expr, Ident, Lit, Meta, Token};
+use syn::{Attribute, Expr, Ident, Lit, Meta, Token};
 
 mod kw {
     syn::custom_keyword!(namespace);
@@ -21,7 +21,20 @@ impl Namespace {
         self.segments.iter()
     }
 
-    pub(crate) fn parse_bridge_attr_namespace(input: ParseStream) -> Result<Self> {
+    /// Parses `namespace = ...` (if present) from `attr`.
+    /// Typically `attr` represents `#[cxx::bridge(...)]` attribute.
+    #[allow(dead_code)] // Only used from tests and cxx-build, but not from cxxbridge-macro
+    pub(crate) fn parse_attr(attr: &Attribute) -> Result<Namespace> {
+        if let Meta::Path(_) = attr.meta {
+            Ok(Namespace::ROOT)
+        } else {
+            attr.parse_args_with(Namespace::parse_stream)
+        }
+    }
+
+    /// Parses `namespace = ...` (if present) from `input`.
+    /// Typically `inputs` represents the "body" of a `#[cxx::bridge(...)]` attribute.
+    pub(crate) fn parse_stream(input: ParseStream) -> Result<Self> {
         if input.is_empty() {
             return Ok(Namespace::ROOT);
         }
@@ -94,5 +107,29 @@ impl<'a> FromIterator<&'a Ident> for Namespace {
     {
         let segments = idents.into_iter().cloned().collect();
         Namespace { segments }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::syntax::test_support::parse_apis;
+    use crate::syntax::Api;
+    use quote::quote;
+
+    #[test]
+    fn test_top_level_namespace() {
+        let apis = parse_apis(quote! {
+            #[cxx::bridge(namespace = "top_level_namespace")]
+            mod ffi {
+                unsafe extern "C++" {
+                    fn foo();
+                }
+            }
+        })
+        .unwrap();
+        let [Api::CxxFunction(f)] = &apis[..] else {
+            panic!("Got unexpected apis");
+        };
+        assert_eq!("top_level_namespace$foo", f.name.to_symbol().to_string());
     }
 }

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -1,7 +1,7 @@
 use crate::syntax::attrs::OtherAttrs;
 use crate::syntax::cfg::CfgExpr;
 use crate::syntax::discriminant::DiscriminantSet;
-use crate::syntax::file::{Item, ItemForeignMod};
+use crate::syntax::file::{Item, ItemForeignMod, Module};
 use crate::syntax::report::Errors;
 use crate::syntax::repr::Repr;
 use crate::syntax::Atom::*;
@@ -28,12 +28,11 @@ pub(crate) mod kw {
     syn::custom_keyword!(Result);
 }
 
-pub(crate) fn parse_items(
-    cx: &mut Errors,
-    items: Vec<Item>,
-    trusted: bool,
-    namespace: &Namespace,
-) -> Vec<Api> {
+pub(crate) fn parse_items(cx: &mut Errors, bridge: &mut Module) -> Vec<Api> {
+    let items = mem::take(&mut bridge.content);
+    let ref namespace = bridge.namespace;
+    let trusted = bridge.unsafety.is_some();
+
     let mut apis = Vec::new();
     for item in items {
         match item {

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -899,17 +899,12 @@ fn parse_type_alias(
         },
     ));
 
-    if lang == Lang::Rust {
-        let span = quote!(#type_token #semi_token);
-        let msg = "type alias in extern \"Rust\" block is not supported";
-        return Err(Error::new_spanned(span, msg));
-    }
-
     let visibility = visibility_pub(&visibility, type_token.span);
     let name = pair(namespace, &ident, cxx_name, rust_name);
 
     Ok(Api::TypeAlias(TypeAlias {
         cfg,
+        lang,
         doc,
         derives,
         attrs,

--- a/syntax/test_support.rs
+++ b/syntax/test_support.rs
@@ -1,7 +1,9 @@
 //! Test helpers for `syntax`-module-level parsing and checking of `#[cxx::bridge]`.
 
+use crate::syntax::attrs::find_cxx_bridge_attr;
 use crate::syntax::check::{self};
 use crate::syntax::file::Module;
+use crate::syntax::namespace::Namespace;
 use crate::syntax::parse::parse_items;
 use crate::syntax::report::Errors;
 use crate::syntax::{Api, Types};
@@ -11,6 +13,10 @@ use proc_macro2::TokenStream;
 /// Parses a `TokenStream` containing `#[cxx::bridge] mod { ... }`.
 pub fn parse_apis(cxx_bridge: TokenStream) -> syn::Result<Vec<Api>> {
     let mut module = syn::parse2::<Module>(cxx_bridge)?;
+    let cxx_bridge_attr = find_cxx_bridge_attr(&module.attrs)
+        .expect("test inputs are expected to always have `#[cxx::bridge]` attribute");
+    module.namespace = Namespace::parse_attr(cxx_bridge_attr)?;
+
     let mut errors = Errors::new();
     let apis = parse_items(&mut errors, &mut module);
     errors.propagate()?;

--- a/syntax/test_support.rs
+++ b/syntax/test_support.rs
@@ -1,0 +1,32 @@
+//! Test helpers for `syntax`-module-level parsing and checking of `#[cxx::bridge]`.
+
+use crate::syntax::check::{self};
+use crate::syntax::file::Module;
+use crate::syntax::parse::parse_items;
+use crate::syntax::report::Errors;
+use crate::syntax::{Api, Types};
+
+use proc_macro2::TokenStream;
+
+/// Parses a `TokenStream` containing `#[cxx::bridge] mod { ... }`.
+pub fn parse_apis(cxx_bridge: TokenStream) -> syn::Result<Vec<Api>> {
+    let mut module = syn::parse2::<Module>(cxx_bridge)?;
+    let mut errors = Errors::new();
+    let apis = parse_items(&mut errors, &mut module);
+    errors.propagate()?;
+
+    Ok(apis)
+}
+
+/// Collects and type-checks types used in `apis`.
+pub fn collect_types(apis: &[Api]) -> syn::Result<Types> {
+    let mut errors = Errors::new();
+    let types = Types::collect(&mut errors, apis);
+    errors.propagate()?;
+
+    let generator = check::Generator::Build;
+    check::typecheck(&mut errors, apis, &types, generator);
+    errors.propagate()?;
+
+    Ok(types)
+}

--- a/syntax/types.rs
+++ b/syntax/types.rs
@@ -293,3 +293,24 @@ fn duplicate_name(cx: &mut Errors, sp: impl ToTokens, name: ItemName) {
     let msg = format!("the {} is defined multiple times", description);
     cx.error(sp, msg);
 }
+
+#[cfg(test)]
+mod test {
+    use crate::syntax::test_support::{collect_types, parse_apis};
+    use quote::{format_ident, quote};
+
+    #[test]
+    fn test_parsing_of_cxx_type_aliases() {
+        let apis = parse_apis(quote! {
+            #[cxx::bridge]
+            mod ffi {
+                extern "C++" {
+                    type Alias = crate::another_module::Foo;
+                }
+            }
+        })
+        .unwrap();
+        let types = collect_types(&apis).unwrap();
+        assert!(types.aliases.contains_key(&format_ident!("Alias")));
+    }
+}

--- a/tests/cpp_compile/mod.rs
+++ b/tests/cpp_compile/mod.rs
@@ -57,6 +57,12 @@ impl Test {
         fs::write(&generated_h, &generated.header).unwrap();
         fs::write(&generated_cc, &generated.implementation).unwrap();
 
+        // Dump the generated files to help with debugging test failures (if any).
+        eprintln!("==================== generated .h file:");
+        eprintln!("{}", String::from_utf8_lossy(&generated.header));
+        eprintln!("==================== generated .cc file:");
+        eprintln!("{}", String::from_utf8_lossy(&generated.implementation));
+
         Self {
             temp_dir,
             generated_cc,
@@ -130,7 +136,9 @@ impl CompilationResult {
     }
 
     fn dump_output_and_panic(&self, msg: &str) -> ! {
+        eprintln!("==================== C++ compiler's stdout:");
         eprintln!("{}", self.stdout());
+        eprintln!("==================== C++ compiler's stderr:");
         eprintln!("{}", self.stderr());
         panic!("{msg}");
     }
@@ -178,6 +186,9 @@ impl CompilationResult {
     /// Panics if there was no error, or if there was more than a single error.
     #[must_use]
     pub fn expect_single_error(&self) -> String {
+        if self.0.status.success() {
+            self.dump_output_and_panic("Compilation unexpectedly succeeded");
+        }
         let error_lines = self.error_lines();
         if error_lines.is_empty() {
             self.dump_output_and_panic("No error lines found, despite non-zero exit code?");

--- a/tests/cpp_ui_tests.rs
+++ b/tests/cpp_ui_tests.rs
@@ -26,3 +26,32 @@ fn test_unique_ptr_of_incomplete_foward_declared_pointee() {
     let err_msg = test.compile().expect_single_error();
     assert!(err_msg.contains("definition of `::ForwardDeclaredType` is required"));
 }
+
+/// This test covers a scenario raised in
+/// https://github.com/dtolnay/cxx/pull/1539#discussion_r2320536648 where C++ side of bindings
+/// didn't enforce that `RustAlias` actually aliases `RustType`.
+#[test]
+fn test_cpp_side_type_alias_conflicting_with_cxx_bridge_rust_type_alias() {
+    let test = cpp_compile::Test::new(quote! {
+        #[cxx::bridge]
+        mod ffi {
+            unsafe extern "C++" {
+                include!("include.h");
+            }
+            extern "Rust" {
+                type RustType;
+                type RustAlias = RustType;
+            }
+        }
+    });
+    test.write_file(
+        "include.h",
+        indoc! {"
+            #include <array>
+            using RustAlias = std::array<char, 1000>;
+        "},
+    );
+    let err_msg = test.compile().expect_single_error();
+    assert!(err_msg
+        .contains("Rust type alias `RustAlias` should alias a type derived from `rust::Opaque`",));
+}

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -369,6 +369,11 @@ pub mod ffi {
     impl SharedPtr<Undefined> {}
     impl SharedPtr<Private> {}
     impl UniquePtr<Array> {}
+
+    extern "Rust" {
+        type CrossModuleRustType = crate::module::CrossModuleRustType;
+        fn r_get_value_from_cross_module_rust_type(value: &CrossModuleRustType) -> i32;
+    }
 }
 
 mod other {
@@ -700,4 +705,8 @@ fn r_try_return_mutsliceu8(slice: &mut [u8]) -> Result<&mut [u8], Error> {
 
 fn r_aliased_function(x: i32) -> String {
     x.to_string()
+}
+
+fn r_get_value_from_cross_module_rust_type(value: &crate::module::CrossModuleRustType) -> i32 {
+    value.0
 }

--- a/tests/ffi/module.rs
+++ b/tests/ffi/module.rs
@@ -78,3 +78,20 @@ pub mod ffi2 {
     impl UniquePtr<F> {}
     impl UniquePtr<G> {}
 }
+
+#[cxx::bridge(namespace = "tests")]
+pub mod ffi3 {
+    extern "Rust" {
+        type CrossModuleRustType;
+
+        #[allow(clippy::unnecessary_box_returns)]
+        fn r_boxed_cross_module_rust_type(value: i32) -> Box<CrossModuleRustType>;
+    }
+}
+
+pub struct CrossModuleRustType(pub i32);
+
+#[allow(clippy::unnecessary_box_returns)]
+fn r_boxed_cross_module_rust_type(value: i32) -> Box<CrossModuleRustType> {
+    Box::new(CrossModuleRustType(value))
+}

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -992,6 +992,9 @@ extern "C" const char *cxx_run_test() noexcept {
   (void)rust::Vec<size_t>();
   (void)rust::Vec<rust::isize>();
 
+  ASSERT(123 == r_get_value_from_cross_module_rust_type(
+      *r_boxed_cross_module_rust_type(123)));
+
   cxx_test_suite_set_correct();
   return nullptr;
 }

--- a/tests/ui/opaque_autotraits.stderr
+++ b/tests/ui/opaque_autotraits.stderr
@@ -47,30 +47,30 @@ note: required by a bound in `assert_sync`
    |                   ^^^^ required by this bound in `assert_sync`
 
 error[E0277]: `PhantomPinned` cannot be unpinned
-  --> tests/ui/opaque_autotraits.rs:15:20
-   |
-15 |     assert_unpin::<ffi::Opaque>();
-   |                    ^^^^^^^^^^^ within `ffi::Opaque`, the trait `Unpin` is not implemented for `PhantomPinned`
-   |
-   = note: consider using the `pin!` macro
-           consider using `Box::pin` if you need to access the pinned value outside of the current scope
+ --> tests/ui/opaque_autotraits.rs:15:20
+  |
+ 15 |     assert_unpin::<ffi::Opaque>();
+    |                    ^^^^^^^^^^^ within `ffi::Opaque`, the trait `Unpin` is not implemented for `PhantomPinned`
+    |
+    = note: consider using the `pin!` macro
+            consider using `Box::pin` if you need to access the pinned value outside of the current scope
 note: required because it appears within the type `PhantomData<PhantomPinned>`
-  --> $RUST/core/src/marker.rs
-   |
-   | pub struct PhantomData<T: PointeeSized>;
-   |            ^^^^^^^^^^^
+   --> $RUST/core/src/marker.rs
+    |
+    | pub struct PhantomData<T: PointeeSized>;
+    |            ^^^^^^^^^^^
 note: required because it appears within the type `cxx::private::Opaque`
-  --> src/opaque.rs
-   |
-   | pub struct Opaque {
-   |            ^^^^^^
+   --> src/opaque.rs
+    |
+ 18 | pub struct Opaque {
+    |            ^^^^^^
 note: required because it appears within the type `ffi::Opaque`
-  --> tests/ui/opaque_autotraits.rs:4:14
-   |
- 4 |         type Opaque;
-   |              ^^^^^^
+   --> tests/ui/opaque_autotraits.rs:4:14
+    |
+  4 |         type Opaque;
+    |              ^^^^^^
 note: required by a bound in `assert_unpin`
-  --> tests/ui/opaque_autotraits.rs:10:20
-   |
-10 | fn assert_unpin<T: Unpin>() {}
-   |                    ^^^^^ required by this bound in `assert_unpin`
+   --> tests/ui/opaque_autotraits.rs:10:20
+    |
+ 10 | fn assert_unpin<T: Unpin>() {}
+    |                    ^^^^^ required by this bound in `assert_unpin`

--- a/tests/ui/slice_of_type_alias.stderr
+++ b/tests/ui/slice_of_type_alias.stderr
@@ -1,16 +1,16 @@
 error[E0271]: type mismatch resolving `<ElementOpaque as ExternType>::Kind == Trivial`
-  --> tests/ui/slice_of_type_alias.rs:13:14
-   |
-13 |         type ElementOpaque = crate::ElementOpaque;
-   |              ^^^^^^^^^^^^^ type mismatch resolving `<ElementOpaque as ExternType>::Kind == Trivial`
-   |
+ --> tests/ui/slice_of_type_alias.rs:13:14
+  |
+ 13 |         type ElementOpaque = crate::ElementOpaque;
+    |              ^^^^^^^^^^^^^ type mismatch resolving `<ElementOpaque as ExternType>::Kind == Trivial`
+    |
 note: expected this to be `Trivial`
-  --> tests/ui/slice_of_type_alias.rs:27:17
-   |
-27 |     type Kind = cxx::kind::Opaque;
-   |                 ^^^^^^^^^^^^^^^^^
+   --> tests/ui/slice_of_type_alias.rs:27:17
+    |
+ 27 |     type Kind = cxx::kind::Opaque;
+    |                 ^^^^^^^^^^^^^^^^^
 note: required by a bound in `verify_extern_kind`
-  --> src/extern_type.rs
-   |
-   | pub fn verify_extern_kind<T: ExternType<Kind = Kind>, Kind: self::Kind>() {}
-   |                                         ^^^^^^^^^^^ required by this bound in `verify_extern_kind`
+   --> src/extern_type.rs
+    |
+    | pub fn verify_extern_kind<T: ExternType<Kind = Kind>, Kind: self::Kind>() {}
+    |                                         ^^^^^^^^^^^ required by this bound in `verify_extern_kind`

--- a/tests/ui/type_alias_rust.rs
+++ b/tests/ui/type_alias_rust.rs
@@ -1,9 +1,0 @@
-#[cxx::bridge]
-mod ffi {
-    extern "Rust" {
-        /// Incorrect.
-        type Alias = crate::Type;
-    }
-}
-
-fn main() {}

--- a/tests/ui/type_alias_rust.stderr
+++ b/tests/ui/type_alias_rust.stderr
@@ -1,5 +1,0 @@
-error: type alias in extern "Rust" block is not supported
- --> tests/ui/type_alias_rust.rs:5:9
-  |
-5 |         type Alias = crate::Type;
-  |         ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/vec_opaque.stderr
+++ b/tests/ui/vec_opaque.stderr
@@ -11,19 +11,19 @@ error: needs a cxx::ExternType impl in order to be used as a vector element in V
    |         ^^^^^^^^
 
 error[E0271]: type mismatch resolving `<Job as ExternType>::Kind == Trivial`
-  --> tests/ui/vec_opaque.rs:22:14
-   |
-22 |         type Job = crate::handle::Job;
-   |              ^^^ type mismatch resolving `<Job as ExternType>::Kind == Trivial`
-   |
+ --> tests/ui/vec_opaque.rs:22:14
+  |
+ 22 |         type Job = crate::handle::Job;
+    |              ^^^ type mismatch resolving `<Job as ExternType>::Kind == Trivial`
+    |
 note: expected this to be `Trivial`
-  --> tests/ui/vec_opaque.rs:1:1
-   |
- 1 | #[cxx::bridge]
-   | ^^^^^^^^^^^^^^
+   --> tests/ui/vec_opaque.rs:1:1
+    |
+  1 | #[cxx::bridge]
+    | ^^^^^^^^^^^^^^
 note: required by a bound in `verify_extern_kind`
-  --> src/extern_type.rs
-   |
-   | pub fn verify_extern_kind<T: ExternType<Kind = Kind>, Kind: self::Kind>() {}
-   |                                         ^^^^^^^^^^^ required by this bound in `verify_extern_kind`
-   = note: this error originates in the attribute macro `cxx::bridge` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> src/extern_type.rs
+    |
+    | pub fn verify_extern_kind<T: ExternType<Kind = Kind>, Kind: self::Kind>() {}
+    |                                         ^^^^^^^^^^^ required by this bound in `verify_extern_kind`
+    = note: this error originates in the attribute macro `cxx::bridge` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/vector_autotraits.stderr
+++ b/tests/ui/vector_autotraits.stderr
@@ -1,34 +1,34 @@
 error[E0277]: `*const cxx::void` cannot be sent between threads safely
-  --> tests/ui/vector_autotraits.rs:20:19
-   |
-20 |     assert_send::<CxxVector<ffi::NotThreadSafe>>();
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const cxx::void` cannot be sent between threads safely
-   |
-   = help: within `CxxVector<NotThreadSafe>`, the trait `Send` is not implemented for `*const cxx::void`
-   = note: required because it appears within the type `[*const cxx::void; 0]`
+ --> tests/ui/vector_autotraits.rs:20:19
+  |
+ 20 |     assert_send::<CxxVector<ffi::NotThreadSafe>>();
+    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const cxx::void` cannot be sent between threads safely
+    |
+    = help: within `CxxVector<NotThreadSafe>`, the trait `Send` is not implemented for `*const cxx::void`
+    = note: required because it appears within the type `[*const cxx::void; 0]`
 note: required because it appears within the type `cxx::private::Opaque`
-  --> src/opaque.rs
-   |
-   | pub struct Opaque {
-   |            ^^^^^^
+   --> src/opaque.rs
+    |
+ 18 | pub struct Opaque {
+    |            ^^^^^^
 note: required because it appears within the type `NotThreadSafe`
-  --> tests/ui/vector_autotraits.rs:7:14
-   |
- 7 |         type NotThreadSafe;
-   |              ^^^^^^^^^^^^^
-   = note: required because it appears within the type `[NotThreadSafe]`
+   --> tests/ui/vector_autotraits.rs:7:14
+    |
+  7 |         type NotThreadSafe;
+    |              ^^^^^^^^^^^^^
+    = note: required because it appears within the type `[NotThreadSafe]`
 note: required because it appears within the type `PhantomData<[NotThreadSafe]>`
-  --> $RUST/core/src/marker.rs
-   |
-   | pub struct PhantomData<T: PointeeSized>;
-   |            ^^^^^^^^^^^
+   --> $RUST/core/src/marker.rs
+    |
+    | pub struct PhantomData<T: PointeeSized>;
+    |            ^^^^^^^^^^^
 note: required because it appears within the type `CxxVector<NotThreadSafe>`
-  --> src/cxx_vector.rs
-   |
-   | pub struct CxxVector<T> {
-   |            ^^^^^^^^^
+   --> src/cxx_vector.rs
+    |
+ 25 | pub struct CxxVector<T> {
+    |            ^^^^^^^^^
 note: required by a bound in `assert_send`
-  --> tests/ui/vector_autotraits.rs:16:19
-   |
-16 | fn assert_send<T: Send>() {}
-   |                   ^^^^ required by this bound in `assert_send`
+   --> tests/ui/vector_autotraits.rs:16:19
+    |
+ 16 | fn assert_send<T: Send>() {}
+    |                   ^^^^ required by this bound in `assert_send`

--- a/tests/ui/wrong_type_id.stderr
+++ b/tests/ui/wrong_type_id.stderr
@@ -1,19 +1,19 @@
 error[E0271]: type mismatch resolving `<StringPiece as ExternType>::Id == (f, o, l, l, y, (), B, y, t, e, R, a, n, g, e)`
-  --> tests/ui/wrong_type_id.rs:11:14
-   |
-11 |         type ByteRange = crate::here::StringPiece;
-   |              ^^^^^^^^^ type mismatch resolving `<StringPiece as ExternType>::Id == (f, o, l, l, y, (), B, y, t, e, R, a, n, g, e)`
-   |
+ --> tests/ui/wrong_type_id.rs:11:14
+  |
+ 11 |         type ByteRange = crate::here::StringPiece;
+    |              ^^^^^^^^^ type mismatch resolving `<StringPiece as ExternType>::Id == (f, o, l, l, y, (), B, y, t, e, R, a, n, g, e)`
+    |
 note: expected this to be `(f, o, l, l, y, (), B, y, t, e, R, a, n, g, e)`
-  --> tests/ui/wrong_type_id.rs:1:1
-   |
- 1 | #[cxx::bridge(namespace = "folly")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: expected tuple `(f, o, l, l, y, (), B, y, t, e, R, a, n, g, e)`
-              found tuple `(f, o, l, l, y, (), S, t, r, i, n, g, P, i, e, c, e)`
+   --> tests/ui/wrong_type_id.rs:1:1
+    |
+  1 | #[cxx::bridge(namespace = "folly")]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    = note: expected tuple `(f, o, l, l, y, (), B, y, t, e, R, a, n, g, e)`
+               found tuple `(f, o, l, l, y, (), S, t, r, i, n, g, P, i, e, c, e)`
 note: required by a bound in `verify_extern_type`
-  --> src/extern_type.rs
-   |
-   | pub fn verify_extern_type<T: ExternType<Id = Id>, Id>() {}
-   |                                         ^^^^^^^ required by this bound in `verify_extern_type`
-   = note: this error originates in the attribute macro `cxx::bridge` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> src/extern_type.rs
+    |
+    | pub fn verify_extern_type<T: ExternType<Id = Id>, Id>() {}
+    |                                         ^^^^^^^ required by this bound in `verify_extern_type`
+    = note: this error originates in the attribute macro `cxx::bridge` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
PTAL?

This PR fixes https://crbug.com/433254489 (/cc @shabbyx as FYI - IIUC they've patched this PR onto their local machine and verified that it does indeed unblock them).

The first commit fixes some existing code duplication and prevents more code duplication around how `fn syntax::parse_items` consumes a `syntax::Module`.  I think this commit is okay and moves things in a reasonable direction, but I acknowledge that adding more partial consumption/destructuring/taking is a bit icky.  More discussion about this aspect of the changes can be found in a comment from a semi-internal review at https://github.com/anforowicz/cxx/pull/2#discussion_r2229465883 and https://github.com/anforowicz/cxx/pull/2#discussion_r2231757082.

I also note that some existing variants of `syntax::Api` `enum` have Rust and C++ versions - e.g. `RustFunction` and `CxxFunction` as well as `RustType` and `CxxType`.  We could also do that for the `TypeAlias` variant which this PR doesn't touch just yet.  Please provide feedback on whether I should also submit an additional commit into this or a separate PR - see https://github.com/anforowicz/cxx/tree/api-rust-type-alias-separate-variant

/cc @zetafunction who has kindly provided initial, semi-internal feedback at https://github.com/anforowicz/cxx/pull/2