### PR TITLE
Avoid special casing of `RustVec<String>` (avoid rewriting it into `RustVec<RustString>`).

### DIFF
--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -24,6 +24,7 @@ syn = { version = "2.0.46", features = ["full"] }
 
 [dev-dependencies]
 cxx = { version = "1.0", path = ".." }
+prettyplease = "0.2.35"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/macro/src/expand.rs
+++ b/macro/src/expand.rs
@@ -2456,3 +2456,115 @@ impl ToTokens for ExportNameAttr {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::syntax::file::Module;
+    use proc_macro2::TokenStream;
+    use quote::quote;
+    use syn::{File, Result};
+
+    fn bridge(cxx_bridge: TokenStream) -> Result<String> {
+        let module = syn::parse2::<Module>(cxx_bridge)?;
+        let tokens = super::bridge(module)?;
+
+        // TODO: Consider returning `TokenStream` and letting clients use `assert_matches!` macros
+        // if Crubit publishes
+        // https://github.com/google/crubit/blob/main/common/token_stream_matchers.rs as a separate
+        // crate.
+        let file = syn::parse2::<File>(tokens)?;
+        let pretty = prettyplease::unparse(&file);
+
+        // Print the whole result in case subsequent assertions lead to a test failure.
+        eprintln!("// expanded.rs - start vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv");
+        eprintln!("{pretty}");
+        eprintln!("// expanded.rs - end   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^");
+
+        Ok(pretty)
+    }
+
+    /// This is a regression test for how `UniquePtrTarget` `impl` is generated.  The regression
+    /// happened in a WIP version of refactoring of how generics are handled:
+    ///
+    /// * Expected:     `unsafe impl<'a> ::cxx::memory::UniquePtrTarget for Borrowed<'a>`
+    /// * Actual/Wrong: `unsafe impl     ::cxx::memory::UniquePtrTarget for Borrowed    `
+    #[test]
+    fn test_unique_ptr_with_lifetime_parametrized_pointee_implicit_impl() {
+        // Note that it is okay that the return type infers and doesn't explicitly spell out
+        // the lifetime parameter of `Borrowed`.  But this lifetime parameter needs to still
+        // be spelled out in `impl<'a> ... for Borrowed<'a'>` in the expansion.
+        //
+        // The original regression was that an incorrect refactoring started to use
+        // the inner type of `UniquePtr` (i.e. `Borrowed` - without generic lifetime args)
+        // in the expansion of `impl...UniquePtrTarget`.  Instead that expansion should
+        // first "resolve" the inner type using `Types::resolve`.
+        let rs = bridge(quote! {
+            mod ffi {
+                unsafe extern "C++" {
+                    type Borrowed<'a>;
+                    fn borrowed(arg: &i32) -> UniquePtr<Borrowed>;
+                }
+            }
+        })
+        .unwrap();
+        assert!(rs.contains("unsafe impl<'a> ::cxx::ExternType for Borrowed<'a>"));
+        assert!(rs.contains("pub fn borrowed(arg: &i32) -> ::cxx::UniquePtr<Borrowed>"));
+        assert!(rs.contains("unsafe impl<'a> ::cxx::memory::UniquePtrTarget for Borrowed<'a>"));
+    }
+
+    /// This is a test that verifies that the lifetime arguments in `impl<'a>` comes from
+    /// an explicit `impl` if one is present.
+    #[test]
+    fn test_unique_ptr_with_lifetime_parametrized_pointee_explicit_impl() {
+        // Note that it is okay that the return type infers and doesn't explicitly spell out
+        // the lifetime parameter of `Borrowed`.  But this lifetime parameter needs to still
+        // be spelled out in `impl<'a> ... for Borrowed<'a'>` in the expansion.
+        //
+        // The original regression was that an incorrect refactoring started to use
+        // the inner type of `UniquePtr` (i.e. `Borrowed` - without generic lifetime args)
+        // in the expansion of `impl...UniquePtrTarget`.  Instead that expansion should
+        // first "resolve" the inner type using `Types::resolve`.
+        let rs = bridge(quote! {
+            mod ffi {
+                unsafe extern "C++" {
+                    type Borrowed<'a>;
+                }
+                impl<'b> UniquePtr<Borrowed<'c>> {}
+            }
+        })
+        .unwrap();
+        assert!(rs.contains("unsafe impl<'a> ::cxx::ExternType for Borrowed<'a>"));
+        assert!(rs.contains("unsafe impl<'b> ::cxx::memory::UniquePtrTarget for Borrowed<'c>"));
+    }
+
+    /// This test verifies if `String` <=> `RustString` substitution happens for `Vec<String>`.
+    #[test]
+    fn test_vec_string_return_by_value() {
+        let rs = bridge(quote! {
+            mod ffi {
+                extern "Rust" {
+                    fn foo() -> Vec<String>;
+                }
+            }
+        })
+        .unwrap();
+        assert!(rs.contains("__return: *mut ::cxx::private::RustVec<::cxx::private::RustString>"));
+        assert!(rs.contains("fn __foo() -> ::cxx::alloc::vec::Vec<::cxx::alloc::string::String>"));
+        assert!(rs.contains("::cxx::private::RustVec::from_vec_string(__foo())"));
+    }
+
+    /// This test verifies if `String` <=> `RustString` substitution happens for `Vec<String>`.
+    #[test]
+    fn test_vec_string_take_by_ref() {
+        let rs = bridge(quote! {
+            mod ffi {
+                extern "Rust" {
+                    fn foo(v: &Vec<String>);
+                }
+            }
+        })
+        .unwrap();
+        assert!(rs.contains("v: &::cxx::private::RustVec<::cxx::private::RustString>"));
+        assert!(rs.contains("fn __foo(v: &::cxx::alloc::vec::Vec<::cxx::alloc::string::String>)"));
+    }
+}

