### PR TITLE
Generate cxx::memory and cxx:vector impls using public path of trait

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1657,7 +1657,7 @@ fn expand_unique_ptr(
     quote_spanned! {end_span=>
         #cfg
         #[automatically_derived]
-        #unsafe_token impl #impl_generics ::cxx::private::UniquePtrTarget for #ident #ty_generics {
+        #unsafe_token impl #impl_generics ::cxx::memory::UniquePtrTarget for #ident #ty_generics {
             fn __typename(f: &mut ::cxx::core::fmt::Formatter<'_>) -> ::cxx::core::fmt::Result {
                 f.write_str(#name)
             }
@@ -1759,7 +1759,7 @@ fn expand_shared_ptr(
     quote_spanned! {end_span=>
         #cfg
         #[automatically_derived]
-        #unsafe_token impl #impl_generics ::cxx::private::SharedPtrTarget for #ident #ty_generics {
+        #unsafe_token impl #impl_generics ::cxx::memory::SharedPtrTarget for #ident #ty_generics {
             fn __typename(f: &mut ::cxx::core::fmt::Formatter<'_>) -> ::cxx::core::fmt::Result {
                 f.write_str(#name)
             }
@@ -1841,7 +1841,7 @@ fn expand_weak_ptr(
     quote_spanned! {end_span=>
         #cfg
         #[automatically_derived]
-        #unsafe_token impl #impl_generics ::cxx::private::WeakPtrTarget for #ident #ty_generics {
+        #unsafe_token impl #impl_generics ::cxx::memory::WeakPtrTarget for #ident #ty_generics {
             fn __typename(f: &mut ::cxx::core::fmt::Formatter<'_>) -> ::cxx::core::fmt::Result {
                 f.write_str(#name)
             }
@@ -1989,7 +1989,7 @@ fn expand_cxx_vector(
     quote_spanned! {end_span=>
         #cfg
         #[automatically_derived]
-        #unsafe_token impl #impl_generics ::cxx::private::VectorElement for #elem #ty_generics {
+        #unsafe_token impl #impl_generics ::cxx::vector::VectorElement for #elem #ty_generics {
             fn __typename(f: &mut ::cxx::core::fmt::Formatter<'_>) -> ::cxx::core::fmt::Result {
                 f.write_str(#name)
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -492,7 +492,6 @@ pub type Vector<T> = CxxVector<T>;
 // Not public API.
 #[doc(hidden)]
 pub mod private {
-    pub use crate::cxx_vector::VectorElement;
     pub use crate::extern_type::{verify_extern_kind, verify_extern_type};
     pub use crate::function::FatFunction;
     pub use crate::hash::hash;
@@ -506,11 +505,8 @@ pub mod private {
     pub use crate::rust_type::{ImplBox, ImplVec, RustType};
     #[cfg(feature = "alloc")]
     pub use crate::rust_vec::RustVec;
-    pub use crate::shared_ptr::SharedPtrTarget;
     pub use crate::string::StackString;
-    pub use crate::unique_ptr::UniquePtrTarget;
     pub use crate::unwind::prevent_unwind;
-    pub use crate::weak_ptr::WeakPtrTarget;
     pub use core::{concat, module_path};
     pub use cxxbridge_macro::type_id;
 }


### PR DESCRIPTION
These traits all can be named publicly since https://github.com/dtolnay/cxx/pull/762.