### PR TITLE
Revert "Raise required compiler to Rust 1.87"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable, 1.87.0]
+        rust: [nightly, beta, stable, 1.82.0]
         os: [ubuntu]
         cc: [g++]
         flags: ['']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["ffi", "c++"]
 license = "MIT OR Apache-2.0"
 links = "cxxbridge1"
 repository = "https://github.com/dtolnay/cxx"
-rust-version = "1.87"
+rust-version = "1.82"
 
 [features]
 default = ["std", "cxxbridge-flags/default"] # c++11

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ cxx = "1.0"
 cxx-build = "1.0"
 ```
 
-*Compiler support: requires rustc 1.87+ and c++11 or newer*<br>
+*Compiler support: requires rustc 1.82+ and c++11 or newer*<br>
 *[Release notes](https://github.com/dtolnay/cxx/releases)*
 
 <br>

--- a/build.rs
+++ b/build.rs
@@ -32,8 +32,8 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(skip_ui_tests)");
 
     if let Some(rustc) = rustc_version() {
-        if rustc.minor < 87 {
-            println!("cargo:warning=The cxx crate requires a rustc version 1.87.0 or newer.");
+        if rustc.minor < 82 {
+            println!("cargo:warning=The cxx crate requires a rustc version 1.82.0 or newer.");
             println!(
                 "cargo:warning=You appear to be building with: {}",
                 rustc.version,

--- a/flags/Cargo.toml
+++ b/flags/Cargo.toml
@@ -7,7 +7,7 @@ description = "Compiler configuration of the `cxx` crate (implementation detail)
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/cxx"
-rust-version = "1.87"
+rust-version = "1.82"
 
 [features]
 default = [] # c++11

--- a/gen/build/Cargo.toml
+++ b/gen/build/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://cxx.rs"
 keywords = ["ffi", "build-dependencies"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/cxx"
-rust-version = "1.87"
+rust-version = "1.82"
 
 [features]
 parallel = ["cc/parallel"]

--- a/gen/cmd/Cargo.toml
+++ b/gen/cmd/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cxx.rs"
 keywords = ["ffi"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/cxx"
-rust-version = "1.87"
+rust-version = "1.82"
 
 [[bin]]
 name = "cxxbridge"

--- a/gen/lib/Cargo.toml
+++ b/gen/lib/Cargo.toml
@@ -10,7 +10,7 @@ exclude = ["build.rs"]
 keywords = ["ffi"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/cxx"
-rust-version = "1.87"
+rust-version = "1.82"
 
 [dependencies]
 codespan-reporting = "0.13.1"

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://cxx.rs"
 keywords = ["ffi"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/cxx"
-rust-version = "1.87"
+rust-version = "1.82"
 
 [lib]
 proc-macro = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! <br>
 //!
-//! *Compiler support: requires rustc 1.87+ and c++11 or newer*<br>
+//! *Compiler support: requires rustc 1.82+ and c++11 or newer*<br>
 //! *[Release notes](https://github.com/dtolnay/cxx/releases)*
 //!
 //! <br>

--- a/third-party/Cargo.toml
+++ b/third-party/Cargo.toml
@@ -4,7 +4,7 @@ name = "third-party"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.87"
+rust-version = "1.82"
 
 [dependencies]
 cc = "1.0.101"


### PR DESCRIPTION
This reverts cac51dd0d6fe486e9862ca325f37d98d44533a98 from #1661. Unneeded since https://github.com/brendanzab/codespan/pull/405 + https://github.com/dtolnay/cxx/pull/1663.