--- a/src/rust_vec.rs
+++ b/src/rust_vec.rs
@@ -1,12 +1,10 @@
 #![cfg(feature = "alloc")]
 #![allow(missing_docs)]
 
-use crate::rust_string::RustString;
-use alloc::string::String;
 use alloc::vec::Vec;
 use core::ffi::c_void;
 use core::marker::PhantomData;
-use core::mem::{self, ManuallyDrop, MaybeUninit};
+use core::mem::{self, MaybeUninit};
 use core::ptr;
 
 // ABI compatible with C++ rust::Vec<T> (not necessarily alloc::vec::Vec<T>).
@@ -71,40 +69,6 @@ impl<T> RustVec<T> {
 
     pub fn truncate(&mut self, len: usize) {
         self.as_mut_vec().truncate(len);
-    }
-}
-
-impl RustVec<RustString> {
-    pub fn from_vec_string(v: Vec<String>) -> Self {
-        let mut v = ManuallyDrop::new(v);
-        let ptr = v.as_mut_ptr().cast::<RustString>();
-        let len = v.len();
-        let cap = v.capacity();
-        Self::from(unsafe { Vec::from_raw_parts(ptr, len, cap) })
-    }
-
-    pub fn from_ref_vec_string(v: &Vec<String>) -> &Self {
-        Self::from_ref(unsafe { &*(v as *const Vec<String> as *const Vec<RustString>) })
-    }
-
-    pub fn from_mut_vec_string(v: &mut Vec<String>) -> &mut Self {
-        Self::from_mut(unsafe { &mut *(v as *mut Vec<String> as *mut Vec<RustString>) })
-    }
-
-    pub fn into_vec_string(self) -> Vec<String> {
-        let mut v = ManuallyDrop::new(self.into_vec());
-        let ptr = v.as_mut_ptr().cast::<String>();
-        let len = v.len();
-        let cap = v.capacity();
-        unsafe { Vec::from_raw_parts(ptr, len, cap) }
-    }
-
-    pub fn as_vec_string(&self) -> &Vec<String> {
-        unsafe { &*(self as *const RustVec<RustString> as *const Vec<String>) }
-    }
-
-    pub fn as_mut_vec_string(&mut self) -> &mut Vec<String> {
-        unsafe { &mut *(self as *mut RustVec<RustString> as *mut Vec<String>) }
     }
 }
 


### PR DESCRIPTION
# Motivation for this PR

The work toward supporting arbitrary `T` in generics would be easier if we didn't special-case specific `T`s.  (I have a local chain of commits that builds on top of this PR, and ends up supporting `Vec<Box<T>>`.)

# Safety/correctness of this PR

IIUC `::cxx::private::RustVec<T>`:

* Has the same ABI regardless of `T`: a few `usize`s: https://github.com/dtolnay/cxx/blob/32c81e07b9d929f38b097281cd0def9842d5a09c/src/rust_vec.rs#L15
* Doesn't leak `T` somewhere else in the FFI ABI (e.g. there are no extern/FFI APIs defined in `rust_vec.rs`)

Therefore I don't understand why:

* `macro/src/expand.rs` replaces `RustVec<String>` with `RustVec<RustString>` (either "manually", or by calling `expand_extern_type`)
* `src/rust_vec.rs` needs to provide (via `impl RustVec<RustString>`) support for transmuting between values/references/etc of `Vec<String>` and `RustVec<RustString>`

So, assuming my understanding above is correct, this PR stops special casing `Vec<String>`.

FWIW `RustVec<RustString>` seems to come all the way from the original commit that added support for `Vec<String>`: https://github.com/dtolnay/cxx/commit/33f56ad8d5e536d3a42f3f2afa74d341d7b0255d.  And before this commit `Vec<String>` was being rejected in `syntax/check.rs`.  So maybe I am missing something here?

# Optional: unrelated `tests/ui` failures in my **local** testing

One more (optional) question: any idea why I see some unexpected differences in `rustc` output for `tests/ui` in my **local** testing via `cargo test`?  For example, when I try with a recent nightly version (`rustc 1.91.0-nightly (7ad23f43a 2025-09-09)`) at a recent `cxx` revision (https://github.com/dtolnay/cxx/commit/c7cb3bf38d5202a1cd12aeaa0332213c52c0741e), then `TRYBUILD=overwrite cargo test` generates the commit at https://github.com/anforowicz/cxx/commit/09a5217b21c65dc9aac712ce8ad7abcdb833634a (which AFAICT only inserts a bit of whitespace in some testcases to indent error messages from `rustc`), but GitHub CI then fails with https://github.com/anforowicz/cxx/actions/runs/17624407527/job/50077573425.  FWIW I tried, but ultimately failed to check which `rustc` version is used by GitHub CI...