### PR TITLE
Improve panic location in SharedPtr::from_raw

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1616,6 +1616,7 @@ fn expand_shared_ptr(
                 }
             }
             #new_method
+            #[track_caller]
             unsafe fn __raw(new: *mut ::cxx::core::ffi::c_void, raw: *mut Self) {
                 #UnsafeExtern extern "C" {
                     #[link_name = #link_raw]

--- a/src/shared_ptr.rs
+++ b/src/shared_ptr.rs
@@ -104,6 +104,7 @@ where
     ///
     /// Pointer must either be null or point to a valid instance of T
     /// heap-allocated in C++ by `new`.
+    #[track_caller]
     pub unsafe fn from_raw(raw: *mut T) -> Self {
         let mut shared_ptr = MaybeUninit::<SharedPtr<T>>::uninit();
         let new = shared_ptr.as_mut_ptr().cast();


### PR DESCRIPTION
In #1579, the panic would be shown as occurring on the line containing `impl SharedPtr<Undefined> {}`. After this PR it will appear on the line containing the `SharedPtr::from_raw` call.