### PR TITLE
Suppress -Wreturn-type-c-linkage on rust::Fn trampoline

### DIFF
--- a/gen/src/pragma.rs
+++ b/gen/src/pragma.rs
@@ -6,6 +6,7 @@ pub(crate) struct Pragma<'a> {
     pub gnu_diagnostic_ignore: BTreeSet<&'a str>,
     pub clang_diagnostic_ignore: BTreeSet<&'a str>,
     pub dollar_in_identifier: bool,
+    pub return_type_c_linkage: bool,
     pub begin: Content<'a>,
     pub end: Content<'a>,
 }
@@ -21,6 +22,12 @@ pub(super) fn write(out: &mut OutFile) {
         out.pragma
             .clang_diagnostic_ignore
             .insert("-Wdollar-in-identifier-extension");
+    }
+
+    if out.pragma.return_type_c_linkage {
+        out.pragma
+            .clang_diagnostic_ignore
+            .insert("-Wreturn-type-c-linkage");
     }
 
     let begin = &mut out.pragma.begin;

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -956,6 +956,8 @@ fn write_cxx_function_shim<'a>(out: &mut OutFile<'a>, efn: &'a ExternFn) {
 }
 
 fn write_function_pointer_trampoline(out: &mut OutFile, efn: &ExternFn, var: &Pair, f: &Signature) {
+    out.pragma.return_type_c_linkage = true;
+
     let r_trampoline = mangle::r_trampoline(efn, var, out.types);
     let indirect_call = true;
     write_rust_function_decl_impl(out, &r_trampoline, f, indirect_call);


### PR DESCRIPTION
Closes #1216.

For Clang maybe we could have used:

```diff
- extern "C" {
- rust::Vec<...> cxxbridge1$...$data_processor$0(...) noexcept;
- }
+ rust::Vec<...> trampoline(...) noexcept asm("cxxbridge1$...$data_processor$0");
```

But I did not figure out any alternative that would work with MSVC.