### PR TITLE
Improving support for cross-bridge type aliases of Rust types.

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -427,6 +427,7 @@ fn write_opaque_type<'a>(out: &mut OutFile<'a>, ety: &'a ExternType, methods: &[
     }
 
     writeln!(out, "  ~{}() = delete;", ety.name.cxx);
+    writeln!(out, "  using IsRelocatable = std::true_type;");
     writeln!(out);
 
     out.builtin.layout = true;

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -991,7 +991,7 @@ fn expand_rust_type_impl(ety: &ExternType) -> TokenStream {
                     #[allow(unused_attributes)] // incorrect lint
                     #[doc(hidden)]
                     type Id = #type_id;
-                    type Kind = ::cxx::kind::Opaque;
+                    type Kind = ::cxx::kind::Trivial;
                 }
             });
         }

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -369,6 +369,15 @@ pub mod ffi {
     impl SharedPtr<Undefined> {}
     impl SharedPtr<Private> {}
     impl UniquePtr<Array> {}
+
+    extern "C++" {
+        type CrossModuleRustType = crate::module::CrossModuleRustType;
+    }
+
+    extern "Rust" {
+        fn r_get_value_from_cross_module_rust_type(value: &CrossModuleRustType) -> i32;
+        fn r_mut_ref_cross_module_rust_type(x: &mut CrossModuleRustType, new_value: i32);
+    }
 }
 
 mod other {
@@ -700,4 +709,12 @@ fn r_try_return_mutsliceu8(slice: &mut [u8]) -> Result<&mut [u8], Error> {
 
 fn r_aliased_function(x: i32) -> String {
     x.to_string()
+}
+
+fn r_get_value_from_cross_module_rust_type(value: &crate::module::CrossModuleRustType) -> i32 {
+    value.0
+}
+
+fn r_mut_ref_cross_module_rust_type(x: &mut crate::module::CrossModuleRustType, new_value: i32) {
+    x.0 = new_value;
 }

--- a/tests/ffi/module.rs
+++ b/tests/ffi/module.rs
@@ -78,3 +78,21 @@ pub mod ffi2 {
     impl UniquePtr<F> {}
     impl UniquePtr<G> {}
 }
+
+#[cxx::bridge(namespace = "tests")]
+pub mod ffi3 {
+    extern "Rust" {
+        #[derive(ExternType)]
+        type CrossModuleRustType;
+
+        #[allow(clippy::unnecessary_box_returns)]
+        fn r_boxed_cross_module_rust_type(value: i32) -> Box<CrossModuleRustType>;
+    }
+}
+
+pub struct CrossModuleRustType(pub i32);
+
+#[allow(clippy::unnecessary_box_returns)]
+fn r_boxed_cross_module_rust_type(value: i32) -> Box<CrossModuleRustType> {
+    Box::new(CrossModuleRustType(value))
+}

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -992,6 +992,12 @@ extern "C" const char *cxx_run_test() noexcept {
   (void)rust::Vec<size_t>();
   (void)rust::Vec<rust::isize>();
 
+  {
+    auto r = r_boxed_cross_module_rust_type(123);
+    r_mut_ref_cross_module_rust_type(*r, 456);
+    ASSERT(456 == r_get_value_from_cross_module_rust_type(*r));
+  }
+
   cxx_test_suite_set_correct();
   return nullptr;
 }


### PR DESCRIPTION
This PR improves docs (to explain that the type alias has to go into a `extern "C++"` section, and to point out the need to use `#[derive(ExternType)]`).

This commit also fixes errors that would be reported if a type alias for a Rust type would be used as a `&mut T` parameter.  The fixes boil down to ensuring that the Rust type is recognized as Rust-movable.  More details can be found in the PR discussion.

# Description of changes in `macro/src/expand.rs`

https://github.com/dtolnay/cxx/commit/16e2620fe51032d789770b489e27a9c6c27719ef has introduced support for `#[derive(ExternType)]` in `extern “Rust”` section.  I don’t understand why this commit used `type Kind = ::cxx::kind::Opaque` rather than `kind::Trivial`.

Docs for [`cxx::kind::Opaque`](https://docs.rs/cxx/1.0.175/cxx/kind/enum.Opaque.html) say that “an opaque type [...] cannot be passed or held by value within Rust” because “Rust’s move semantics are such that every move is equivalent to a memcpy” (which is “incompatible in general with C++’s constructor-based move semantics”).

Docs for [`cxx::kind::Trivial`](https://docs.rs/cxx/1.0.175/cxx/kind/enum.Trivial.html) say that this is “a type with trivial move constructor and no destructor, which can therefore be owned and moved around in Rust code without requiring indirection”.

Based on [`tests/ui/rust_pinned.rs`](https://github.com/dtolnay/cxx/blob/fff9d28d713a54a1b575b3d798432d2ae8027f0b/tests/ui/rust_pinned.rs) (and the corresponding expected error message in [the `.stderr` file here](https://github.com/dtolnay/cxx/blob/fff9d28d713a54a1b575b3d798432d2ae8027f0b/tests/ui/rust_pinned.stderr) I assume that `cxx` does not allow `extern “Rust” { type RustType; }` for `!Unpin` types.  So this would mean that all Rust types supported by `cxx` can be moved by `memcpy`.

Therefore it seems okay to change `macro/src/[expand.rs](http://expand.rs/)` to emit `type Kind = ::cxx::kind::Trivial`

Without the change in [`macro/src/expand.rs`](https://github.com/dtolnay/cxx/commit/81f774d2b1a44cdf2a600a9c1e8b5e69b78ca4af#diff-e21af94dd924766138d7f7e4602b7cfed26b1976d0c0830d40b9c4b948dd929e), the new tests would result in the following error:

```
error[E0271]: type mismatch resolving `<CrossModuleRustType as ExternType>::Kind == Trivial`
   --> tests/ffi/lib.rs:374:14
    |
374 |         type CrossModuleRustType = crate::module::CrossModuleRustType;
    |              ^^^^^^^^^^^^^^^^^^^ type mismatch resolving `<CrossModuleRustType as ExternType>::Kind == Trivial`
    |
note: expected this to be `Trivial`
   --> tests/ffi/module.rs:85:18
    |
 85 |         #[derive(ExternType)]
    |                  ^^^^^^^^^^
note: required by a bound in `verify_extern_kind`
   --> /usr/local/google/home/lukasza/src/github/cxx/src/extern_type.rs:187:41
    |
187 | pub fn verify_extern_kind<T: ExternType<Kind = Kind>, Kind: self::Kind>() {}
    |                                         ^^^^^^^^^^^ required by this bound in `verify_extern_kind`
```

# Description of changes in `gen/src/write.rs`

Currently C++ bindings for `extern “Rust”` types do **not** mark the bindings as relocatable (in the [`cxx::IsRelocatable<T>`](https://github.com/dtolnay/cxx/blob/fff9d28d713a54a1b575b3d798432d2ae8027f0b/include/cxx.h#L489-L490) sense).

The doc comment of `cxx::IsRelocatable` says this is an assertion that the type “is soundly relocatable by Rust”.

We already established above that all Rust types supported by `cxx` can be moved by `memcpy`.  Therefore from that perspective it seems okay to start emitting `using IsRelocatable = ::std::true_type` inside the struct/bindings emitted for Rust types by `fn write_opaque_type` in `gen/src/[write.rs](http://write.rs/)`.

Emitting a new public member carries a risk that its name may conflict/clash with another, preexisting member.  So from that perspective, it may be safer to directly specialize `cxx::IsRelocatable`.  OTOH, [the Rust naming guidelines](https://rust-lang.github.io/api-guidelines/naming.html#casing-conforms-to-rfc-430-c-case) reserve UpperCamelCase to types, traits, enum variants, and type parameters - this means that a clash with `IsRelocatable` seems unlikely.

Without the change in [`gen/src/write.rs`](https://github.com/dtolnay/cxx/commit/81f774d2b1a44cdf2a600a9c1e8b5e69b78ca4af#diff-7719228d0694503ed3ea2dd14d6561e3bcaad827e0ce3c8f2433b70476dff099), the new tests would result in the following error:

```
warning: cxx-test-suite@0.0.0: /usr/local/google/home/lukasza/src/github/cxx/target/debug/build/cxx-test-suite-690332097c2cd1c3/out/cxxbridge/sources/tests/ffi/lib.rs.cc:1489:58: error: static assertion failed: type tests::CrossModuleRustType should be trivially move constructible and trivially destructible in C++ to be used as a non-pinned mutable reference in signature of `r_mut_ref_cross_module_rust_type` in Rust
warning: cxx-test-suite@0.0.0:  1489 |     ::rust::IsRelocatable<::tests::CrossModuleRustType>::value,
warning: cxx-test-suite@0.0.0:       |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
error: failed to run custom build command for `cxx-test-suite v0.0.0 (/usr/local/google/home/lukasza/src/github/cxx/tests/ffi)`
```

----------------

/cc @ShabbyX