### PR TITLE
Cover top-level `BUILD.bazel` + `MODULE.bazel` in mdbook Bazel chapter.

### DIFF
--- a/book/src/build/bazel.md
+++ b/book/src/build/bazel.md
@@ -35,84 +35,23 @@ as an illustration of one possible working pattern.
 ```python
 # tools/bazel/rust_cxx_bridge.bzl
 
-load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
-def rust_cxx_bridge(name, src, deps = []):
-    native.alias(
-        name = "%s/header" % name,
-        actual = src + ".h",
-    )
-
-    native.alias(
-        name = "%s/source" % name,
-        actual = src + ".cc",
-    )
-
-    run_binary(
-        name = "%s/generated" % name,
-        srcs = [src],
-        outs = [
-            src + ".h",
-            src + ".cc",
-        ],
-        args = [
-            "$(location %s)" % src,
-            "-o",
-            "$(location %s.h)" % src,
-            "-o",
-            "$(location %s.cc)" % src,
-        ],
-        tool = "//:codegen",
-    )
-
-    cc_library(
-        name = name,
-        srcs = [src + ".cc"],
-        deps = deps + [":%s/include" % name],
-    )
-
-    cc_library(
-        name = "%s/include" % name,
-        hdrs = [src + ".h"],
-    )
+{{#include ../../../tools/bazel/rust_cxx_bridge.bzl}}
 ```
 
 ```python
 # demo/BUILD.bazel
 
-load("@rules_cc//cc:defs.bzl", "cc_library")
-load("@rules_rust//rust:defs.bzl", "rust_binary")
-load("//tools/bazel:rust_cxx_bridge.bzl", "rust_cxx_bridge")
+{{#include ../../../demo/BUILD.bazel}}
+```
 
-rust_binary(
-    name = "demo",
-    srcs = glob(["src/**/*.rs"]),
-    deps = [
-        ":blobstore-sys",
-        ":bridge",
-        "//:cxx",
-    ],
-)
+```python
+# BUILD.bazel
 
-rust_cxx_bridge(
-    name = "bridge",
-    src = "src/main.rs",
-    deps = [":blobstore-include"],
-)
+{{#include ../../../BUILD.bazel}}
+```
 
-cc_library(
-    name = "blobstore-sys",
-    srcs = ["src/blobstore.cc"],
-    deps = [
-        ":blobstore-include",
-        ":bridge/include",
-    ],
-)
+```python
+# MODULE.bazel
 
-cc_library(
-    name = "blobstore-include",
-    hdrs = ["include/blobstore.h"],
-    deps = ["//:core"],
-)
+{{#include ../../../MODULE.bazel}}
 ```


### PR DESCRIPTION
PTAL?

The mdbook `{{#include ...}}` syntax is based on what I found in https://rust-lang.github.io/mdBook/format/mdbook.html#including-portions-of-a-file.  I tested manually by running `DISPLAY=:20 mdbook build -o` under `book/` and looking at the Bazel chapter.
 
I don't really use Bazel often, but I hope that including a more complete example helps.  Not sure if a more canonical/reusable example is possible - I hope that Bazel experts if any can chime in with additional/future PRs if needed.

I understand that this PR probably doesn't directly help the reporter of https://github.com/dtolnay/cxx/issues/1676 (since they have more of a custom setup with an ad-hoc `rust_binary` target for `cxxbridge-cmd` and with `cxxbridge-macro` defined somewhere else (hopefully with a matching version).  