### PR TITLE
Ignore GCC 15's new mismatched-new-delete

### DIFF
--- a/gen/src/pragma.rs
+++ b/gen/src/pragma.rs
@@ -6,6 +6,7 @@ pub(crate) struct Pragma<'a> {
     pub gnu_diagnostic_ignore: BTreeSet<&'a str>,
     pub clang_diagnostic_ignore: BTreeSet<&'a str>,
     pub dollar_in_identifier: bool,
+    pub mismatched_new_delete: bool,
     pub missing_declarations: bool,
     pub return_type_c_linkage: bool,
     pub begin: Content<'a>,
@@ -23,6 +24,7 @@ pub(super) fn write(out: &mut OutFile) {
         ref mut gnu_diagnostic_ignore,
         ref mut clang_diagnostic_ignore,
         dollar_in_identifier,
+        mismatched_new_delete,
         missing_declarations,
         return_type_c_linkage,
         ref mut begin,
@@ -31,6 +33,9 @@ pub(super) fn write(out: &mut OutFile) {
 
     if dollar_in_identifier {
         clang_diagnostic_ignore.insert("-Wdollar-in-identifier-extension");
+    }
+    if mismatched_new_delete {
+        gnu_diagnostic_ignore.insert("-Wmismatched-new-delete");
     }
     if missing_declarations {
         gnu_diagnostic_ignore.insert("-Wmissing-declarations");

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1826,6 +1826,7 @@ fn write_unique_ptr_common(out: &mut OutFile, ty: &Type) {
 
     if can_construct_from_value {
         out.builtin.maybe_uninit = true;
+        out.pragma.mismatched_new_delete = true;
         begin_function_definition(out);
         writeln!(
             out,
@@ -1921,6 +1922,7 @@ fn write_shared_ptr(out: &mut OutFile, key: &NamedImplKey) {
 
     if can_construct_from_value {
         out.builtin.maybe_uninit = true;
+        out.pragma.mismatched_new_delete = true;
         begin_function_definition(out);
         writeln!(
             out,


### PR DESCRIPTION
```cpp
::org::blobstore::ApiZones *cxxbridge1$unique_ptr$org$blobstore$ApiZones$uninit(::std::unique_ptr<::org::blobstore::ApiZones> *ptr) noexcept {
  ::org::blobstore::ApiZones *uninit = reinterpret_cast<::org::blobstore::ApiZones *>(new ::rust::MaybeUninit<::org::blobstore::ApiZones>);
  ::new (ptr) ::std::unique_ptr<::org::blobstore::ApiZones>(uninit);
  return uninit;
}
```

```console
target/cxxbridge/demo/src/main.rs.cc: In function 'org::blobstore::ApiZones* cxxbridge1$unique_ptr$org$blobstore$ApiZones$uninit(std::unique_ptr<org::blobstore::ApiZones>*)':
target/cxxbridge/demo/src/main.rs.cc:1005:99: warning: 'void operator delete(void*, std::size_t)' called on pointer returned from a mismatched allocation function [-Wmismatched-new-delete]
 1005 |   ::org::blobstore::ApiZones *uninit = reinterpret_cast<::org::blobstore::ApiZones *>(new ::rust::MaybeUninit<::org::blobstore::ApiZones>);
      |                                                                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
target/cxxbridge/demo/src/main.rs.cc:1005:99: note: returned from 'static void* rust::cxxbridge1::MaybeUninit<T>::operator new(std::size_t) [with T = org::blobstore::ApiZones]'
 1005 |   ::org::blobstore::ApiZones *uninit = reinterpret_cast<::org::blobstore::ApiZones *>(new ::rust::MaybeUninit<::org::blobstore::ApiZones>);
      |                                                                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

It wants there to be a `void operator delete(void *, ::std::size_t) {}` in the definition of MaybeUninit\<T\>. For our usage that is unnecessary because we never delete through this type. Deletion is handled by `std::default_delete`.

```cpp
#include <cstddef>
#include <new>

namespace rust {
inline namespace cxxbridge1 {
namespace detail {
template <typename T, typename = void *>
struct operator_new {
  void *operator()(::std::size_t sz) { return ::operator new(sz); }
};

template <typename T>
struct operator_new<T, decltype(T::operator new(sizeof(T)))> {
  void *operator()(::std::size_t sz) { return T::operator new(sz); }
};
} // namespace detail

template <typename T>
union MaybeUninit {
  T value;
  void *operator new(::std::size_t sz) { return detail::operator_new<T>{}(sz); }
  MaybeUninit() {}
  ~MaybeUninit() {}
};
} // namespace cxxbridge1
} // namespace rust
```