### PR TITLE
Add CI on Rust 1.81

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable, 1.82.0, 1.80.0, 1.77.0, 1.73.0]
+        rust: [nightly, beta, stable, 1.82.0, 1.81.0, 1.80.0, 1.77.0, 1.73.0]
         os: [ubuntu]
         cc: ['']
         flags: ['']


### PR DESCRIPTION
This covers the oldest version on which we use the `core::error::Error` trait.

https://github.com/dtolnay/cxx/blob/462c1e0a02f3be63fa53de7eb0e65f798a16f4c9/build.rs#L53-L56

https://github.com/dtolnay/cxx/blob/462c1e0a02f3be63fa53de7eb0e65f798a16f4c9/src/exception.rs#L6-L7