### PR TITLE
Remove double-copy of message during rust::Error construction

### DIFF
--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -463,8 +463,9 @@ static_assert(!std::is_same<Vec<std::uint8_t>::const_iterator,
               "Vec<T>::const_iterator != Vec<T>::iterator");
 
 static const char *errorCopy(const char *ptr, std::size_t len) {
-  char *copy = new char[len];
+  char *copy = new char[len + 1];
   std::memcpy(copy, ptr, len);
+  copy[len] = '\0';
   return copy;
 }
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -37,8 +37,6 @@ where
 }
 
 unsafe fn to_c_error(msg: String) -> Result {
-    let mut msg = msg;
-    unsafe { msg.as_mut_vec() }.push(b'\0');
     let ptr = msg.as_ptr();
     let len = msg.len();
 


### PR DESCRIPTION
This makes `errorCopy` work whether it's copying an error message from a Rust `String` (no nul terminator) or `rust::Error`'s copy constructor (already nul terminated). Previously it only worked with nul terminated input.