### PR TITLE
Raise required compiler to Rust 1.78

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable, 1.82.0, 1.81.0, 1.80.0, 1.77.0, 1.73.0]
+        rust: [nightly, beta, stable, 1.82.0, 1.81.0, 1.80.0, 1.78.0]
         os: [ubuntu]
         cc: [g++]
         flags: ['']
@@ -121,7 +121,7 @@ jobs:
         # builds.
         run: |
           echo RUSTFLAGS=$RUSTFLAGS >> $GITHUB_ENV
-          echo exclude=--exclude cxx-test-suite ${{matrix.rust == '1.73.0' && '--exclude cxxbridge-cmd' || ''}} >> $GITHUB_OUTPUT
+          echo exclude=--exclude cxx-test-suite >> $GITHUB_OUTPUT
         env:
           RUSTFLAGS: ${{env.RUSTFLAGS}} ${{matrix.os != 'ubuntu' && github.event_name != 'schedule' && '--cfg skip_ui_tests' || ''}}
         id: testsuite
@@ -131,7 +131,7 @@ jobs:
         if: matrix.os == 'macos'
       - run: cargo run --manifest-path demo/Cargo.toml
       - run: cargo test --workspace ${{steps.testsuite.outputs.exclude}}
-        if: matrix.rust != '1.73.0' && !contains(matrix.flags, '-fno-exceptions')
+        if: !contains(matrix.flags, '-fno-exceptions')
       - run: cargo check --no-default-features --features alloc
         env:
           RUSTFLAGS: --cfg compile_error_if_std ${{env.RUSTFLAGS}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
         if: matrix.os == 'macos'
       - run: cargo run --manifest-path demo/Cargo.toml
       - run: cargo test --workspace ${{steps.testsuite.outputs.exclude}}
-        if: !contains(matrix.flags, '-fno-exceptions')
+        if: contains(matrix.flags, '-fno-exceptions') == false
       - run: cargo check --no-default-features --features alloc
         env:
           RUSTFLAGS: --cfg compile_error_if_std ${{env.RUSTFLAGS}}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["ffi", "c++"]
 license = "MIT OR Apache-2.0"
 links = "cxxbridge1"
 repository = "https://github.com/dtolnay/cxx"
-rust-version = "1.73"
+rust-version = "1.78"
 
 [features]
 default = ["std", "cxxbridge-flags/default"] # c++11

--- a/build.rs
+++ b/build.rs
@@ -37,8 +37,8 @@ fn main() {
             println!("cargo:rustc-check-cfg=cfg(skip_ui_tests)");
         }
 
-        if rustc.minor < 73 {
-            println!("cargo:warning=The cxx crate requires a rustc version 1.73.0 or newer.");
+        if rustc.minor < 78 {
+            println!("cargo:warning=The cxx crate requires a rustc version 1.78.0 or newer.");
             println!(
                 "cargo:warning=You appear to be building with: {}",
                 rustc.version,

--- a/flags/Cargo.toml
+++ b/flags/Cargo.toml
@@ -7,7 +7,7 @@ description = "Compiler configuration of the `cxx` crate (implementation detail)
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/cxx"
-rust-version = "1.73"
+rust-version = "1.78"
 
 [features]
 default = [] # c++11

--- a/gen/build/Cargo.toml
+++ b/gen/build/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://cxx.rs"
 keywords = ["ffi", "build-dependencies"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/cxx"
-rust-version = "1.73"
+rust-version = "1.78"
 
 [features]
 parallel = ["cc/parallel"]

--- a/gen/cmd/Cargo.toml
+++ b/gen/cmd/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cxx.rs"
 keywords = ["ffi"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/cxx"
-rust-version = "1.73"
+rust-version = "1.78"
 
 [[bin]]
 name = "cxxbridge"

--- a/gen/lib/Cargo.toml
+++ b/gen/lib/Cargo.toml
@@ -10,7 +10,7 @@ exclude = ["build.rs"]
 keywords = ["ffi"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/cxx"
-rust-version = "1.73"
+rust-version = "1.78"
 
 [dependencies]
 codespan-reporting = "0.12"

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cxx.rs"
 keywords = ["ffi"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/cxx"
-rust-version = "1.73"
+rust-version = "1.78"
 
 [lib]
 proc-macro = true

--- a/third-party/Cargo.toml
+++ b/third-party/Cargo.toml
@@ -4,7 +4,7 @@ name = "third-party"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.77"
+rust-version = "1.78"
 
 [dependencies]
 cc = "1.0.101"


### PR DESCRIPTION
This release stabilizes the `diagnostics` attribute namespace. https://blog.rust-lang.org/2024/05/02/Rust-1.78.0/#diagnostic-attributes

This will allow improving many of cxx's trait-related error messages, and deferring some errors from macro expansion to later in compilation, for example the suggestion to write `Pin<&mut T>` when using `&mut T` on an extern type that does not implement `Unpin`.