### PR TITLE
Convert pragma::write to exhaustive match

### DIFF
--- a/gen/src/pragma.rs
+++ b/gen/src/pragma.rs
@@ -18,49 +18,52 @@ impl<'a> Pragma<'a> {
 }
 
 pub(super) fn write(out: &mut OutFile) {
-    if out.pragma.dollar_in_identifier {
-        out.pragma
-            .clang_diagnostic_ignore
-            .insert("-Wdollar-in-identifier-extension");
-    }
+    let Pragma {
+        ref gnu_diagnostic_ignore,
+        ref mut clang_diagnostic_ignore,
+        dollar_in_identifier,
+        return_type_c_linkage,
+        ref mut begin,
+        ref mut end,
+    } = out.pragma;
 
-    if out.pragma.return_type_c_linkage {
-        out.pragma
-            .clang_diagnostic_ignore
-            .insert("-Wreturn-type-c-linkage");
+    if dollar_in_identifier {
+        clang_diagnostic_ignore.insert("-Wdollar-in-identifier-extension");
     }
+    if return_type_c_linkage {
+        clang_diagnostic_ignore.insert("-Wreturn-type-c-linkage");
+    }
+    let clang_diagnostic_ignore = &*clang_diagnostic_ignore;
 
-    let begin = &mut out.pragma.begin;
-    if !out.pragma.gnu_diagnostic_ignore.is_empty() {
+    if !gnu_diagnostic_ignore.is_empty() {
         writeln!(begin, "#ifdef __GNUC__");
         if out.header {
             writeln!(begin, "#pragma GCC diagnostic push");
         }
-        for diag in &out.pragma.gnu_diagnostic_ignore {
+        for diag in gnu_diagnostic_ignore {
             writeln!(begin, "#pragma GCC diagnostic ignored \"{diag}\"");
         }
     }
-    if !out.pragma.clang_diagnostic_ignore.is_empty() {
+    if !clang_diagnostic_ignore.is_empty() {
         writeln!(begin, "#ifdef __clang__");
-        if out.header && out.pragma.gnu_diagnostic_ignore.is_empty() {
+        if out.header && gnu_diagnostic_ignore.is_empty() {
             writeln!(begin, "#pragma clang diagnostic push");
         }
-        for diag in &out.pragma.clang_diagnostic_ignore {
+        for diag in clang_diagnostic_ignore {
             writeln!(begin, "#pragma clang diagnostic ignored \"{diag}\"");
         }
         writeln!(begin, "#endif // __clang__");
     }
-    if !out.pragma.gnu_diagnostic_ignore.is_empty() {
+    if !gnu_diagnostic_ignore.is_empty() {
         writeln!(begin, "#endif // __GNUC__");
     }
 
     if out.header {
-        let end = &mut out.pragma.end;
-        if !out.pragma.gnu_diagnostic_ignore.is_empty() {
+        if !gnu_diagnostic_ignore.is_empty() {
             writeln!(end, "#ifdef __GNUC__");
             writeln!(end, "#pragma GCC diagnostic pop");
             writeln!(end, "#endif // __GNUC__");
-        } else if !out.pragma.clang_diagnostic_ignore.is_empty() {
+        } else if !clang_diagnostic_ignore.is_empty() {
             writeln!(end, "#ifdef __clang__");
             writeln!(end, "#pragma clang diagnostic pop");
             writeln!(end, "#endif // __clang__");


### PR DESCRIPTION
This rules out the possibility of forgetting to update pragma::write after adding a new field in Pragma.