### PR TITLE
Drop Rust 1.74 from test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable, 1.82.0, 1.80.0, 1.77.0, 1.74.0, 1.73.0]
+        rust: [nightly, beta, stable, 1.82.0, 1.80.0, 1.77.0, 1.73.0]
         os: [ubuntu]
         cc: ['']
         flags: ['']
@@ -83,7 +83,7 @@ jobs:
         if: matrix.os == 'macos'
       - run: cargo run --manifest-path demo/Cargo.toml
       - run: cargo test --workspace ${{steps.testsuite.outputs.exclude}}
-        if: matrix.rust != '1.74.0' && matrix.rust != '1.73.0'
+        if: matrix.rust != '1.73.0'
       - run: cargo check --no-default-features --features alloc
         env:
           RUSTFLAGS: --cfg compile_error_if_std ${{env.RUSTFLAGS}}


### PR DESCRIPTION
This was added in https://github.com/dtolnay/cxx/commit/318be9adf0c3ba2b5b0a411458c79c56f94a887b because it was the oldest compiler we supported testing at the time. These days the minimum is 1.77 since https://github.com/dtolnay/cxx/commit/6a217fc9f773c3ebab6c4cc789a651f27f908a35 and there is no longer a point building 1.74, as it will be identical to 1.73.