### PR TITLE
Move C++ testing from /tmp to Cargo scratch directory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ indoc = "2"
 proc-macro2 = "1.0.95"
 quote = "1.0.40"
 rustversion = "1.0.13"
+scratch = "1"
 target-triple = "0.1"
 tempfile = "3"
 trybuild = { version = "1.0.81", features = ["diff"] }

--- a/tests/cpp_compile/mod.rs
+++ b/tests/cpp_compile/mod.rs
@@ -47,7 +47,8 @@ impl Test {
     #[must_use]
     pub fn new(cxx_bridge: TokenStream) -> Self {
         let prefix = concat!(env!("CARGO_CRATE_NAME"), "-");
-        let temp_dir = TempDir::with_prefix(prefix).unwrap();
+        let scratch = scratch::path("cxx-test-suite");
+        let temp_dir = TempDir::with_prefix_in(prefix, scratch).unwrap();
         let generated_h = temp_dir.path().join("cxx_bridge.generated.h");
         let generated_cc = temp_dir.path().join("cxx_bridge.generated.cc");
 


### PR DESCRIPTION
If the test is interrupted before cleaning up a tempdir, they are cleaned up by `cargo clean` instead of remaining in /tmp.