### PR TITLE
Propagate cfg and lint attributes to derived impls

### DIFF
--- a/macro/src/derive.rs
+++ b/macro/src/derive.rs
@@ -100,8 +100,10 @@ pub(crate) fn expand_enum(enm: &Enum, actual_derives: &mut Option<TokenStream>) 
 fn struct_copy(strct: &Struct, span: Span) -> TokenStream {
     let ident = &strct.name.rust;
     let generics = &strct.generics;
+    let attrs = &strct.attrs;
 
     quote_spanned! {span=>
+        #attrs
         #[automatically_derived]
         impl #generics ::cxx::core::marker::Copy for #ident #generics {}
     }
@@ -110,6 +112,7 @@ fn struct_copy(strct: &Struct, span: Span) -> TokenStream {
 fn struct_clone(strct: &Struct, span: Span) -> TokenStream {
     let ident = &strct.name.rust;
     let generics = &strct.generics;
+    let attrs = &strct.attrs;
 
     let body = if derive::contains(&strct.derives, Trait::Copy) {
         quote!(*self)
@@ -127,6 +130,7 @@ fn struct_clone(strct: &Struct, span: Span) -> TokenStream {
     };
 
     quote_spanned! {span=>
+        #attrs
         #[automatically_derived]
         #[allow(clippy::expl_impl_clone_on_copy)]
         impl #generics ::cxx::core::clone::Clone for #ident #generics {
@@ -140,11 +144,13 @@ fn struct_clone(strct: &Struct, span: Span) -> TokenStream {
 fn struct_debug(strct: &Struct, span: Span) -> TokenStream {
     let ident = &strct.name.rust;
     let generics = &strct.generics;
+    let attrs = &strct.attrs;
     let struct_name = ident.to_string();
     let fields = strct.fields.iter().map(|field| &field.name.rust);
     let field_names = fields.clone().map(Ident::to_string);
 
     quote_spanned! {span=>
+        #attrs
         #[automatically_derived]
         impl #generics ::cxx::core::fmt::Debug for #ident #generics {
             fn fmt(&self, formatter: &mut ::cxx::core::fmt::Formatter<'_>) -> ::cxx::core::fmt::Result {
@@ -159,9 +165,11 @@ fn struct_debug(strct: &Struct, span: Span) -> TokenStream {
 fn struct_default(strct: &Struct, span: Span) -> TokenStream {
     let ident = &strct.name.rust;
     let generics = &strct.generics;
+    let attrs = &strct.attrs;
     let fields = strct.fields.iter().map(|field| &field.name.rust);
 
     quote_spanned! {span=>
+        #attrs
         #[automatically_derived]
         #[allow(clippy::derivable_impls)] // different spans than the derived impl
         impl #generics ::cxx::core::default::Default for #ident #generics {
@@ -179,9 +187,11 @@ fn struct_default(strct: &Struct, span: Span) -> TokenStream {
 fn struct_ord(strct: &Struct, span: Span) -> TokenStream {
     let ident = &strct.name.rust;
     let generics = &strct.generics;
+    let attrs = &strct.attrs;
     let fields = strct.fields.iter().map(|field| &field.name.rust);
 
     quote_spanned! {span=>
+        #attrs
         #[automatically_derived]
         impl #generics ::cxx::core::cmp::Ord for #ident #generics {
             fn cmp(&self, other: &Self) -> ::cxx::core::cmp::Ordering {
@@ -200,6 +210,7 @@ fn struct_ord(strct: &Struct, span: Span) -> TokenStream {
 fn struct_partial_ord(strct: &Struct, span: Span) -> TokenStream {
     let ident = &strct.name.rust;
     let generics = &strct.generics;
+    let attrs = &strct.attrs;
 
     let body = if derive::contains(&strct.derives, Trait::Ord) {
         quote! {
@@ -219,6 +230,7 @@ fn struct_partial_ord(strct: &Struct, span: Span) -> TokenStream {
     };
 
     quote_spanned! {span=>
+        #attrs
         #[automatically_derived]
         impl #generics ::cxx::core::cmp::PartialOrd for #ident #generics {
             #[allow(clippy::non_canonical_partial_ord_impl)]
@@ -232,8 +244,10 @@ fn struct_partial_ord(strct: &Struct, span: Span) -> TokenStream {
 
 fn enum_copy(enm: &Enum, span: Span) -> TokenStream {
     let ident = &enm.name.rust;
+    let attrs = &enm.attrs;
 
     quote_spanned! {span=>
+        #attrs
         #[automatically_derived]
         impl ::cxx::core::marker::Copy for #ident {}
     }
@@ -241,8 +255,10 @@ fn enum_copy(enm: &Enum, span: Span) -> TokenStream {
 
 fn enum_clone(enm: &Enum, span: Span) -> TokenStream {
     let ident = &enm.name.rust;
+    let attrs = &enm.attrs;
 
     quote_spanned! {span=>
+        #attrs
         #[automatically_derived]
         #[allow(clippy::expl_impl_clone_on_copy)]
         impl ::cxx::core::clone::Clone for #ident {
@@ -255,6 +271,7 @@ fn enum_clone(enm: &Enum, span: Span) -> TokenStream {
 
 fn enum_debug(enm: &Enum, span: Span) -> TokenStream {
     let ident = &enm.name.rust;
+    let attrs = &enm.attrs;
     let variants = enm.variants.iter().map(|variant| {
         let variant = &variant.name.rust;
         let name = variant.to_string();
@@ -265,6 +282,7 @@ fn enum_debug(enm: &Enum, span: Span) -> TokenStream {
     let fallback = format!("{}({{}})", ident);
 
     quote_spanned! {span=>
+        #attrs
         #[automatically_derived]
         impl ::cxx::core::fmt::Debug for #ident {
             fn fmt(&self, formatter: &mut ::cxx::core::fmt::Formatter<'_>) -> ::cxx::core::fmt::Result {
@@ -279,8 +297,10 @@ fn enum_debug(enm: &Enum, span: Span) -> TokenStream {
 
 fn enum_ord(enm: &Enum, span: Span) -> TokenStream {
     let ident = &enm.name.rust;
+    let attrs = &enm.attrs;
 
     quote_spanned! {span=>
+        #attrs
         #[automatically_derived]
         impl ::cxx::core::cmp::Ord for #ident {
             fn cmp(&self, other: &Self) -> ::cxx::core::cmp::Ordering {
@@ -292,8 +312,10 @@ fn enum_ord(enm: &Enum, span: Span) -> TokenStream {
 
 fn enum_partial_ord(enm: &Enum, span: Span) -> TokenStream {
     let ident = &enm.name.rust;
+    let attrs = &enm.attrs;
 
     quote_spanned! {span=>
+        #attrs
         #[automatically_derived]
         impl ::cxx::core::cmp::PartialOrd for #ident {
             #[allow(clippy::non_canonical_partial_ord_impl)]

--- a/syntax/resolve.rs
+++ b/syntax/resolve.rs
@@ -1,3 +1,4 @@
+use crate::syntax::attrs::OtherAttrs;
 use crate::syntax::instantiate::NamedImplKey;
 use crate::syntax::{Lifetimes, NamedType, Pair, Types};
 use proc_macro2::Ident;
@@ -5,6 +6,8 @@ use proc_macro2::Ident;
 #[derive(Copy, Clone)]
 pub(crate) struct Resolution<'a> {
     pub name: &'a Pair,
+    #[allow(dead_code)] // only used by cxxbridge-macro, not cxx-build
+    pub attrs: &'a OtherAttrs,
     pub generics: &'a Lifetimes,
 }
 


### PR DESCRIPTION
For example:

```rust
#[cxx::bridge]
pub mod ffi {
    #[cfg(target_os = "ios")]
    #[derive(PartialEq)]
    struct Thing {
        name: String,
    }
}
```

Previously this would fail (when not compiling for iOS) because the data structure would be generated conditionally but all its trait impls would be generated unconditionally.

```console
error[E0412]: cannot find type `Thing` in this scope
 --> src/main.rs:5:12
  |
5 |     struct Thing {
  |            ^^^^^ not found in this scope

error[E0412]: cannot find type `Thing` in module `super`
 --> src/main.rs:5:12
  |
5 |     struct Thing {
  |            ^^^^^ not found in `super`
  |
note: found an item that was configured out
 --> src/main.rs:5:12
  |
3 |     #[cfg(target_os = "ios")]
  |           ----------------- the item is gated behind the `ios` feature
4 |     #[derive(PartialEq)]
5 |     struct Thing {
  |            ^^^^^
```