### PR TITLE
Skip redefining RUST_CXX_NO_EXCEPTIONS

### DIFF
--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -17,8 +17,8 @@
 //
 // On MSVC, it is possible for exception throwing and catching to be enabled
 // without __cpp_exceptions being defined, so do not try to detect anything.
-#if defined(__cpp_attributes) && !defined(__cpp_exceptions) &&                 \
-    (!defined(_MSC_VER) || defined(__llvm__))
+#if !defined(RUST_CXX_NO_EXCEPTIONS) && defined(__cpp_attributes) &&           \
+    !defined(__cpp_exceptions) && (!defined(_MSC_VER) || defined(__llvm__))
 #define RUST_CXX_NO_EXCEPTIONS
 #endif
 


### PR DESCRIPTION
This fixes a distracting warning produced by some compilers.

```console
warning: cxx@1.0.177: /git/cxx/src/cxx.cc:22:9: warning: 'RUST_CXX_NO_EXCEPTIONS' macro redefined [-Wmacro-redefined]
warning: cxx@1.0.177: #define RUST_CXX_NO_EXCEPTIONS
warning: cxx@1.0.177:         ^
warning: cxx@1.0.177: <command line>:6:9: note: previous definition is here
warning: cxx@1.0.177: #define RUST_CXX_NO_EXCEPTIONS 1
warning: cxx@1.0.177:         ^
warning: cxx@1.0.177: 1 warning generated.
```