### PR TITLE
Retrieve new packages before installing clang-tidy-20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install clang-tidy
-        run: sudo apt-get install clang-tidy-20
+        run: sudo apt-get update && sudo apt-get install clang-tidy-20
       - name: Run clang-tidy
         run: clang-tidy-20 src/cxx.cc --warnings-as-errors=*
 


### PR DESCRIPTION
Some CI jobs are successfully installing clang-tidy-20 and some are not. This might help.

<p align="center"><img width="600" src="https://github.com/user-attachments/assets/6cf7cf3e-c043-4fcf-8db6-c16b4d76b91e" /></p>

<p align="center"><img width="600" src="https://github.com/user-attachments/assets/48fabf37-3179-4afb-835d-639f1db9f674" /></p>
