### PR TITLE
Same restrictions on slice as unpinned mutable reference

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -526,8 +526,7 @@ fn check_trivial_extern_type(out: &mut OutFile, alias: &TypeAlias, reasons: &[Tr
             TrivialReason::BoxTarget { .. } | TrivialReason::VecElement { .. } => true,
             TrivialReason::StructField(_)
             | TrivialReason::FunctionArgument(_)
-            | TrivialReason::FunctionReturn(_)
-            | TrivialReason::SliceElement { .. } => false,
+            | TrivialReason::FunctionReturn(_) => false,
         };
         // If the type is only used as a struct field or Vec element, not as
         // by-value function argument or return value, then C array of trivially
@@ -543,8 +542,7 @@ fn check_trivial_extern_type(out: &mut OutFile, alias: &TypeAlias, reasons: &[Tr
             TrivialReason::StructField(_) | TrivialReason::VecElement { .. } => true,
             TrivialReason::FunctionArgument(_)
             | TrivialReason::FunctionReturn(_)
-            | TrivialReason::BoxTarget { .. }
-            | TrivialReason::SliceElement { .. } => false,
+            | TrivialReason::BoxTarget { .. } => false,
         };
     }
 

--- a/syntax/unpin.rs
+++ b/syntax/unpin.rs
@@ -1,14 +1,14 @@
 use crate::syntax::cfg::ComputedCfg;
 use crate::syntax::map::{OrderedMap, UnorderedMap};
 use crate::syntax::set::UnorderedSet;
-use crate::syntax::{Api, Enum, NamedType, Receiver, Ref, Struct, Type, TypeAlias};
+use crate::syntax::{Api, Enum, NamedType, Receiver, Ref, SliceRef, Struct, Type, TypeAlias};
 use proc_macro2::Ident;
 
 #[allow(dead_code)] // only used by cxxbridge-macro, not cxx-build
 pub(crate) enum UnpinReason<'a> {
     Receiver(&'a Receiver),
     Ref(&'a Ref),
-    Slice,
+    Slice(&'a SliceRef),
 }
 
 pub(crate) fn required_unpin_reasons<'a>(
@@ -32,7 +32,7 @@ pub(crate) fn required_unpin_reasons<'a>(
         if let Type::SliceRef(ty) = ty {
             if let Type::Ident(inner) = &ty.inner {
                 if is_extern_type_alias(inner) {
-                    reasons.insert(&inner.rust, UnpinReason::Slice);
+                    reasons.insert(&inner.rust, UnpinReason::Slice(ty));
                 }
             }
         }

--- a/syntax/unpin.rs
+++ b/syntax/unpin.rs
@@ -1,13 +1,14 @@
 use crate::syntax::cfg::ComputedCfg;
 use crate::syntax::map::{OrderedMap, UnorderedMap};
 use crate::syntax::set::UnorderedSet;
-use crate::syntax::{Api, Enum, Receiver, Ref, Struct, Type, TypeAlias};
+use crate::syntax::{Api, Enum, NamedType, Receiver, Ref, Struct, Type, TypeAlias};
 use proc_macro2::Ident;
 
 #[allow(dead_code)] // only used by cxxbridge-macro, not cxx-build
 pub(crate) enum UnpinReason<'a> {
     Receiver(&'a Receiver),
     Ref(&'a Ref),
+    Slice,
 }
 
 pub(crate) fn required_unpin_reasons<'a>(
@@ -20,16 +21,27 @@ pub(crate) fn required_unpin_reasons<'a>(
 ) -> UnorderedMap<&'a Ident, UnpinReason<'a>> {
     let mut reasons = UnorderedMap::new();
 
+    let is_extern_type_alias = |ty: &NamedType| -> bool {
+        cxx.contains(&ty.rust)
+            && !structs.contains_key(&ty.rust)
+            && !enums.contains_key(&ty.rust)
+            && aliases.contains_key(&ty.rust)
+    };
+
+    for (ty, _cfgs) in all {
+        if let Type::SliceRef(ty) = ty {
+            if let Type::Ident(inner) = &ty.inner {
+                if is_extern_type_alias(inner) {
+                    reasons.insert(&inner.rust, UnpinReason::Slice);
+                }
+            }
+        }
+    }
+
     for api in apis {
         if let Api::CxxFunction(efn) | Api::RustFunction(efn) = api {
             if let Some(receiver) = efn.receiver() {
-                if receiver.mutable
-                    && !receiver.pinned
-                    && cxx.contains(&receiver.ty.rust)
-                    && !structs.contains_key(&receiver.ty.rust)
-                    && !enums.contains_key(&receiver.ty.rust)
-                    && aliases.contains_key(&receiver.ty.rust)
-                {
+                if receiver.mutable && !receiver.pinned && is_extern_type_alias(&receiver.ty) {
                     reasons.insert(&receiver.ty.rust, UnpinReason::Receiver(receiver));
                 }
             }
@@ -39,13 +51,7 @@ pub(crate) fn required_unpin_reasons<'a>(
     for (ty, _cfg) in all {
         if let Type::Ref(ty) = ty {
             if let Type::Ident(inner) = &ty.inner {
-                if ty.mutable
-                    && !ty.pinned
-                    && cxx.contains(&inner.rust)
-                    && !structs.contains_key(&inner.rust)
-                    && !enums.contains_key(&inner.rust)
-                    && aliases.contains_key(&inner.rust)
-                {
+                if ty.mutable && !ty.pinned && is_extern_type_alias(inner) {
                     reasons.insert(&inner.rust, UnpinReason::Ref(ty));
                 }
             }

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -241,6 +241,7 @@ pub mod ffi {
         boxed: Box<OpaqueRust>,
         vecked: Vec<OpaqueRust>,
         referenced: &'a mut OpaqueRust,
+        sliced: &'a mut [OpaqueRust],
     }
 
     extern "C++" {

--- a/tests/ui/slice_of_type_alias.rs
+++ b/tests/ui/slice_of_type_alias.rs
@@ -1,10 +1,11 @@
 use cxx::{type_id, ExternType};
+use std::marker::PhantomPinned;
 
 #[repr(C)]
 struct ElementTrivial(usize);
 
 #[repr(C)]
-struct ElementOpaque(usize);
+struct ElementOpaque(usize, PhantomPinned);
 
 #[cxx::bridge]
 mod ffi {

--- a/tests/ui/slice_of_type_alias.stderr
+++ b/tests/ui/slice_of_type_alias.stderr
@@ -1,18 +1,7 @@
-error[E0277]: `PhantomPinned` cannot be unpinned
-  --> tests/ui/slice_of_type_alias.rs:14:14
+error[E0277]: slice of opaque C++ type is not supported
+  --> tests/ui/slice_of_type_alias.rs:17:21
    |
-14 |         type ElementOpaque = crate::ElementOpaque;
-   |              ^^^^^^^^^^^^^ within `ElementOpaque`, the trait `Unpin` is not implemented for `PhantomPinned`
+17 |         fn g(slice: &[ElementOpaque]);
+   |                     ^^^^^^^^^^^^^^^^ requires `ElementOpaque: Unpin`
    |
-   = note: consider using the `pin!` macro
-           consider using `Box::pin` if you need to access the pinned value outside of the current scope
-note: required because it appears within the type `ElementOpaque`
-  --> tests/ui/slice_of_type_alias.rs:8:8
-   |
- 8 | struct ElementOpaque(usize, PhantomPinned);
-   |        ^^^^^^^^^^^^^
-note: required by a bound in `require_unpin`
-  --> src/rust_type.rs
-   |
-   | pub fn require_unpin<T: ?Sized + Unpin>() {}
-   |                                  ^^^^^ required by this bound in `require_unpin`
+   = help: the trait `SliceOfUnpin_ElementOpaque` is not implemented for `&[ElementOpaque]`

--- a/tests/ui/slice_of_type_alias.stderr
+++ b/tests/ui/slice_of_type_alias.stderr
@@ -1,16 +1,18 @@
-error[E0271]: type mismatch resolving `<ElementOpaque as ExternType>::Kind == Trivial`
-  --> tests/ui/slice_of_type_alias.rs:13:14
+error[E0277]: `PhantomPinned` cannot be unpinned
+  --> tests/ui/slice_of_type_alias.rs:14:14
    |
-13 |         type ElementOpaque = crate::ElementOpaque;
-   |              ^^^^^^^^^^^^^ type mismatch resolving `<ElementOpaque as ExternType>::Kind == Trivial`
+14 |         type ElementOpaque = crate::ElementOpaque;
+   |              ^^^^^^^^^^^^^ within `ElementOpaque`, the trait `Unpin` is not implemented for `PhantomPinned`
    |
-note: expected this to be `Trivial`
-  --> tests/ui/slice_of_type_alias.rs:27:17
+   = note: consider using the `pin!` macro
+           consider using `Box::pin` if you need to access the pinned value outside of the current scope
+note: required because it appears within the type `ElementOpaque`
+  --> tests/ui/slice_of_type_alias.rs:8:8
    |
-27 |     type Kind = cxx::kind::Opaque;
-   |                 ^^^^^^^^^^^^^^^^^
-note: required by a bound in `verify_extern_kind`
-  --> src/extern_type.rs
+ 8 | struct ElementOpaque(usize, PhantomPinned);
+   |        ^^^^^^^^^^^^^
+note: required by a bound in `require_unpin`
+  --> src/rust_type.rs
    |
-   | pub fn verify_extern_kind<T: ExternType<Kind = Kind>, Kind: self::Kind>() {}
-   |                                         ^^^^^^^^^^^ required by this bound in `verify_extern_kind`
+   | pub fn require_unpin<T: ?Sized + Unpin>() {}
+   |                                  ^^^^^ required by this bound in `require_unpin`

--- a/tests/ui/slice_unsupported.stderr
+++ b/tests/ui/slice_unsupported.stderr
@@ -3,9 +3,3 @@ error: unsupported &mut [T] element type: opaque C++ type is not supported yet
   |
 6 |         fn f(_: &mut [Opaque]);
   |                 ^^^^^^^^^^^^^
-
-error: needs a cxx::ExternType impl in order to be used as a slice element in &mut [Opaque]
- --> tests/ui/slice_unsupported.rs:4:9
-  |
-4 |         type Opaque;
-  |         ^^^^^^^^^^^


### PR DESCRIPTION
`&[T]` and `&mut [T]` work a lot like `&mut T` from #1610.