### PR TITLE
Suppress unsafe_derive_deserialize pedantic clippy lint

### DIFF
--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -155,6 +155,7 @@ fn expand(ffi: Module, doc: Doc, attrs: OtherAttrs, apis: &[Api], types: &Types)
             clippy::no_effect_underscore_binding,
             clippy::ptr_as_ptr,
             clippy::ref_as_ptr,
+            clippy::unsafe_derive_deserialize,
             clippy::upper_case_acronyms,
             clippy::use_self,
         )]

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -14,7 +14,6 @@
 #![warn(rust_2024_compatibility)]
 #![forbid(unsafe_op_in_unsafe_fn)]
 #![deny(warnings)] // Check that expansion of `cxx::bridge` doesn't trigger warnings.
-#![allow(clippy::unsafe_derive_deserialize)]
 
 pub mod cast;
 pub mod module;


### PR DESCRIPTION
This lint is just noise in shared structs that may have methods implemented by C++ member functions.

```console
warning: you are deriving `serde::Deserialize` on a type that has methods using `unsafe`
  --> tests/ffi/lib.rs:37:71
   |
37 |     #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
   |                                                                       ^^^^^^^^^^^
   |
   = help: consider implementing `serde::Deserialize` manually. See https://serde.rs/impl-deserialize.html
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unsafe_derive_deserialize
   = note: `-W clippy::unsafe-derive-deserialize` implied by `-W clippy::pedantic`
   = help: to override `-W clippy::pedantic` add `#[allow(clippy::unsafe_derive_deserialize)]`
   = note: this warning originates in the derive macro `::serde::Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)
```