### PR TITLE
Generate implicit impls with cfg matching uses

### DIFF
--- a/macro/src/cfg.rs
+++ b/macro/src/cfg.rs
@@ -1,0 +1,63 @@
+use crate::syntax::cfg::CfgExpr;
+use proc_macro2::{Delimiter, Group, Ident, Span, TokenStream};
+use quote::{ToTokens, TokenStreamExt as _};
+use syn::{token, AttrStyle, Attribute, MacroDelimiter, Meta, MetaList, Path, Token};
+
+impl CfgExpr {
+    pub(crate) fn into_attr(&self) -> Option<Attribute> {
+        if let CfgExpr::Unconditional = self {
+            None
+        } else {
+            let span = Span::call_site();
+            Some(Attribute {
+                pound_token: Token![#](span),
+                style: AttrStyle::Outer,
+                bracket_token: token::Bracket(span),
+                meta: Meta::List(MetaList {
+                    path: Path::from(Ident::new("cfg", span)),
+                    delimiter: MacroDelimiter::Paren(token::Paren(span)),
+                    tokens: Print { cfg: self, span }.into_token_stream(),
+                }),
+            })
+        }
+    }
+}
+
+struct Print<'a> {
+    cfg: &'a CfgExpr,
+    span: Span,
+}
+
+impl<'a> ToTokens for Print<'a> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let span = self.span;
+        let print = |cfg| Print { cfg, span };
+        match self.cfg {
+            CfgExpr::Unconditional => unreachable!(),
+            CfgExpr::Eq(ident, value) => {
+                ident.to_tokens(tokens);
+                if let Some(value) = value {
+                    Token![=](span).to_tokens(tokens);
+                    value.to_tokens(tokens);
+                }
+            }
+            CfgExpr::All(inner) => {
+                tokens.append(Ident::new("all", span));
+                let mut group = TokenStream::new();
+                group.append_separated(inner.iter().map(print), Token![,](span));
+                tokens.append(Group::new(Delimiter::Parenthesis, group));
+            }
+            CfgExpr::Any(inner) => {
+                tokens.append(Ident::new("any", span));
+                let mut group = TokenStream::new();
+                group.append_separated(inner.iter().map(print), Token![,](span));
+                tokens.append(Group::new(Delimiter::Parenthesis, group));
+            }
+            CfgExpr::Not(inner) => {
+                tokens.append(Ident::new("not", span));
+                let group = print(inner).into_token_stream();
+                tokens.append(Group::new(Delimiter::Parenthesis, group));
+            }
+        }
+    }
+}

--- a/macro/src/generics.rs
+++ b/macro/src/generics.rs
@@ -1,5 +1,6 @@
 use crate::syntax::instantiate::NamedImplKey;
 use crate::syntax::resolve::Resolution;
+use crate::syntax::types::ConditionalImpl;
 use crate::syntax::{Impl, Lifetimes};
 use proc_macro2::TokenStream;
 use quote::ToTokens;
@@ -18,16 +19,16 @@ pub(crate) struct TyGenerics<'a> {
 
 pub(crate) fn split_for_impl<'a>(
     key: &'a NamedImplKey<'a>,
-    explicit_impl: Option<&'a Impl>,
+    conditional_impl: &ConditionalImpl<'a>,
     resolve: Resolution<'a>,
 ) -> (ImplGenerics<'a>, TyGenerics<'a>) {
     let impl_generics = ImplGenerics {
-        explicit_impl,
+        explicit_impl: conditional_impl.explicit_impl,
         resolve,
     };
     let ty_generics = TyGenerics {
         key,
-        explicit_impl,
+        explicit_impl: conditional_impl.explicit_impl,
         resolve,
     };
     (impl_generics, ty_generics)

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -23,6 +23,7 @@
 )]
 #![allow(unknown_lints, mismatched_lifetime_syntaxes)]
 
+mod cfg;
 mod derive;
 mod expand;
 mod generics;

