### PR TITLE
Declare dev dependency on tempfile 3.8+

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ quote = "1.0.40"
 rustversion = "1.0.13"
 scratch = "1"
 target-triple = "0.1"
-tempfile = "3"
+tempfile = "3.8"
 trybuild = { version = "1.0.81", features = ["diff"] }
 
 # Disallow incompatible cxxbridge-cmd version appearing in the same lockfile.


### PR DESCRIPTION
We use TempDir::with_prefix_in which was not present in older versions.

```console
error[E0599]: no function or associated item named `with_prefix_in` found for struct `TempDir` in the current scope
   --> tests/cpp_compile/mod.rs:51:33
    |
 51 |         let temp_dir = TempDir::with_prefix_in(prefix, scratch).unwrap();
    |                                 ^^^^^^^^^^^^^^ function or associated item not found in `TempDir`
    |
note: if you're trying to build a new `TempDir` consider using one of the following associated functions:
      TempDir::new
      TempDir::new_in
   --> $CARGO_HOME/registry/src/index.crates.io-1949cf8c6b5b557f/tempfile-3.7.1/src/dir.rs:234:5
    |
234 |     pub fn new() -> io::Result<TempDir> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
263 |     pub fn new_in<P: AsRef<Path>>(dir: P) -> io::Result<TempDir> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```