### PR TITLE
Update WebAssembly/wasi-sdk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,14 +156,14 @@ jobs:
           targets: wasm32-wasip1
           components: rust-src
       - uses: dtolnay/install@wasmtime-cli
-      - run: curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-27/wasi-sdk-27.0-x86_64-linux.tar.gz --location --silent --show-error --fail --retry 2 --output ${{runner.temp}}/wasi-sdk-27.0-x86_64-linux.tar.gz
-      - run: tar xf ${{runner.temp}}/wasi-sdk-27.0-x86_64-linux.tar.gz -C ${{runner.temp}}
+      - run: curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-28/wasi-sdk-28.0-x86_64-linux.tar.gz --location --silent --show-error --fail --retry 2 --output ${{runner.temp}}/wasi-sdk-28.0-x86_64-linux.tar.gz
+      - run: tar xf ${{runner.temp}}/wasi-sdk-28.0-x86_64-linux.tar.gz -C ${{runner.temp}}
       - run: cargo build --target=wasm32-wasip1 --manifest-path=demo/Cargo.toml --release
-          --config='target.wasm32-wasip1.linker="${{runner.temp}}/wasi-sdk-27.0-x86_64-linux/bin/lld"'
-          --config='target.wasm32-wasip1.rustflags=["-Clink-args=-L${{runner.temp}}/wasi-sdk-27.0-x86_64-linux/share/wasi-sysroot/lib/wasm32-wasip1", "-Clink-args=-lc++abi"]'
+          --config='target.wasm32-wasip1.linker="${{runner.temp}}/wasi-sdk-28.0-x86_64-linux/bin/lld"'
+          --config='target.wasm32-wasip1.rustflags=["-Clink-args=-L${{runner.temp}}/wasi-sdk-28.0-x86_64-linux/share/wasi-sysroot/lib/wasm32-wasip1", "-Clink-args=-lc++abi"]'
         env:
-          CXX: ${{runner.temp}}/wasi-sdk-27.0-x86_64-linux/bin/clang++
-          CXXFLAGS: --sysroot=${{runner.temp}}/wasi-sdk-27.0-x86_64-linux/share/wasi-sysroot
+          CXX: ${{runner.temp}}/wasi-sdk-28.0-x86_64-linux/bin/clang++
+          CXXFLAGS: --sysroot=${{runner.temp}}/wasi-sdk-28.0-x86_64-linux/share/wasi-sysroot
       - run: wasmtime target/wasm32-wasip1/release/demo.wasm
 
   emscripten:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,14 +156,14 @@ jobs:
           targets: wasm32-wasip1
           components: rust-src
       - uses: dtolnay/install@wasmtime-cli
-      - run: curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-30/wasi-sdk-30.0-x86_64-linux.tar.gz --location --silent --show-error --fail --retry 2 --output ${{runner.temp}}/wasi-sdk-30.0-x86_64-linux.tar.gz
-      - run: tar xf ${{runner.temp}}/wasi-sdk-30.0-x86_64-linux.tar.gz -C ${{runner.temp}}
+      - run: curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-31/wasi-sdk-31.0-x86_64-linux.tar.gz --location --silent --show-error --fail --retry 2 --output ${{runner.temp}}/wasi-sdk-31.0-x86_64-linux.tar.gz
+      - run: tar xf ${{runner.temp}}/wasi-sdk-31.0-x86_64-linux.tar.gz -C ${{runner.temp}}
       - run: cargo build --target=wasm32-wasip1 --manifest-path=demo/Cargo.toml --release
-          --config='target.wasm32-wasip1.linker="${{runner.temp}}/wasi-sdk-30.0-x86_64-linux/bin/lld"'
-          --config='target.wasm32-wasip1.rustflags=["-Clink-args=-L${{runner.temp}}/wasi-sdk-30.0-x86_64-linux/share/wasi-sysroot/lib/wasm32-wasip1", "-Clink-args=-lc++abi"]'
+          --config='target.wasm32-wasip1.linker="${{runner.temp}}/wasi-sdk-31.0-x86_64-linux/bin/lld"'
+          --config='target.wasm32-wasip1.rustflags=["-Clink-args=-L${{runner.temp}}/wasi-sdk-31.0-x86_64-linux/share/wasi-sysroot/lib/wasm32-wasip1", "-Clink-args=-lc++abi"]'
         env:
-          CXX: ${{runner.temp}}/wasi-sdk-30.0-x86_64-linux/bin/clang++
-          CXXFLAGS: --sysroot=${{runner.temp}}/wasi-sdk-30.0-x86_64-linux/share/wasi-sysroot
+          CXX: ${{runner.temp}}/wasi-sdk-31.0-x86_64-linux/bin/clang++
+          CXXFLAGS: --sysroot=${{runner.temp}}/wasi-sdk-31.0-x86_64-linux/share/wasi-sysroot
       - run: wasmtime target/wasm32-wasip1/release/demo.wasm
 
   emscripten:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,14 +156,14 @@ jobs:
           targets: wasm32-wasip1
           components: rust-src
       - uses: dtolnay/install@wasmtime-cli
