### PR TITLE
Fix elided_lifetimes_in_paths warning on extern types

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1401,16 +1401,19 @@ fn expand_type_alias_verify(alias: &TypeAlias, types: &Types) -> TokenStream {
     let begin = quote_spanned!(begin_span=> ::cxx::private::verify_extern_type::<);
     let end = quote_spanned!(end_span=> >);
 
+    let resolve = types.resolve(ident);
+    let lifetimes = resolve.generics.to_underscore_lifetimes();
+
     let mut verify = quote! {
         #attrs
-        const _: fn() = #begin #ident, #type_id #end;
+        const _: fn() = #begin #ident #lifetimes, #type_id #end;
     };
 
     if types.required_trivial.contains_key(&alias.name.rust) {
         let begin = quote_spanned!(begin_span=> ::cxx::private::verify_extern_kind::<);
         verify.extend(quote! {
             #attrs
-            const _: fn() = #begin #ident, ::cxx::kind::Trivial #end;
+            const _: fn() = #begin #ident #lifetimes, ::cxx::kind::Trivial #end;
         });
     }
 

--- a/tests/ui/deny_elided_lifetimes.rs
+++ b/tests/ui/deny_elided_lifetimes.rs
@@ -1,5 +1,19 @@
 #![deny(elided_lifetimes_in_paths, mismatched_lifetime_syntaxes)]
 
+use cxx::ExternType;
+use std::marker::PhantomData;
+
+#[repr(C)]
+struct Alias<'a> {
+    ptr: *const std::ffi::c_void,
+    lifetime: PhantomData<&'a str>,
+}
+
+unsafe impl<'a> ExternType for Alias<'a> {
+    type Id = cxx::type_id!("Alias");
+    type Kind = cxx::kind::Trivial;
+}
+
 #[cxx::bridge]
 mod ffi {
     #[derive(PartialEq, PartialOrd, Hash)]
@@ -13,6 +27,7 @@ mod ffi {
 
     unsafe extern "C++" {
         type Cpp<'a>;
+        type Alias<'a> = crate::Alias<'a>;
 
         fn lifetime_named<'a>(s: &'a i32) -> UniquePtr<Cpp<'a>>;
 

--- a/tests/ui/deny_elided_lifetimes.stderr
+++ b/tests/ui/deny_elided_lifetimes.stderr
@@ -14,17 +14,6 @@ help: indicate the anonymous lifetime
 36 |         fn lifetime_elided(s: &i32) -> UniquePtr<Cpp<'_>>;
    |                                                     ++++
 
-error: hidden lifetime parameters in types are deprecated
-  --> tests/ui/deny_elided_lifetimes.rs:30:14
-   |
-30 |         type Alias<'a> = crate::Alias<'a>;
-   |              ^^^^^ expected lifetime parameter
-   |
-help: indicate the anonymous lifetime
-   |
-30 |         type Alias<'_><'a> = crate::Alias<'a>;
-   |                   ++++
-
 error: hiding a lifetime that's elided elsewhere is confusing
   --> tests/ui/deny_elided_lifetimes.rs:36:31
    |

--- a/tests/ui/deny_elided_lifetimes.stderr
+++ b/tests/ui/deny_elided_lifetimes.stderr
@@ -1,7 +1,7 @@
 error: hidden lifetime parameters in types are deprecated
-  --> tests/ui/deny_elided_lifetimes.rs:21:50
+  --> tests/ui/deny_elided_lifetimes.rs:36:50
    |
-21 |         fn lifetime_elided(s: &i32) -> UniquePtr<Cpp>;
+36 |         fn lifetime_elided(s: &i32) -> UniquePtr<Cpp>;
    |                                                  ^^^ expected lifetime parameter
    |
 note: the lint level is defined here
@@ -11,13 +11,24 @@ note: the lint level is defined here
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 help: indicate the anonymous lifetime
    |
-21 |         fn lifetime_elided(s: &i32) -> UniquePtr<Cpp<'_>>;
+36 |         fn lifetime_elided(s: &i32) -> UniquePtr<Cpp<'_>>;
    |                                                     ++++
 
-error: hiding a lifetime that's elided elsewhere is confusing
-  --> tests/ui/deny_elided_lifetimes.rs:21:31
+error: hidden lifetime parameters in types are deprecated
+  --> tests/ui/deny_elided_lifetimes.rs:30:14
    |
-21 |         fn lifetime_elided(s: &i32) -> UniquePtr<Cpp>;
+30 |         type Alias<'a> = crate::Alias<'a>;
+   |              ^^^^^ expected lifetime parameter
+   |
+help: indicate the anonymous lifetime
+   |
+30 |         type Alias<'_><'a> = crate::Alias<'a>;
+   |                   ++++
+
+error: hiding a lifetime that's elided elsewhere is confusing
+  --> tests/ui/deny_elided_lifetimes.rs:36:31
+   |
+36 |         fn lifetime_elided(s: &i32) -> UniquePtr<Cpp>;
    |                               ^^^^               ^^^ the same lifetime is hidden here
    |                               |
    |                               the lifetime is elided here
@@ -30,5 +41,5 @@ note: the lint level is defined here
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: use `'_` for type paths
    |
-21 |         fn lifetime_elided(s: &i32) -> UniquePtr<Cpp<'_>>;
+36 |         fn lifetime_elided(s: &i32) -> UniquePtr<Cpp<'_>>;
    |                                                     ++++


### PR DESCRIPTION
Previously, this would produce a warning inside macro-generated code.

```rust
#![warn(elided_lifetimes_in_paths)]

#[cxx::bridge]
mod ffi {
    extern "C++" {
        type Thing<'a> = path::to::Thing<'a>;
    }
}
```