### PR TITLE
Require cc version >=1.0.101

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,11 @@ foldhash = { version = "0.2", default-features = false }
 link-cplusplus = "1.0.9"
 
 [build-dependencies]
-cc = "1.0.83"
+cc = "1.0.101"
 cxxbridge-flags = { version = "=1.0.173", path = "flags", default-features = false }
 
 [dev-dependencies]
-cc = "1.0.83"
+cc = "1.0.101"
 cxx-build = { version = "=1.0.173", path = "gen/build" }
 cxx-gen = { version = "0.7", path = "gen/lib" }
 cxx-test-suite = { version = "0", path = "tests/ffi" }

--- a/gen/build/Cargo.toml
+++ b/gen/build/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.73"
 parallel = ["cc/parallel"]
 
 [dependencies]
-cc = "1.0.83"
+cc = "1.0.101"
 codespan-reporting = "0.12"
 indexmap = "2.9.0"
 proc-macro2 = { version = "1.0.74", default-features = false, features = ["span-locations"] }

--- a/third-party/Cargo.toml
+++ b/third-party/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 rust-version = "1.77"
 
 [dependencies]
-cc = "1.0.83"
+cc = "1.0.101"
 clap = { version = "4", default-features = false, features = ["error-context", "help", "std", "usage"] }
 codespan-reporting = "0.12"
 foldhash = "0.2"


### PR DESCRIPTION
Versions 1.0.70 through 1.0.100 no longer compile in nightly-2025-08-31 due to a regression in std::env::split_paths.

This unbreaks our `-Zminimal-versions` CI.