### PR TITLE
Support slice of type alias of Rust types

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -523,11 +523,12 @@ fn check_trivial_extern_type(out: &mut OutFile, alias: &TypeAlias, reasons: &[Tr
         // Allow extern type that inherits from ::rust::Opaque in positions
         // where an opaque Rust type would be allowed.
         rust_type_ok &= match reason {
-            TrivialReason::BoxTarget { .. } | TrivialReason::VecElement { .. } => true,
+            TrivialReason::BoxTarget { .. }
+            | TrivialReason::VecElement { .. }
+            | TrivialReason::SliceElement { .. } => true,
             TrivialReason::StructField(_)
             | TrivialReason::FunctionArgument(_)
-            | TrivialReason::FunctionReturn(_)
-            | TrivialReason::SliceElement { .. } => false,
+            | TrivialReason::FunctionReturn(_) => false,
         };
         // If the type is only used as a struct field or Vec element, not as
         // by-value function argument or return value, then C array of trivially

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1427,7 +1427,10 @@ fn expand_type_alias_verify(alias: &TypeAlias, types: &Types) -> TokenStream {
                 TrivialReason::StructField(_)
                 | TrivialReason::FunctionArgument(_)
                 | TrivialReason::FunctionReturn(_) => require_extern_type_trivial = true,
-                TrivialReason::SliceElement(slice) => require_rust_type_or_trivial = Some(slice),
+                TrivialReason::SliceElement(slice) => {
+                    require_unpin |= slice.mutable;
+                    require_rust_type_or_trivial = Some(slice);
+                }
             }
         }
     }

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1539,10 +1539,13 @@ fn expand_type_alias_verify(alias: &TypeAlias, types: &Types) -> TokenStream {
             #attrs
             const _: fn() = #begin #ident #lifetimes, ::cxx::kind::Trivial #end;
         });
-    } else if require_rust_type_or_trivial {
+    } else if let Some(slice_type) = require_rust_type_or_trivial {
+        let ampersand = &slice_type.ampersand;
+        let mutability = &slice_type.mutability;
+        let inner = quote_spanned!(slice_type.bracket.span.join()=> [#ident #lifetimes]);
         verify.extend(quote! {
             #attrs
-            let _ = || ::cxx::private::with::<#ident #lifetimes>().check_rust_type_or_trivial::<#ident #lifetimes>();
+            let _ = || ::cxx::private::with::<#ident #lifetimes>().check_slice::<#ampersand #mutability #inner>();
         });
     }
 

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -1427,95 +1427,101 @@ fn expand_type_alias_verify(alias: &TypeAlias, types: &Types) -> TokenStream {
                 TrivialReason::StructField(_)
                 | TrivialReason::FunctionArgument(_)
                 | TrivialReason::FunctionReturn(_) => require_extern_type_trivial = true,
-                TrivialReason::SliceElement(slice) => {
-                    require_unpin |= slice.mutable;
-                    require_rust_type_or_trivial = Some(slice);
-                }
+                TrivialReason::SliceElement(slice) => require_rust_type_or_trivial = Some(slice),
             }
         }
     }
 
