### PR TITLE
Generalize queries about types to work with a reference

### DIFF
--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -22,6 +22,7 @@ mod parse;
 mod pod;
 pub(crate) mod primitive;
 pub(crate) mod qualified;
+pub(crate) mod query;
 pub(crate) mod report;
 pub(crate) mod repr;
 pub(crate) mod resolve;

--- a/syntax/pod.rs
+++ b/syntax/pod.rs
@@ -1,10 +1,11 @@
 use crate::syntax::atom::Atom::{self, *};
-use crate::syntax::{primitive, Type, Types};
+use crate::syntax::query::TypeQuery;
+use crate::syntax::{primitive, Types};
 
 impl<'a> Types<'a> {
-    pub(crate) fn is_guaranteed_pod(&self, ty: &Type) -> bool {
-        match ty {
-            Type::Ident(ident) => {
+    pub(crate) fn is_guaranteed_pod(&self, ty: impl Into<TypeQuery<'a>>) -> bool {
+        match ty.into() {
+            TypeQuery::Ident(ident) => {
                 let ident = &ident.rust;
                 if let Some(atom) = Atom::from(ident) {
                     match atom {
@@ -20,15 +21,19 @@ impl<'a> Types<'a> {
                     self.enums.contains_key(ident)
                 }
             }
-            Type::RustBox(_)
-            | Type::RustVec(_)
-            | Type::UniquePtr(_)
-            | Type::SharedPtr(_)
-            | Type::WeakPtr(_)
-            | Type::CxxVector(_)
-            | Type::Void(_) => false,
-            Type::Ref(_) | Type::Str(_) | Type::Fn(_) | Type::SliceRef(_) | Type::Ptr(_) => true,
-            Type::Array(array) => self.is_guaranteed_pod(&array.inner),
+            TypeQuery::RustBox
+            | TypeQuery::RustVec
+            | TypeQuery::UniquePtr
+            | TypeQuery::SharedPtr
+            | TypeQuery::WeakPtr
+            | TypeQuery::CxxVector
+            | TypeQuery::Void => false,
+            TypeQuery::Ref(_)
+            | TypeQuery::Str
+            | TypeQuery::Fn
+            | TypeQuery::SliceRef
+            | TypeQuery::Ptr(_) => true,
+            TypeQuery::Array(array) => self.is_guaranteed_pod(&array.inner),
         }
     }
 }

--- a/syntax/query.rs
+++ b/syntax/query.rs
@@ -1,0 +1,46 @@
+use crate::syntax::{Array, NamedType, Ptr, Ref, Type};
+
+#[derive(Copy, Clone)]
+pub(crate) enum TypeQuery<'a> {
+    Ident(&'a NamedType),
+    RustBox,
+    RustVec,
+    UniquePtr,
+    SharedPtr,
+    WeakPtr,
+    Ref(&'a Ref),
+    Ptr(&'a Ptr),
+    Str,
+    CxxVector,
+    Fn,
+    Void,
+    SliceRef,
+    Array(&'a Array),
+}
+
+impl<'a> From<&'a NamedType> for TypeQuery<'a> {
+    fn from(query: &'a NamedType) -> Self {
+        TypeQuery::Ident(query)
+    }
+}
+
+impl<'a> From<&'a Type> for TypeQuery<'a> {
+    fn from(query: &'a Type) -> Self {
+        match query {
+            Type::Ident(query) => TypeQuery::Ident(query),
+            Type::RustBox(_) => TypeQuery::RustBox,
+            Type::RustVec(_) => TypeQuery::RustVec,
+            Type::UniquePtr(_) => TypeQuery::UniquePtr,
+            Type::SharedPtr(_) => TypeQuery::SharedPtr,
+            Type::WeakPtr(_) => TypeQuery::WeakPtr,
+            Type::Ref(query) => TypeQuery::Ref(query),
+            Type::Ptr(query) => TypeQuery::Ptr(query),
+            Type::Str(_) => TypeQuery::Str,
+            Type::CxxVector(_) => TypeQuery::CxxVector,
+            Type::Fn(_) => TypeQuery::Fn,
+            Type::Void(_) => TypeQuery::Void,
+            Type::SliceRef(_) => TypeQuery::SliceRef,
+            Type::Array(query) => TypeQuery::Array(query),
+        }
+    }
+}

--- a/syntax/types.rs
+++ b/syntax/types.rs
@@ -3,6 +3,7 @@ use crate::syntax::cfg::ComputedCfg;
 use crate::syntax::improper::ImproperCtype;
 use crate::syntax::instantiate::ImplKey;
 use crate::syntax::map::{OrderedMap, UnorderedMap};
+use crate::syntax::query::TypeQuery;
 use crate::syntax::report::Errors;
 use crate::syntax::resolve::Resolution;
 use crate::syntax::set::UnorderedSet;
@@ -285,16 +286,17 @@ impl<'a> Types<'a> {
         types
     }
 
-    pub(crate) fn needs_indirect_abi(&self, ty: &Type) -> bool {
+    pub(crate) fn needs_indirect_abi(&self, ty: impl Into<TypeQuery<'a>>) -> bool {
+        let ty = ty.into();
         match ty {
-            Type::RustBox(_)
-            | Type::UniquePtr(_)
-            | Type::Ref(_)
-            | Type::Ptr(_)
-            | Type::Str(_)
-            | Type::Fn(_)
-            | Type::SliceRef(_) => false,
-            Type::Array(_) => true,
+            TypeQuery::RustBox
+            | TypeQuery::UniquePtr
+            | TypeQuery::Ref(_)
+            | TypeQuery::Ptr(_)
+            | TypeQuery::Str
+            | TypeQuery::Fn
+            | TypeQuery::SliceRef => false,
+            TypeQuery::Array(_) => true,
             _ => !self.is_guaranteed_pod(ty) || self.is_considered_improper_ctype(ty),
         }
     }
@@ -305,7 +307,7 @@ impl<'a> Types<'a> {
     // refuses to believe that C could know how to supply us with a pointer to a
     // Rust String, even though C could easily have obtained that pointer
     // legitimately from a Rust call.
-    pub(crate) fn is_considered_improper_ctype(&self, ty: &Type) -> bool {
+    pub(crate) fn is_considered_improper_ctype(&self, ty: impl Into<TypeQuery<'a>>) -> bool {
         match self.determine_improper_ctype(ty) {
             ImproperCtype::Definite(improper) => improper,
             ImproperCtype::Depends(ident) => self.struct_improper_ctypes.contains(ident),


### PR DESCRIPTION
Previously, methods like `types.needs_indirect_abi(ty)` took ty as `&Type`, which made it unusable when looking at a `&NamedType`, such as in the case of a method receiver.