### PR TITLE
Add cc_library load in additive_build_file_content

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ rustdoc-args = [
 
 [package.metadata.bazel]
 additive_build_file_content = """
+load("@rules_cc//cc:defs.bzl", "cc_library")
 cc_library(
     name = "cxx_cc",
     srcs = ["src/cxx.cc"],


### PR DESCRIPTION
This hinges on bazel allowing `load` after some targets are already defined, which is the case as far as I can tell.

Closes #1694.