### PR TITLE
Drop support for Bazel 7

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -3,7 +3,7 @@ matrix:
     - macos_arm64
     - ubuntu2404
     - windows
-  bazel: [7.x, 8.x]
+  bazel: [8.x]
 tasks:
   verify_targets:
     name: Verify build targets

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 module(
     name = "cxx.rs",
     version = "0.0.0",
-    bazel_compatibility = [">=7.2.1"],
+    bazel_compatibility = [">=8.0.0"],
     compatibility_level = 1,
 )
 


### PR DESCRIPTION
https://github.com/bazelbuild/bazel-central-registry/pull/7244

```console
(17:12:20) ERROR: /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/d5cfde109bfc8374b1c1783dd97c5f60/external/cxx.rs~/tools/bazel/BUILD.bazel:11:14: in xcode_version rule @@cxx.rs~//tools/bazel:github_actions_xcode_26_2_0:
Traceback (most recent call last):
	File "/var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/d5cfde109bfc8374b1c1783dd97c5f60/external/apple_support~/xcode/xcode_version.bzl", line 33, column 13, in _xcode_version_impl
		fail("This rule is not available on the current Bazel version")
Error in fail: This rule is not available on the current Bazel version
(17:12:20) ERROR: /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/d5cfde109bfc8374b1c1783dd97c5f60/external/cxx.rs~/tools/bazel/BUILD.bazel:11:14: Analysis of target '@@cxx.rs~//tools/bazel:github_actions_xcode_26_2_0' failed
Target @@cxx.rs~//third-party/bazel:srcs failed to build
(17:12:20) ERROR: Analysis of target '@@cxx.rs~//tools/bazel:github_actions_xcode_26_2_0' failed; build aborted
(17:12:20) INFO: Elapsed time: 1.672s, Critical Path: 0.03s
(17:12:20) INFO: 1 process: 1 internal.
(17:12:20) ERROR: Build did NOT complete successfully
```