-      - run: curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-29/wasi-sdk-29.0-x86_64-linux.tar.gz --location --silent --show-error --fail --retry 2 --output ${{runner.temp}}/wasi-sdk-29.0-x86_64-linux.tar.gz
-      - run: tar xf ${{runner.temp}}/wasi-sdk-29.0-x86_64-linux.tar.gz -C ${{runner.temp}}
+      - run: curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-30/wasi-sdk-30.0-x86_64-linux.tar.gz --location --silent --show-error --fail --retry 2 --output ${{runner.temp}}/wasi-sdk-30.0-x86_64-linux.tar.gz
+      - run: tar xf ${{runner.temp}}/wasi-sdk-30.0-x86_64-linux.tar.gz -C ${{runner.temp}}
       - run: cargo build --target=wasm32-wasip1 --manifest-path=demo/Cargo.toml --release
-          --config='target.wasm32-wasip1.linker="${{runner.temp}}/wasi-sdk-29.0-x86_64-linux/bin/lld"'
-          --config='target.wasm32-wasip1.rustflags=["-Clink-args=-L${{runner.temp}}/wasi-sdk-29.0-x86_64-linux/share/wasi-sysroot/lib/wasm32-wasip1", "-Clink-args=-lc++abi"]'
+          --config='target.wasm32-wasip1.linker="${{runner.temp}}/wasi-sdk-30.0-x86_64-linux/bin/lld"'
+          --config='target.wasm32-wasip1.rustflags=["-Clink-args=-L${{runner.temp}}/wasi-sdk-30.0-x86_64-linux/share/wasi-sysroot/lib/wasm32-wasip1", "-Clink-args=-lc++abi"]'
         env:
-          CXX: ${{runner.temp}}/wasi-sdk-29.0-x86_64-linux/bin/clang++
-          CXXFLAGS: --sysroot=${{runner.temp}}/wasi-sdk-29.0-x86_64-linux/share/wasi-sysroot
+          CXX: ${{runner.temp}}/wasi-sdk-30.0-x86_64-linux/bin/clang++
+          CXXFLAGS: --sysroot=${{runner.temp}}/wasi-sdk-30.0-x86_64-linux/share/wasi-sysroot
       - run: wasmtime target/wasm32-wasip1/release/demo.wasm
 
   emscripten:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,14 +156,14 @@ jobs:
           targets: wasm32-wasip1
           components: rust-src
       - uses: dtolnay/install@wasmtime-cli
-      - run: curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-31/wasi-sdk-31.0-x86_64-linux.tar.gz --location --silent --show-error --fail --retry 2 --output ${{runner.temp}}/wasi-sdk-31.0-x86_64-linux.tar.gz
-      - run: tar xf ${{runner.temp}}/wasi-sdk-31.0-x86_64-linux.tar.gz -C ${{runner.temp}}
+      - run: curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-32/wasi-sdk-32.0-x86_64-linux.tar.gz --location --silent --show-error --fail --retry 2 --output ${{runner.temp}}/wasi-sdk-32.0-x86_64-linux.tar.gz
+      - run: tar xf ${{runner.temp}}/wasi-sdk-32.0-x86_64-linux.tar.gz -C ${{runner.temp}}
       - run: cargo build --target=wasm32-wasip1 --manifest-path=demo/Cargo.toml --release
-          --config='target.wasm32-wasip1.linker="${{runner.temp}}/wasi-sdk-31.0-x86_64-linux/bin/lld"'
-          --config='target.wasm32-wasip1.rustflags=["-Clink-args=-L${{runner.temp}}/wasi-sdk-31.0-x86_64-linux/share/wasi-sysroot/lib/wasm32-wasip1", "-Clink-args=-lc++abi"]'
+          --config='target.wasm32-wasip1.linker="${{runner.temp}}/wasi-sdk-32.0-x86_64-linux/bin/lld"'
+          --config='target.wasm32-wasip1.rustflags=["-Clink-args=-L${{runner.temp}}/wasi-sdk-32.0-x86_64-linux/share/wasi-sysroot/lib/wasm32-wasip1", "-Clink-args=-lc++abi"]'
         env:
-          CXX: ${{runner.temp}}/wasi-sdk-31.0-x86_64-linux/bin/clang++
-          CXXFLAGS: --sysroot=${{runner.temp}}/wasi-sdk-31.0-x86_64-linux/share/wasi-sysroot
+          CXX: ${{runner.temp}}/wasi-sdk-32.0-x86_64-linux/bin/clang++
+          CXXFLAGS: --sysroot=${{runner.temp}}/wasi-sdk-32.0-x86_64-linux/share/wasi-sysroot
       - run: wasmtime target/wasm32-wasip1/release/demo.wasm
 
   emscripten:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,14 +156,14 @@ jobs:
           targets: wasm32-wasip1
           components: rust-src
       - uses: dtolnay/install@wasmtime-cli