--- a/syntax/attrs.rs
+++ b/syntax/attrs.rs
@@ -146,7 +146,7 @@ pub(crate) fn parse(cx: &mut Errors, attrs: Vec<Attribute>, mut parser: Parser) 
             match cfg::parse_attribute(&attr) {
                 Ok(cfg_expr) => {
                     if let Some(cfg) = &mut parser.cfg {
-                        cfg.merge(cfg_expr);
+                        cfg.merge_and(cfg_expr);
                         passthrough_attrs.push(attr);
                         continue;
                     }

--- a/syntax/cfg.rs
+++ b/syntax/cfg.rs
@@ -9,21 +9,35 @@ pub(crate) enum CfgExpr {
     #[allow(dead_code)] // only used by cxx-build, not cxxbridge-macro
     Eq(Ident, Option<LitStr>),
     All(Vec<CfgExpr>),
-    #[allow(dead_code)] // only used by cxx-build, not cxxbridge-macro
     Any(Vec<CfgExpr>),
     #[allow(dead_code)] // only used by cxx-build, not cxxbridge-macro
     Not(Box<CfgExpr>),
 }
 
 impl CfgExpr {
-    pub(crate) fn merge(&mut self, expr: CfgExpr) {
+    pub(crate) fn merge_and(&mut self, expr: CfgExpr) {
         if let CfgExpr::Unconditional = self {
             *self = expr;
+        } else if let CfgExpr::Unconditional = expr {
+            // drop
         } else if let CfgExpr::All(list) = self {
             list.push(expr);
         } else {
             let prev = mem::replace(self, CfgExpr::Unconditional);
             *self = CfgExpr::All(vec![prev, expr]);
+        }
+    }
+
+    pub(crate) fn merge_or(&mut self, expr: CfgExpr) {
+        if let CfgExpr::Unconditional = self {
+            // drop
+        } else if let CfgExpr::Unconditional = expr {
+            *self = expr;
+        } else if let CfgExpr::Any(list) = self {
+            list.push(expr);
+        } else {
+            let prev = mem::replace(self, CfgExpr::Unconditional);
+            *self = CfgExpr::Any(vec![prev, expr]);
         }
     }
 }

--- a/syntax/cfg.rs
+++ b/syntax/cfg.rs
@@ -6,11 +6,9 @@ use syn::{parenthesized, token, Attribute, LitStr, Token};
 #[derive(Clone)]
 pub(crate) enum CfgExpr {
     Unconditional,
-    #[allow(dead_code)] // only used by cxx-build, not cxxbridge-macro
     Eq(Ident, Option<LitStr>),
     All(Vec<CfgExpr>),
     Any(Vec<CfgExpr>),
-    #[allow(dead_code)] // only used by cxx-build, not cxxbridge-macro
     Not(Box<CfgExpr>),
 }
 

--- a/syntax/map.rs
+++ b/syntax/map.rs
@@ -30,6 +30,10 @@ mod ordered {
             self.0.insert(key, value)
         }
 
+        pub(crate) fn entry(&mut self, key: K) -> indexmap::map::Entry<K, V> {
+            self.0.entry(key)
+        }
+
         pub(crate) fn contains_key<Q>(&self, key: &Q) -> bool
         where
             Q: ?Sized + Hash + indexmap::Equivalent<K>,

--- a/syntax/map.rs
+++ b/syntax/map.rs
@@ -33,13 +33,6 @@ mod ordered {
         pub(crate) fn entry(&mut self, key: K) -> indexmap::map::Entry<K, V> {
             self.0.entry(key)
         }
-
-        pub(crate) fn contains_key<Q>(&self, key: &Q) -> bool
-        where
-            Q: ?Sized + Hash + indexmap::Equivalent<K>,
-        {
-            self.0.contains_key(key)
-        }
     }
 
     impl<'a, K, V> IntoIterator for &'a OrderedMap<K, V> {

--- a/syntax/trivial.rs
+++ b/syntax/trivial.rs
@@ -1,4 +1,5 @@
-use crate::syntax::map::UnorderedMap;
+use crate::syntax::cfg::CfgExpr;
+use crate::syntax::map::{OrderedMap, UnorderedMap};
 use crate::syntax::set::{OrderedSet as Set, UnorderedSet};
 use crate::syntax::{Api, Enum, ExternFn, NamedType, Pair, Struct, Type};
 use proc_macro2::Ident;
@@ -17,7 +18,7 @@ pub(crate) enum TrivialReason<'a> {
 
 pub(crate) fn required_trivial_reasons<'a>(
     apis: &'a [Api],
-    all: &Set<&'a Type>,
+    all: &OrderedMap<&'a Type, CfgExpr>,
     structs: &UnorderedMap<&'a Ident, &'a Struct>,
     enums: &UnorderedMap<&'a Ident, &'a Enum>,
     cxx: &UnorderedSet<&'a Ident>,
@@ -92,7 +93,10 @@ pub(crate) fn required_trivial_reasons<'a>(
         }
     }
 
-    for ty in all {
+    for (ty, _cfg) in all {
+        // Ignore cfg. For now if any use of an extern type requires it to be
+        // trivial, we enforce that it is trivial in all configurations. This
+        // can potentially be relaxed if there is a motivating use case.
         match ty {
             Type::RustBox(ty) => {
                 if let Type::Ident(ident) = &ty.inner {


### PR DESCRIPTION
For example:

```rust
#[cxx::bridge]
pub mod ffi {
    extern "C++" {
        type Thing;
    }

    #[cfg(aaaa)]
    struct Wrapper {
        name: String,
        #[cfg(bbbb)]
        thing: UniquePtr<Thing>,
    }

    #[cfg(cccc)]
    unsafe extern "C++" {
        #[cfg(dddd)]
        fn mk() -> UniquePtr<Thing>;
    }
}
```

This needs to expand to

```rust
...
#[cfg(any(all(aaaa, bbbb), all(cccc, dddd)))]
#[automatically_derived]
unsafe impl ::cxx::memory::UniquePtrTarget for Thing
...
```

because this is the configuration under which the required C++ symbols will exist on the generated C++ side.