### PR TITLE
Support creation of rust::Str from consteval utf8 checked string literal

### DIFF
--- a/include/cxx.h
+++ b/include/cxx.h
@@ -138,42 +138,42 @@ public:
     const std::size_t len;
     // This can only be called from a user-defined literal initialization and it's
     // always evaluated at compile time.
-    static consteval void assert_utf8(const char8_t *s, std::size_t len) {
+    static consteval void assert_utf8(const char8_t *s, std::size_t len) noexcept {
       for (std::size_t i = 0; i < len;) {
         auto c = static_cast<unsigned char>(s[i]);
-        std::size_t seq;
+        std::size_t seq = 1;
         if (c <= 0x7F) {
           seq = 1;
         } else if ((c & 0xE0) == 0xC0) {
           seq = 2;
           if (c < 0xC2)
-            throw "overlong UTF-8 sequence";
+            std::abort();
         } else if ((c & 0xF0) == 0xE0) {
           seq = 3;
         } else if ((c & 0xF8) == 0xF0) {
           seq = 4;
           if (c > 0xF4)
-            throw "codepoint out of range";
+            std::abort();
         } else {
-          throw "invalid UTF-8 start byte";
+          std::abort();
         }
         if (i + seq > len)
-          throw "truncated UTF-8 sequence";
+          std::abort();
         for (std::size_t j = 1; j < seq; ++j)
           if ((static_cast<unsigned char>(s[i + j]) & 0xC0) != 0x80)
-            throw "invalid UTF-8 continuation byte";
+            std::abort();
         if (seq == 3) {
           auto c1 = static_cast<unsigned char>(s[i + 1]);
           if (c == 0xE0 && c1 < 0xA0)
-            throw "overlong UTF-8 sequence";
+            std::abort();
           if (c == 0xED && c1 >= 0xA0)
-            throw "UTF-16 surrogate in UTF-8";
+            std::abort();
         } else if (seq == 4) {
           auto c1 = static_cast<unsigned char>(s[i + 1]);
           if (c == 0xF0 && c1 < 0x90)
-            throw "overlong UTF-8 sequence";
+            std::abort();
           if (c == 0xF4 && c1 > 0x8F)
-            throw "codepoint out of range";
+            std::abort();
         }
         i += seq;
       }

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -124,6 +124,63 @@ public:
   Str(const std::string &);
   Str(const char *);
   Str(const char *, std::size_t);
+#if defined(__cpp_char8_t) && __cplusplus >= 202002L
+  struct utf8_literal {
+  private:
+    friend class Str;
+    friend consteval utf8_literal operator""_utf8(const char8_t *s,
+                                                  std::size_t len) noexcept;
+    inline consteval utf8_literal(const char8_t *s, std::size_t len) noexcept
+        : ptr(s), len(len) {
+      assert_utf8(s, len);
+    }
+    const char8_t *const ptr;
+    const std::size_t len;
+    // This can only be called from a user-defined literal initialization and it's
+    // always evaluated at compile time.
+    static consteval void assert_utf8(const char8_t *s, std::size_t len) {
+      for (std::size_t i = 0; i < len;) {
+        auto c = static_cast<unsigned char>(s[i]);
+        std::size_t seq;
+        if (c <= 0x7F) {
+          seq = 1;
+        } else if ((c & 0xE0) == 0xC0) {
+          seq = 2;
+          if (c < 0xC2)
+            throw "overlong UTF-8 sequence";
+        } else if ((c & 0xF0) == 0xE0) {
+          seq = 3;
+        } else if ((c & 0xF8) == 0xF0) {
+          seq = 4;
+          if (c > 0xF4)
+            throw "codepoint out of range";
+        } else {
+          throw "invalid UTF-8 start byte";
+        }
+        if (i + seq > len)
+          throw "truncated UTF-8 sequence";
+        for (std::size_t j = 1; j < seq; ++j)
+          if ((static_cast<unsigned char>(s[i + j]) & 0xC0) != 0x80)
+            throw "invalid UTF-8 continuation byte";
+        if (seq == 3) {
+          auto c1 = static_cast<unsigned char>(s[i + 1]);
+          if (c == 0xE0 && c1 < 0xA0)
+            throw "overlong UTF-8 sequence";
+          if (c == 0xED && c1 >= 0xA0)
+            throw "UTF-16 surrogate in UTF-8";
+        } else if (seq == 4) {
+          auto c1 = static_cast<unsigned char>(s[i + 1]);
+          if (c == 0xF0 && c1 < 0x90)
+            throw "overlong UTF-8 sequence";
+          if (c == 0xF4 && c1 > 0x8F)
+            throw "codepoint out of range";
+        }
+        i += seq;
+      }
+    }
+  };
+  Str(const utf8_literal lit) noexcept;
+#endif
 
   Str &operator=(const Str &) & noexcept = default;
 
@@ -165,6 +222,13 @@ private:
 
   std::array<std::uintptr_t, 2> repr;
 };
+
+#if defined(__cpp_char8_t) && __cplusplus >= 202002L
+inline consteval Str::utf8_literal operator""_utf8(const char8_t *s,
+                                                   std::size_t len) noexcept {
+  return Str::utf8_literal(s, len);
+}
+#endif
 #endif // CXXBRIDGE1_RUST_STR
 
 #ifndef CXXBRIDGE1_RUST_SLICE

--- a/src/cxx.cc
+++ b/src/cxx.cc
@@ -87,6 +87,8 @@ void cxxbridge1$str$new(rust::Str *self) noexcept;
 void cxxbridge1$str$ref(rust::Str *self, const rust::String *string) noexcept;
 bool cxxbridge1$str$from(rust::Str *self, const char *ptr,
                          std::size_t len) noexcept;
+void cxxbridge1$str$from_utf8_unchecked(rust::Str *self, const char *ptr,
+                                        std::size_t len) noexcept;
 const char *cxxbridge1$str$ptr(const rust::Str *self) noexcept;
 std::size_t cxxbridge1$str$len(const rust::Str *self) noexcept;
 
@@ -346,6 +348,17 @@ Str::Str(const char *s, std::size_t len) {
           s == nullptr && len == 0 ? reinterpret_cast<const char *>(1) : s,
           len);
 }
