### PR TITLE
Set `/WX` (warnings as errors) for MSVC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
             flags: -std=c++20
     env:
       CXX: ${{matrix.cc}}
-      CXXFLAGS: ${{matrix.flags}} ${{matrix.os != 'windows' && '-Werror -Wall' || ''}}
+      CXXFLAGS: ${{matrix.flags}} ${{matrix.os == 'windows' && '/WX' || '-Werror -Wall'}}
       RUSTFLAGS: --cfg deny_warnings -Dwarnings
     timeout-minutes: 45
     steps:


### PR DESCRIPTION
https://learn.microsoft.com/en-us/cpp/build/reference/compiler-option-warning-level?view=msvc-170