### PR TITLE
Disable exception detection on MSVC

### DIFF
--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -10,7 +10,11 @@
 //
 // Some compilers never set either one. On these, rely on the user to do
 // `-DRUST_CXX_NO_EXCEPTIONS` if they are not using exceptions.
-#if defined(__cpp_attributes) && !defined(__cpp_exceptions)
+//
+// On MSVC, it is possible for exception throwing and catching to be enabled
+// without __cpp_exceptions being defined, so do not try to detect anything.
+#if defined(__cpp_attributes) && !defined(__cpp_exceptions) &&                 \
+    (!defined(_MSC_VER) || defined(__llvm__))
 #define RUST_CXX_NO_EXCEPTIONS
 #endif
 


### PR DESCRIPTION
This test was passing prior to https://github.com/dtolnay/cxx/pull/1174 without needing https://github.com/dtolnay/cxx/pull/1556. This means there are cases where MSVC has working support for throw/catch without defining `__cpp_exceptions`.

https://github.com/dtolnay/cxx/blob/c6ab3793f72dee725b2d2ea6d74cf74deca63b46/tests/ffi/tests.cc#L385-L392