+
+#if defined(__cpp_char8_t) && __cplusplus >= 202002L
+static void initStrUnchecked(Str *self, const char *ptr,
+                             std::size_t len) noexcept {
+  cxxbridge1$str$from_utf8_unchecked(self, ptr, len);
+}
+
+Str::Str(const utf8_literal lit) noexcept {
+  initStrUnchecked(this, reinterpret_cast<const char *>(lit.ptr), lit.len);
+}
+#endif
 
 Str::operator std::string() const {
   return std::string(this->data(), this->size());

--- a/src/symbols/rust_str.rs
+++ b/src/symbols/rust_str.rs
@@ -32,6 +32,18 @@ unsafe extern "C" fn str_from(this: &mut MaybeUninit<&str>, ptr: *const u8, len:
     }
 }
 
+#[export_name = "cxxbridge1$str$from_utf8_unchecked"]
+unsafe extern "C" fn str_from_utf8_unchecked(
+    this: &mut MaybeUninit<&str>,
+    ptr: *const u8,
+    len: usize,
+) {
+    let slice = unsafe { slice::from_raw_parts(ptr, len) };
+    let s = unsafe { str::from_utf8_unchecked(slice) };
+    let this = this.as_mut_ptr();
+    unsafe { ptr::write(this, s) }
+}
+
 #[export_name = "cxxbridge1$str$ptr"]
 unsafe extern "C" fn str_ptr(this: &&str) -> *const u8 {
     this.as_ptr()

--- a/tests/cpp_ui_tests.rs
+++ b/tests/cpp_ui_tests.rs
@@ -26,3 +26,58 @@ fn test_unique_ptr_of_incomplete_foward_declared_pointee() {
     let err_msg = test.compile().expect_single_error();
     assert!(err_msg.contains("definition of `::ForwardDeclaredType` is required"));
 }
+
+#[test]
+fn test_str_rejects_non_utf8() {
+    let test = cpp_compile::Test::new(quote! {
+        #[cxx::bridge]
+        mod ffi {
+            extern "Rust" {
+                fn dummy(s: &str);
+            }
+        }
+    });
+    test.write_file(
+        "cxx_bridge.generated.cc",
+        indoc! {r#"
+            #include "cxx_bridge.generated.h"
+
+            #ifdef __cpp_char8_t
+            using rust::operator""_utf8;
+            inline void must_fail() {
+                rust::Str s{u8"test\xff"_utf8};
+            }
+            #endif
+        "#},
+    );
+    let err_msg = test.compile().expect_single_error();
+    println!("error message: {err_msg}");
+    assert!(err_msg.contains("consteval function"), "unexpected error: {err_msg}");
+}
+
+#[test]
+fn test_str_rejects_non_constexpr_variable() {
+    let test = cpp_compile::Test::new(quote! {
+        #[cxx::bridge]
+        mod ffi {
+            extern "Rust" {
+                fn dummy(s: &str);
+            }
+        }
+    });
+    test.write_file(
+        "cxx_bridge.generated.cc",
+        indoc! {r#"
+            #include "cxx_bridge.generated.h"
+
+            #ifdef __cpp_char8_t
+            inline void must_fail() {
+                rust::Str s{u8"test\xff"};
+            }
+            #endif
+        "#},
+    );
+    let err_msg = test.compile().expect_single_error();
+    println!("error message: {err_msg}");
+    assert!(err_msg.contains("no matching constructor"), "unexpected error: {err_msg}");
+}

--- a/tests/cpp_ui_tests.rs
+++ b/tests/cpp_ui_tests.rs
@@ -27,6 +27,7 @@ fn test_unique_ptr_of_incomplete_foward_declared_pointee() {
     assert!(err_msg.contains("definition of `::ForwardDeclaredType` is required"));
 }
 
+#[cfg(feature = "c++20")]
 #[test]
 fn test_str_rejects_non_utf8() {
     let test = cpp_compile::Test::new(quote! {
@@ -52,9 +53,13 @@ fn test_str_rejects_non_utf8() {
     );
     let err_msg = test.compile().expect_single_error();
     println!("error message: {err_msg}");
-    assert!(err_msg.contains("consteval function"), "unexpected error: {err_msg}");
+    assert!(
+        err_msg.contains("consteval") || err_msg.contains("constexpr"),
+        "unexpected error: {err_msg}"
+    );
 }
 
+#[cfg(feature = "c++20")]
 #[test]
 fn test_str_rejects_non_constexpr_variable() {
     let test = cpp_compile::Test::new(quote! {
@@ -79,5 +84,8 @@ fn test_str_rejects_non_constexpr_variable() {
     );
     let err_msg = test.compile().expect_single_error();
     println!("error message: {err_msg}");
-    assert!(err_msg.contains("no matching constructor"), "unexpected error: {err_msg}");
+    assert!(
+        err_msg.contains("no matching constructor") || err_msg.contains("invalid conversion"),
+        "unexpected error: {err_msg}"
+    );
 }

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -924,6 +924,13 @@ extern "C" const char *cxx_run_test() noexcept {
   rust::String bad_utf16_rstring = rust::String::lossy(bad_utf16_literal);
   ASSERT(bad_utf8_rstring == bad_utf16_rstring);
 
+#if defined(__cpp_char8_t) && __cplusplus >= 202002L
+  using rust::operator""_utf8;
+  rust::Str utf8_rstr{u8"Test string"_utf8};
+  ASSERT(std::string(utf8_rstr) == "Test string");
+  ASSERT(utf8_rstr.size() == 11);
+#endif
+
   // Test Slice<T> explicit constructor from container
   {
     std::vector<int> cpp_vec{1, 2, 3};


### PR DESCRIPTION
This change adds a C++20-only path for constructing rust::Str from UTF-8 string literals. The _utf8 literal validates the input at compile time using consteval function and then calls the unsafe version of constructing a str from rust to avoid double checking it (https://doc.rust-lang.org/std/str/fn.from_utf8_unchecked.html).

This is useful for creating literal Str without utf8 runtime checking overhead.

It can be especially useful in non exception code such as Chromium as extra utf8 check would have to be done outside the cxx library as a potential failure will result in abort, bringing the checks for static literals from 2 to 0.

Working example:

```cpp
rust::Str var{u8"Valid👍"_utf8};
```

This will not compile:

```cpp
rust::Str var{u8"Invalid\xff"_utf8};
```