### PR TITLE
Don't track bridge files in `OUT_DIR`

### DIFF
--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -401,7 +401,9 @@ fn generate_bridge(prj: &Project, build: &mut Build, rust_source_file: &Path) ->
         doxygen: CFG.doxygen,
         ..Opt::default()
     };
-    println!("cargo:rerun-if-changed={}", rust_source_file.display());
+    if !rust_source_file.starts_with(&prj.out_dir) {
+        println!("cargo:rerun-if-changed={}", rust_source_file.display());
+    }
     let generated = gen::generate_from_path(rust_source_file, &opt);
     let ref rel_path = paths::local_relative_path(rust_source_file);
 


### PR DESCRIPTION
Files in the `OUT_DIR` are likely generated by the very same build script. As such, they likely have a modification time that is after the build script's start time. This causes cargo to assume that the file has changed since the last run, thereby considering the build script dirty on every build. The result is that the build script and everything above in the dependency is recompiled on every build.

This commit avoids that problem by emitting the `rerun-if-changed` command only for files that are not in the `OUT_DIR`.

Proposed in https://github.com/dtolnay/cxx/pull/1462#issuecomment-3517779624