### PR TITLE
Turn on exception handling for Buck on Windows

### DIFF
--- a/tools/buck/toolchains/BUCK
+++ b/tools/buck/toolchains/BUCK
@@ -10,7 +10,7 @@ system_cxx_toolchain(
     cxx_flags = select({
         "config//os:linux": ["-std=c++17"],
         "config//os:macos": ["-std=c++17"],
-        "config//os:windows": [],
+        "config//os:windows": ["/EHsc"],
     }),
     link_flags = select({
         "config//os:linux": ["-lstdc++"],


### PR DESCRIPTION
Without this one of the tests is going to abort instead of throw.

> Error: rust::Vec index out of range. Aborting.