-      - run: curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-28/wasi-sdk-28.0-x86_64-linux.tar.gz --location --silent --show-error --fail --retry 2 --output ${{runner.temp}}/wasi-sdk-28.0-x86_64-linux.tar.gz
-      - run: tar xf ${{runner.temp}}/wasi-sdk-28.0-x86_64-linux.tar.gz -C ${{runner.temp}}
+      - run: curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-29/wasi-sdk-29.0-x86_64-linux.tar.gz --location --silent --show-error --fail --retry 2 --output ${{runner.temp}}/wasi-sdk-29.0-x86_64-linux.tar.gz
+      - run: tar xf ${{runner.temp}}/wasi-sdk-29.0-x86_64-linux.tar.gz -C ${{runner.temp}}
       - run: cargo build --target=wasm32-wasip1 --manifest-path=demo/Cargo.toml --release
-          --config='target.wasm32-wasip1.linker="${{runner.temp}}/wasi-sdk-28.0-x86_64-linux/bin/lld"'
-          --config='target.wasm32-wasip1.rustflags=["-Clink-args=-L${{runner.temp}}/wasi-sdk-28.0-x86_64-linux/share/wasi-sysroot/lib/wasm32-wasip1", "-Clink-args=-lc++abi"]'
+          --config='target.wasm32-wasip1.linker="${{runner.temp}}/wasi-sdk-29.0-x86_64-linux/bin/lld"'
+          --config='target.wasm32-wasip1.rustflags=["-Clink-args=-L${{runner.temp}}/wasi-sdk-29.0-x86_64-linux/share/wasi-sysroot/lib/wasm32-wasip1", "-Clink-args=-lc++abi"]'
         env:
-          CXX: ${{runner.temp}}/wasi-sdk-28.0-x86_64-linux/bin/clang++
-          CXXFLAGS: --sysroot=${{runner.temp}}/wasi-sdk-28.0-x86_64-linux/share/wasi-sysroot
+          CXX: ${{runner.temp}}/wasi-sdk-29.0-x86_64-linux/bin/clang++
+          CXXFLAGS: --sysroot=${{runner.temp}}/wasi-sdk-29.0-x86_64-linux/share/wasi-sysroot
       - run: wasmtime target/wasm32-wasip1/release/demo.wasm
 
   emscripten:


### PR DESCRIPTION
Fixes this link error that started happening yesterday when building for wasm32-wasip1.

```console
error: linking with `/home/runner/work/_temp/wasi-sdk-27.0-x86_64-linux/bin/lld` failed: exit status: 1
  |
  = note:  "/home/runner/work/_temp/wasi-sdk-27.0-x86_64-linux/bin/lld" "-flavor" "wasm" "--export" "__main_void" "--export" "org$blobstore$cxxbridge1$194$MultiBuf$operator$alignof" "--export" "org$blobstore$cxxbridge1$194$MultiBuf$operator$sizeof" "--export" "org$blobstore$cxxbridge1$194$next_chunk" "--export" "cxxbridge1$exception" "--export" "cxxbridge1$rust_vec$bool$capacity" "--export" "cxxbridge1$rust_vec$bool$data" "--export" "cxxbridge1$rust_vec$bool$drop" "--export" "cxxbridge1$rust_vec$bool$len" "--export" "cxxbridge1$rust_vec$bool$new" "--export" "cxxbridge1$rust_vec$bool$reserve_total" "--export" "cxxbridge1$rust_vec$bool$set_len" "--export" "cxxbridge1$rust_vec$bool$truncate" "--export" "cxxbridge1$rust_vec$char$capacity" "--export" "cxxbridge1$rust_vec$char$data" "--export" "cxxbridge1$rust_vec$char$drop" "--export" "cxxbridge1$rust_vec$char$len" "--export" "cxxbridge1$rust_vec$char$new" "--export" "cxxbridge1$rust_vec$char$reserve_total" "--export" "cxxbridge1$rust_vec$char
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: lld: error: /home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-wasip1/lib/self-contained/libc.a(sbrk.c.obj): undefined symbol: __wasm_first_page_end
          lld: error: /home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-wasip1/lib/self-contained/libc.a(sbrk.c.obj): undefined symbol: __wasm_first_page_end
          lld: error: /home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-wasip1/lib/self-contained/libc.a(sbrk.c.obj): undefined symbol: __wasm_first_page_end
          lld: error: /home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-wasip1/lib/self-contained/libc.a(sbrk.c.obj): undefined symbol: __wasm_first_page_end
          lld: error: /home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-wasip1/lib/self-contained/libc.a(dlmalloc.c.obj): undefined symbol: __wasm_first_page_end
          lld: error: /home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-wasip1/lib/self-contained/libc.a(dlmalloc.c.obj): undefined symbol: __wasm_first_page_end
          lld: error: /home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-wasip1/lib/self-contained/libc.a(dlmalloc.c.obj): undefined symbol: __wasm_first_page_end
          lld: error: /home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-wasip1/lib/self-contained/libc.a(dlmalloc.c.obj): undefined symbol: __wasm_first_page_end
          lld: error: /home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-wasip1/lib/self-contained/libc.a(dlmalloc.c.obj): undefined symbol: __wasm_first_page_end
```