### PR TITLE
Disable initramfs update and man-db update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,12 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v5
+      - name: Disable initramfs update
+        run: sudo sed -i 's/^update_initramfs=yes$/update_initramfs=no/' /etc/initramfs-tools/update-initramfs.conf
+        if: matrix.os == 'ubuntu'
+      - name: Disable man-db update
+        run: sudo rm -f /var/lib/man-db/auto-update
+        if: matrix.os == 'ubuntu'
       - name: Install lld
         run: sudo apt-get install lld
         if: matrix.os == 'ubuntu'
@@ -264,6 +270,10 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v5
+      - name: Disable initramfs update
+        run: sudo sed -i 's/^update_initramfs=yes$/update_initramfs=no/' /etc/initramfs-tools/update-initramfs.conf
+      - name: Disable man-db update
+        run: sudo rm -f /var/lib/man-db/auto-update
       - name: Install clang-tidy
         run: sudo apt-get update && sudo apt-get install clang-tidy-20
       - name: Run clang-tidy


### PR DESCRIPTION
Recently the CI jobs that run apt-get have been extremely slow. Sometimes over 10 minutes to install clang-tidy-20 or lld. This might help.