### PR TITLE
Switch from snap to setup-firefox action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,9 +190,10 @@ jobs:
       - name: Create demo.html for demo.js
         run: echo '<!DOCTYPE html><script src="demo.js"></script>' > target/wasm32-unknown-emscripten/release/demo.html
       - name: Install firefox
-        run: sudo snap install firefox
+        uses: browser-actions/setup-firefox@v1
+        id: setup-firefox
       - run: emrun target/wasm32-unknown-emscripten/release/demo.html
-          --browser=/snap/firefox/current/usr/lib/firefox/firefox
+          --browser=${{steps.setup-firefox.outputs.firefox-path}}
           --browser_args=-headless
           --safe_firefox_profile
           --log_stdout=${{runner.temp}}/demo.log


### PR DESCRIPTION
Since April 30 the `sudo snap install firefox` step has been failing with **"error: unable to contact snap store"**. See if this works better.