### PR TITLE
dev: update cxx dev dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ cxxbridge-flags = { version = "=1.0.192", path = "flags", default-features = fal
 [dev-dependencies]
 cc = "1.0.101"
 cxx-build = { version = "1", path = "gen/build" }
-cxx-gen = { version = "0.7", path = "gen/lib" }
+cxx-gen = { version = "0.7.192", path = "gen/lib" }
 cxx-test-suite = { version = "0", path = "tests/ffi" }
 indoc = "2"
 proc-macro2 = "1.0.95"


### PR DESCRIPTION
Some tests (I encountered https://github.com/dtolnay/cxx/blob/master/tests/cpp_ui_tests.rs and https://github.com/dtolnay/cxx/blob/master/tests/cxx_gen.rs) depend on a current version of cxx-gen.

This encodes that relationship in the dependency.