-    if let Some(reason) = types.required_unpin.get(ident) {
-        let ampersand;
-        let reference_lifetime;
-        let mutability;
-        let mut inner;
-        let generics;
-        let shorthand;
-        match reason {
-            UnpinReason::Receiver(receiver) => {
-                ampersand = &receiver.ampersand;
-                reference_lifetime = &receiver.lifetime;
-                mutability = &receiver.mutability;
-                inner = receiver.ty.rust.clone();
-                generics = &receiver.ty.generics;
-                shorthand = receiver.shorthand;
-                if receiver.shorthand {
-                    inner.set_span(receiver.var.span);
-                }
-            }
-            UnpinReason::Ref(mutable_reference) => {
-                ampersand = &mutable_reference.ampersand;
-                reference_lifetime = &mutable_reference.lifetime;
-                mutability = &mutable_reference.mutability;
-                let Type::Ident(inner_type) = &mutable_reference.inner else {
-                    unreachable!();
-                };
-                inner = inner_type.rust.clone();
-                generics = &inner_type.generics;
-                shorthand = false;
-            }
-        }
-        let trait_name = format_ident!("ReferenceToUnpin_{ident}");
-        let message =
-            format!("mutable reference to C++ type requires a pin -- use Pin<&mut {ident}>");
-        let label = {
-            let mut label = Message::new();
-            write!(label, "use `");
-            if shorthand {
-                write!(label, "self: ");
-            }
-            write!(label, "Pin<&");
-            if let Some(reference_lifetime) = reference_lifetime {
-                write!(label, "{reference_lifetime} ");
-            }
-            write!(label, "mut {ident}");
-            if !generics.lifetimes.is_empty() {
-                write!(label, "<");
-                for (i, lifetime) in generics.lifetimes.iter().enumerate() {
-                    if i > 0 {
-                        write!(label, ", ");
+    'unpin: {
+        if let Some(reason) = types.required_unpin.get(ident) {
+            let ampersand;
+            let reference_lifetime;
+            let mutability;
+            let mut inner;
+            let generics;
+            let shorthand;
+            match reason {
+                UnpinReason::Receiver(receiver) => {
+                    ampersand = &receiver.ampersand;
+                    reference_lifetime = &receiver.lifetime;
+                    mutability = &receiver.mutability;
+                    inner = receiver.ty.rust.clone();
+                    generics = &receiver.ty.generics;
+                    shorthand = receiver.shorthand;
+                    if receiver.shorthand {
+                        inner.set_span(receiver.var.span);
                     }
-                    write!(label, "{lifetime}");
                 }
-                write!(label, ">");
-            } else if shorthand && !alias.generics.lifetimes.is_empty() {
-                write!(label, "<");
-                for i in 0..alias.generics.lifetimes.len() {
-                    if i > 0 {
-                        write!(label, ", ");
-                    }
-                    write!(label, "'_");
+                UnpinReason::Ref(mutable_reference) => {
+                    ampersand = &mutable_reference.ampersand;
+                    reference_lifetime = &mutable_reference.lifetime;
+                    mutability = &mutable_reference.mutability;
+                    let Type::Ident(inner_type) = &mutable_reference.inner else {
+                        unreachable!();
+                    };
+                    inner = inner_type.rust.clone();
+                    generics = &inner_type.generics;
+                    shorthand = false;
                 }
-                write!(label, ">");
+                UnpinReason::Slice(_mutable_slice) => {
+                    require_unpin = true;
+                    break 'unpin;
+                }
             }
-            write!(label, ">`");
-            label
-        };
-        let lifetimes = generics.to_underscore_lifetimes();
-        verify.extend(quote! {
-            #attrs
-            let _ = {
-                #[diagnostic::on_unimplemented(message = #message, label = #label)]
-                trait #trait_name {
-                    fn check_unpin() {}
+            let trait_name = format_ident!("ReferenceToUnpin_{ident}");
+            let message =
+                format!("mutable reference to C++ type requires a pin -- use Pin<&mut {ident}>");
+            let label = {
+                let mut label = Message::new();
+                write!(label, "use `");
+                if shorthand {
+                    write!(label, "self: ");
                 }
-                #[diagnostic::do_not_recommend]
-                impl<'a, T: ?::cxx::core::marker::Sized + ::cxx::core::marker::Unpin> #trait_name for &'a mut T {}
-                <#ampersand #mutability #inner #lifetimes as #trait_name>::check_unpin
+                write!(label, "Pin<&");
+                if let Some(reference_lifetime) = reference_lifetime {
+                    write!(label, "{reference_lifetime} ");
+                }
+                write!(label, "mut {ident}");
+                if !generics.lifetimes.is_empty() {
+                    write!(label, "<");
+                    for (i, lifetime) in generics.lifetimes.iter().enumerate() {
+                        if i > 0 {
+                            write!(label, ", ");
+                        }
+                        write!(label, "{lifetime}");
+                    }
+                    write!(label, ">");
+                } else if shorthand && !alias.generics.lifetimes.is_empty() {
+                    write!(label, "<");
+                    for i in 0..alias.generics.lifetimes.len() {
+                        if i > 0 {
+                            write!(label, ", ");
+                        }
+                        write!(label, "'_");
+                    }
+                    write!(label, ">");
+                }
+                write!(label, ">`");
+                label
             };
-        });
-    } else if require_unpin {
+            let lifetimes = generics.to_underscore_lifetimes();
+            verify.extend(quote! {
+                #attrs
+                let _ = {
+                    #[diagnostic::on_unimplemented(message = #message, label = #label)]
+                    trait #trait_name {
+                        fn check_unpin() {}
+                    }
+                    #[diagnostic::do_not_recommend]
+                    impl<'a, T: ?::cxx::core::marker::Sized + ::cxx::core::marker::Unpin> #trait_name for &'a mut T {}
+                    <#ampersand #mutability #inner #lifetimes as #trait_name>::check_unpin
+                };
+            });
+            require_unpin = false;
+        }
+    }
+
+    if require_unpin {
         verify.extend(quote! {
             #attrs
             const _: fn() = ::cxx::private::require_unpin::<#ident #lifetimes>;

--- a/src/rust_type.rs
+++ b/src/rust_type.rs
@@ -1,5 +1,7 @@
 #![allow(missing_docs)]
 
+use crate::extern_type::ExternType;
+use crate::kind::Trivial;
 use core::marker::{PhantomData, Unpin};
 use core::ops::Deref;
 
@@ -20,9 +22,9 @@ pub const fn with<T: ?Sized>() -> With<T> {
     With(PhantomData)
 }
 
-impl<T: ?Sized + Unpin> With<T> {
+impl<T: ?Sized + RustType> With<T> {
     #[allow(clippy::unused_self)]
-    pub const fn check_unpin<U>(&self) {}
+    pub const fn check_rust_type_or_trivial<U>(&self) {}
 }
 
 impl<T: ?Sized> Deref for With<T> {
@@ -30,4 +32,9 @@ impl<T: ?Sized> Deref for With<T> {
     fn deref(&self) -> &Self::Target {
         &Without
     }
+}
+
+impl Without {
+    #[allow(clippy::unused_self)]
+    pub const fn check_rust_type_or_trivial<U: ExternType<Kind = Trivial>>(&self) {}
 }

--- a/src/rust_type.rs
+++ b/src/rust_type.rs
@@ -24,7 +24,7 @@ pub const fn with<T: ?Sized>() -> With<T> {
 
 impl<T: ?Sized + RustType> With<T> {
     #[allow(clippy::unused_self)]
-    pub const fn check_rust_type_or_trivial<U>(&self) {}
+    pub const fn check_slice<U>(&self) {}
 }
 
 impl<T: ?Sized> Deref for With<T> {
@@ -34,7 +34,17 @@ impl<T: ?Sized> Deref for With<T> {
     }
 }
 
+pub trait SliceOfExternType {
+    type Kind;
+}
+impl<T: ExternType> SliceOfExternType for &[T] {
+    type Kind = T::Kind;
+}
+impl<T: ExternType> SliceOfExternType for &mut [T] {
+    type Kind = T::Kind;
+}
+
 impl Without {
     #[allow(clippy::unused_self)]
-    pub const fn check_rust_type_or_trivial<U: ExternType<Kind = Trivial>>(&self) {}
+    pub const fn check_slice<U: SliceOfExternType<Kind = Trivial>>(&self) {}
 }

--- a/syntax/unpin.rs
+++ b/syntax/unpin.rs
@@ -1,13 +1,14 @@
 use crate::syntax::cfg::ComputedCfg;
 use crate::syntax::map::{OrderedMap, UnorderedMap};
 use crate::syntax::set::UnorderedSet;
-use crate::syntax::{Api, Enum, Receiver, Ref, Struct, Type, TypeAlias};
+use crate::syntax::{Api, Enum, NamedType, Receiver, Ref, SliceRef, Struct, Type, TypeAlias};
 use proc_macro2::Ident;
 
 #[allow(dead_code)] // only used by cxxbridge-macro, not cxx-build
 pub(crate) enum UnpinReason<'a> {
     Receiver(&'a Receiver),
     Ref(&'a Ref),
+    Slice(&'a SliceRef),
 }
 
 pub(crate) fn required_unpin_reasons<'a>(
@@ -20,16 +21,27 @@ pub(crate) fn required_unpin_reasons<'a>(
 ) -> UnorderedMap<&'a Ident, UnpinReason<'a>> {
     let mut reasons = UnorderedMap::new();
 
+    let is_extern_type_alias = |ty: &NamedType| -> bool {
+        cxx.contains(&ty.rust)
+            && !structs.contains_key(&ty.rust)
+            && !enums.contains_key(&ty.rust)
+            && aliases.contains_key(&ty.rust)
+    };
+
+    for (ty, _cfgs) in all {
+        if let Type::SliceRef(slice) = ty {
+            if let Type::Ident(inner) = &slice.inner {
+                if slice.mutable && is_extern_type_alias(inner) {
+                    reasons.insert(&inner.rust, UnpinReason::Slice(slice));
+                }
+            }
+        }
+    }
+
     for api in apis {
         if let Api::CxxFunction(efn) | Api::RustFunction(efn) = api {
             if let Some(receiver) = efn.receiver() {
-                if receiver.mutable
-                    && !receiver.pinned
-                    && cxx.contains(&receiver.ty.rust)
-                    && !structs.contains_key(&receiver.ty.rust)
-                    && !enums.contains_key(&receiver.ty.rust)
-                    && aliases.contains_key(&receiver.ty.rust)
-                {
+                if receiver.mutable && !receiver.pinned && is_extern_type_alias(&receiver.ty) {
                     reasons.insert(&receiver.ty.rust, UnpinReason::Receiver(receiver));
                 }
             }
@@ -39,13 +51,7 @@ pub(crate) fn required_unpin_reasons<'a>(
     for (ty, _cfg) in all {
         if let Type::Ref(ty) = ty {
             if let Type::Ident(inner) = &ty.inner {
-                if ty.mutable
-                    && !ty.pinned
-                    && cxx.contains(&inner.rust)
-                    && !structs.contains_key(&inner.rust)
-                    && !enums.contains_key(&inner.rust)
-                    && aliases.contains_key(&inner.rust)
-                {
+                if ty.mutable && !ty.pinned && is_extern_type_alias(inner) {
                     reasons.insert(&inner.rust, UnpinReason::Ref(ty));
                 }
             }

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -241,6 +241,7 @@ pub mod ffi {
         boxed: Box<OpaqueRust>,
         vecked: Vec<OpaqueRust>,
         referenced: &'a mut OpaqueRust,
+        sliced: &'a mut [OpaqueRust],
     }
 
     extern "C++" {

--- a/tests/ui/slice_of_pinned.rs
+++ b/tests/ui/slice_of_pinned.rs
@@ -1,0 +1,20 @@
+use cxx::{type_id, ExternType};
+use std::marker::PhantomPinned;
+
+#[repr(C)]
+struct Pinned(usize, PhantomPinned);
+
+#[cxx::bridge]
+mod ffi {
+    unsafe extern "C++" {
+        type Pinned = crate::Pinned;
+        fn f(_: &[Pinned], _: &mut [Pinned]);
+    }
+}
+
+unsafe impl ExternType for Pinned {
+    type Id = type_id!("Pinned");
+    type Kind = cxx::kind::Trivial;
+}
+
+fn main() {}

--- a/tests/ui/slice_of_pinned.stderr
+++ b/tests/ui/slice_of_pinned.stderr
@@ -1,0 +1,18 @@
+error[E0277]: `PhantomPinned` cannot be unpinned
+  --> tests/ui/slice_of_pinned.rs:10:14
+   |
+10 |         type Pinned = crate::Pinned;
+   |              ^^^^^^ within `Pinned`, the trait `Unpin` is not implemented for `PhantomPinned`
+   |
+   = note: consider using the `pin!` macro
+           consider using `Box::pin` if you need to access the pinned value outside of the current scope
+note: required because it appears within the type `Pinned`
+  --> tests/ui/slice_of_pinned.rs:5:8
+   |
+ 5 | struct Pinned(usize, PhantomPinned);
+   |        ^^^^^^
+note: required by a bound in `require_unpin`
+  --> src/rust_type.rs
+   |
+   | pub fn require_unpin<T: ?Sized + Unpin>() {}
+   |                                  ^^^^^ required by this bound in `require_unpin`

--- a/tests/ui/slice_of_pinned.stderr
+++ b/tests/ui/slice_of_pinned.stderr
@@ -1,18 +1,7 @@
-error[E0277]: `PhantomPinned` cannot be unpinned
-  --> tests/ui/slice_of_pinned.rs:10:14
+error[E0277]: mutable slice of pinned type is not supported
+  --> tests/ui/slice_of_pinned.rs:11:31
    |
-10 |         type Pinned = crate::Pinned;
-   |              ^^^^^^ within `Pinned`, the trait `Unpin` is not implemented for `PhantomPinned`
+11 |         fn f(_: &[Pinned], _: &mut [Pinned]);
+   |                               ^^^^^^^^^^^^^ requires `Pinned: Unpin`
    |
-   = note: consider using the `pin!` macro
-           consider using `Box::pin` if you need to access the pinned value outside of the current scope
-note: required because it appears within the type `Pinned`
-  --> tests/ui/slice_of_pinned.rs:5:8
-   |
- 5 | struct Pinned(usize, PhantomPinned);
-   |        ^^^^^^
-note: required by a bound in `require_unpin`
-  --> src/rust_type.rs
-   |
-   | pub fn require_unpin<T: ?Sized + Unpin>() {}
-   |                                  ^^^^^ required by this bound in `require_unpin`
+   = help: the trait `SliceOfUnpin_Pinned` is not implemented for `&mut [Pinned]`

--- a/tests/ui/slice_of_type_alias.stderr
+++ b/tests/ui/slice_of_type_alias.stderr
@@ -1,16 +1,11 @@
-error[E0271]: type mismatch resolving `<ElementOpaque as ExternType>::Kind == Trivial`
-  --> tests/ui/slice_of_type_alias.rs:13:14
+error[E0271]: type mismatch resolving `<&[ElementOpaque] as SliceOfExternType>::Kind == Trivial`
+  --> tests/ui/slice_of_type_alias.rs:16:21
    |
-13 |         type ElementOpaque = crate::ElementOpaque;
-   |              ^^^^^^^^^^^^^ type mismatch resolving `<ElementOpaque as ExternType>::Kind == Trivial`
+16 |         fn g(slice: &[ElementOpaque]);
+   |                     ^^^^^^^^^^^^^^^^ expected `Trivial`, found `Opaque`
    |
-note: expected this to be `Trivial`
-  --> tests/ui/slice_of_type_alias.rs:27:17
-   |
-27 |     type Kind = cxx::kind::Opaque;
-   |                 ^^^^^^^^^^^^^^^^^
-note: required by a bound in `Without::check_rust_type_or_trivial`
+note: required by a bound in `Without::check_slice`
   --> src/rust_type.rs
    |
-   |     pub const fn check_rust_type_or_trivial<U: ExternType<Kind = Trivial>>(&self) {}
-   |                                                           ^^^^^^^^^^^^^^ required by this bound in `Without::check_rust_type_or_trivial`
+   |     pub const fn check_slice<U: SliceOfExternType<Kind = Trivial>>(&self) {}
+   |                                                   ^^^^^^^^^^^^^^ required by this bound in `Without::check_slice`

--- a/tests/ui/slice_of_type_alias.stderr
+++ b/tests/ui/slice_of_type_alias.stderr
@@ -9,8 +9,8 @@ note: expected this to be `Trivial`
    |
 27 |     type Kind = cxx::kind::Opaque;
    |                 ^^^^^^^^^^^^^^^^^
-note: required by a bound in `verify_extern_kind`
-  --> src/extern_type.rs
+note: required by a bound in `Without::check_rust_type_or_trivial`
+  --> src/rust_type.rs
    |
-   | pub fn verify_extern_kind<T: ExternType<Kind = Kind>, Kind: self::Kind>() {}
-   |                                         ^^^^^^^^^^^ required by this bound in `verify_extern_kind`
+   |     pub const fn check_rust_type_or_trivial<U: ExternType<Kind = Trivial>>(&self) {}
+   |                                                           ^^^^^^^^^^^^^^ required by this bound in `Without::check_rust_type_or_trivial`


### PR DESCRIPTION
```rust
// first crate

#[cxx::bridge]
pub mod ffi {
    extern "Rust" {
        #[derive(ExternType)]
        type Thing;
    }
}

pub struct Thing {
    ...
}
```

```rust
// second crate

#[cxx::bridge]
pub mod ffi {
    extern "C++" {
        include!("first/src/lib.rs.h");
        type Thing = first::Thing;
    }

    struct Struct<'a> {
        things: &'a mut [Thing],
    }
}
```

The soundness requirements are:

- `&[T]` requires `T: RustType` **or** `T: ExternType<Kind = Trivial>`
- `&mut [T]` requires `T: Unpin + RustType` **or** `T: Unpin + ExternType<Kind = Trivial>`