### PR TITLE
Use a portable isize definition.

### DIFF
--- a/include/cxx.h
+++ b/include/cxx.h
@@ -14,7 +14,6 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
-#endif
 
 #if __cplusplus >= 201703L
 #include <string_view>


### PR DESCRIPTION
Remove platform specific headers which were included for ssize_t and use intptr_t instead to prevent failures in baremetal builds.
