### PR TITLE
Deduplicate elements of computed cfg

### DIFF
--- a/syntax/cfg.rs
+++ b/syntax/cfg.rs
@@ -1,4 +1,7 @@
+use indexmap::{indexset as set, IndexSet as Set};
 use proc_macro2::Ident;
+use std::hash::{Hash, Hasher};
+use std::iter;
 use std::mem;
 use syn::parse::{Error, ParseStream, Result};
 use syn::{parenthesized, token, Attribute, LitStr, Token};
@@ -15,9 +18,8 @@ pub(crate) enum CfgExpr {
 #[derive(Clone)]
 pub(crate) enum ComputedCfg<'a> {
     Leaf(&'a CfgExpr),
-    #[allow(dead_code)] // only used by cxxbridge-macro, not cxx-build
-    All(Vec<&'a CfgExpr>),
-    Any(Vec<ComputedCfg<'a>>),
+    All(Set<&'a CfgExpr>),
+    Any(Set<ComputedCfg<'a>>),
 }
 
 impl CfgExpr {
@@ -37,12 +39,12 @@ impl CfgExpr {
 
 impl<'a> ComputedCfg<'a> {
     pub(crate) fn all(one: &'a CfgExpr, two: &'a CfgExpr) -> Self {
-        if let CfgExpr::Unconditional = two {
+        if let (cfg, CfgExpr::Unconditional) | (CfgExpr::Unconditional, cfg) = (one, two) {
+            ComputedCfg::Leaf(cfg)
+        } else if one == two {
             ComputedCfg::Leaf(one)
-        } else if let CfgExpr::Unconditional = one {
-            ComputedCfg::Leaf(two)
         } else {
-            ComputedCfg::All(vec![one, two])
+            ComputedCfg::All(set![one, two])
         }
     }
 
@@ -52,10 +54,12 @@ impl<'a> ComputedCfg<'a> {
             // drop
         } else if let ComputedCfg::Leaf(CfgExpr::Unconditional) = other {
             *self = other;
+        } else if *self == other {
+            // drop
         } else if let ComputedCfg::Any(list) = self {
-            list.push(other);
+            list.insert(other);
         } else {
-            let prev = mem::replace(self, ComputedCfg::Any(Vec::new()));
+            let prev = mem::replace(self, ComputedCfg::Any(Set::new()));
             let ComputedCfg::Any(list) = self else {
                 unreachable!();
             };
@@ -67,6 +71,79 @@ impl<'a> ComputedCfg<'a> {
 impl<'a> From<&'a CfgExpr> for ComputedCfg<'a> {
     fn from(cfg: &'a CfgExpr) -> Self {
         ComputedCfg::Leaf(cfg)
+    }
+}
+
+impl Eq for CfgExpr {}
+
+impl PartialEq for CfgExpr {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (CfgExpr::Unconditional, CfgExpr::Unconditional) => true,
+            (CfgExpr::Eq(this_ident, None), CfgExpr::Eq(other_ident, None)) => {
+                this_ident == other_ident
+            }
+            (
+                CfgExpr::Eq(this_ident, Some(this_value)),
+                CfgExpr::Eq(other_ident, Some(other_value)),
+            ) => {
+                this_ident == other_ident
+                    && this_value.token().to_string() == other_value.token().to_string()
+            }
+            (CfgExpr::All(this), CfgExpr::All(other))
+            | (CfgExpr::Any(this), CfgExpr::Any(other)) => this == other,
+            (CfgExpr::Not(this), CfgExpr::Not(other)) => this == other,
+            (_, _) => false,
+        }
+    }
+}
+
+impl Hash for CfgExpr {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        mem::discriminant(self).hash(hasher);
+        match self {
+            CfgExpr::Unconditional => {}
+            CfgExpr::Eq(ident, value) => {
+                ident.hash(hasher);
+                // syn::LitStr does not have its own Hash impl
+                value.as_ref().map(LitStr::value).hash(hasher);
+            }
+            CfgExpr::All(inner) | CfgExpr::Any(inner) => inner.hash(hasher),
+            CfgExpr::Not(inner) => inner.hash(hasher),
+        }
+    }
+}
+
+impl<'a> Eq for ComputedCfg<'a> {}
+
+impl<'a> PartialEq for ComputedCfg<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (ComputedCfg::Leaf(this), ComputedCfg::Leaf(other)) => this == other,
+            // For the purpose of deduplicating the contents of an `all` or
+            // `any`, we only consider sets equal if they contain the same cfgs
+            // in the same order.
+            (ComputedCfg::All(this), ComputedCfg::All(other)) => {
+                this.len() == other.len()
+                    && iter::zip(this, other).all(|(this, other)| this == other)
+            }
+            (ComputedCfg::Any(this), ComputedCfg::Any(other)) => {
+                this.len() == other.len()
+                    && iter::zip(this, other).all(|(this, other)| this == other)
+            }
+            (_, _) => false,
+        }
+    }
+}
+
+impl<'a> Hash for ComputedCfg<'a> {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        mem::discriminant(self).hash(hasher);
+        match self {
+            ComputedCfg::Leaf(cfg) => cfg.hash(hasher),
+            ComputedCfg::All(inner) => inner.iter().for_each(|cfg| cfg.hash(hasher)),
+            ComputedCfg::Any(inner) => inner.iter().for_each(|cfg| cfg.hash(hasher)),
+        }
     }
 }
 

--- a/syntax/trivial.rs
+++ b/syntax/trivial.rs
@@ -1,4 +1,4 @@
-use crate::syntax::cfg::CfgExpr;
+use crate::syntax::cfg::ComputedCfg;
 use crate::syntax::map::{OrderedMap, UnorderedMap};
 use crate::syntax::set::{OrderedSet as Set, UnorderedSet};
 use crate::syntax::{Api, Enum, ExternFn, NamedType, Pair, Struct, Type};
@@ -18,7 +18,7 @@ pub(crate) enum TrivialReason<'a> {
 
 pub(crate) fn required_trivial_reasons<'a>(
     apis: &'a [Api],
-    all: &OrderedMap<&'a Type, CfgExpr>,
+    all: &OrderedMap<&'a Type, ComputedCfg>,
     structs: &UnorderedMap<&'a Ident, &'a Struct>,
     enums: &UnorderedMap<&'a Ident, &'a Enum>,
     cxx: &UnorderedSet<&'a Ident>,


### PR DESCRIPTION
Previously, a module containing multiple conditional uses of an implicit impl, like this:

```rust
pub mod ffi {
    extern "C++" {
        type Thing;
    }
    #[cfg(target_os = "linux")]
    unsafe extern "C++" {
        fn a(_: UniquePtr<Thing>);
        fn b(_: UniquePtr<Thing>);
        fn c(_: UniquePtr<Thing>);
        fn d(_: UniquePtr<Thing>);
    }
}
```

would expand to a repetitive cfg on the UniquePtr impl:

```rust
...
#[cfg(any(any(target_os = "linux", target_os = "linux", target_os = "linux", target_os = "linux")))]
#[automatically_derived]
unsafe impl ::cxx::memory::UniquePtrTarget for Thing
...
```

This change makes it expand to `#[cfg(target_os = "linux")]` by accumulating `any` and `all` cfg elements in a set, instead of a vec.