### PR TITLE
Add partial support for safe shared structs via the `#[safe_shared_extern]` attribute

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -113,7 +113,11 @@ fn write_data_structures<'a>(out: &mut OutFile<'a>, apis: &'a [Api]) {
         match api {
             Api::Struct(strct) if !structs_written.contains(&strct.name.rust) => {
                 for next in &mut toposorted_structs {
-                    if !out.types.cxx.contains(&next.name.rust) {
+                    if strct.safe_shared_extern {
+                        check_struct_strong(out, strct);
+                    } else if out.types.cxx.contains(&next.name.rust) {
+                        /* Unsafe shared extern: do not generate anything on the C++ side. */
+                    } else {
                         out.next_section();
                         let methods = methods_for_type
                             .get(&next.name.rust)
@@ -497,6 +501,64 @@ fn check_enum<'a>(out: &mut OutFile<'a>, enm: &'a Enum) {
         out.suppress_next_section();
         write_enum_operators(out, enm);
         writeln!(out, "#endif // {}", guard);
+    }
+}
+
+/// Asserts that:
+/// - All members present in the Rust struct definition are also present in the
+///   C++ definition, are public in C++, and have identical types;
+/// - The order of the members in the layout is the same as in the Rust struct;
+/// - The struct is trivial (could be relaxed for structs that don't require it);
+/// - The size of the struct is eqaul to the total size of all fields defined
+///   in Rust. This guarantees that no new fields are added on the C++ side.
+///   As a side effect, requires that the struct layout has no padding.
+fn check_struct_strong<'a>(out: &mut OutFile<'a>, strct: &'a Struct) {
+    out.set_namespace(&strct.name.namespace);
+    out.include.cstddef = true;
+    out.include.type_traits = true;
+    out.include.utility = true;
+    out.builtin.relocatable = true;
+
+    // Ensure that the type is a class/struct
+    writeln!(
+        out,
+        "static_assert(::std::is_class<{}>::value, \"expected a struct/class\");",
+        strct.name.cxx,
+    );
+
+    // Ensure that it is trivial
+    writeln!(out, "static_assert(::rust::IsRelocatable<{}>::value, \"cxx does not yet support non-trivial structs as safe shared extern\");", strct.name.cxx);
+
+    // Ensure that the struct is of expected size, i.e., sum of all fields sizes.
+    // Structs with padding are not supported, since we cannot reliably detect
+    // if new fields are added on the C++ side :(
+    write!(out, "static_assert(sizeof({}) == (0", strct.name.cxx);
+    for field in &strct.fields {
+        write!(out, ") + sizeof(");
+        write_type(out, &field.ty);
+    }
+    writeln!(out, "), \"unexpected struct size; note that structs with padding in the layout are not supported\");");
+
+    for (idx, field) in strct.fields.iter().enumerate() {
+        // Ensure that every field has the right type and is public (thus the use of `std::declval`)
+        write!(out, "static_assert(::std::is_same<");
+        write_type(out, &field.ty);
+        writeln!(
+            out,
+            ", decltype(std::declval<{}>().{})>::value, \"wrong field type\");",
+            strct.name.cxx, field.name.cxx
+        );
+
+        // Ensure that the order is correct
+        if idx > 0 {
+            writeln!(
+                out,
+                "static_assert(offsetof({strct}, {field0}) < offsetof({strct}, {field1}), \"wrong fields order\");",
+                strct = strct.name.cxx,
+                field0 = strct.fields[idx - 1].name.cxx,
+                field1 = field.name.cxx,
+            );
+        }
     }
 }
 

--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -78,7 +78,13 @@ fn write_forward_declarations(out: &mut OutFile, apis: &[Api]) {
         for api in apis {
             write!(out, "{:1$}", "", indent);
             match api {
-                Api::Struct(strct) => write_struct_decl(out, &strct.name),
+                Api::Struct(strct) => {
+                    if strct.safe_shared_extern {
+                        write_struct_using(out, &strct.name);
+                    } else {
+                        write_struct_decl(out, &strct.name)
+                    }
+                }
                 Api::Enum(enm) => write_enum_decl(out, enm),
                 Api::CxxType(ety) => write_struct_using(out, &ety.name),
                 Api::RustType(ety) => write_struct_decl(out, &ety.name),

--- a/syntax/attrs.rs
+++ b/syntax/attrs.rs
@@ -36,6 +36,7 @@ pub(crate) struct Parser<'a> {
     pub cxx_name: Option<&'a mut Option<ForeignName>>,
     pub rust_name: Option<&'a mut Option<Ident>>,
     pub self_type: Option<&'a mut Option<Ident>>,
+    pub safe_shared_extern: Option<&'a mut bool>,
     pub ignore_unrecognized: bool,
 
     // Suppress clippy needless_update lint ("struct update has no effect, all
@@ -192,6 +193,20 @@ pub(crate) fn parse(cx: &mut Errors, attrs: Vec<Attribute>, mut parser: Parser) 
                 other_attrs.lint.push(attr);
                 continue;
             }
+        } else if attr_path.is_ident("safe_shared_extern") {
+            // Only effective for an extern struct.
+            // Causes `cxx` to generate assertions that ensure correctnes of the defined type,
+            // but only supports structs without padding in the layout.
+            if let Some(safe_shared_extern) = &mut parser.safe_shared_extern {
+                **safe_shared_extern = true;
+            } else {
+                cx.error(
+                    attr,
+                    "unexpected #[safe_shared_extern]: it is only effective for structs",
+                );
+                break;
+            }
+            continue;
         }
         if !parser.ignore_unrecognized {
             cx.error(attr, "unsupported attribute");

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -341,8 +341,13 @@ fn check_api_struct(cx: &mut Check, strct: &Struct) {
 
     if cx.types.cxx.contains(&name.rust) {
         if let Some(ety) = cx.types.untrusted.get(&name.rust) {
-            let msg = "extern shared struct must be declared in an `unsafe extern` block";
-            cx.error(ety, msg);
+            if strct.safe_shared_extern {
+                let msg = "a `#[safe_shared_extern]` struct does not need a `type` entry in the `extern \"C++\"` block";
+                cx.error(ety, msg);
+            } else {
+                let msg = "extern shared struct must be declared in an `unsafe extern` block or marked with `#[safe_shared_extern]`";
+                cx.error(ety, msg);
+            }
         }
     }
 

--- a/syntax/mod.rs
+++ b/syntax/mod.rs
@@ -119,6 +119,7 @@ pub(crate) struct Struct {
     pub generics: Lifetimes,
     pub brace_token: Brace,
     pub fields: Vec<Var>,
+    pub safe_shared_extern: bool,
 }
 
 pub(crate) struct Enum {

--- a/syntax/parse.rs
+++ b/syntax/parse.rs
@@ -64,6 +64,7 @@ fn parse_struct(cx: &mut Errors, mut item: ItemStruct, namespace: &Namespace) ->
     let mut namespace = namespace.clone();
     let mut cxx_name = None;
     let mut rust_name = None;
+    let mut safe_shared_extern = false;
     let attrs = attrs::parse(
         cx,
         mem::take(&mut item.attrs),
@@ -75,6 +76,7 @@ fn parse_struct(cx: &mut Errors, mut item: ItemStruct, namespace: &Namespace) ->
             namespace: Some(&mut namespace),
             cxx_name: Some(&mut cxx_name),
             rust_name: Some(&mut rust_name),
+            safe_shared_extern: Some(&mut safe_shared_extern),
             ..Default::default()
         },
     );
@@ -197,6 +199,7 @@ fn parse_struct(cx: &mut Errors, mut item: ItemStruct, namespace: &Namespace) ->
         generics,
         brace_token,
         fields,
+        safe_shared_extern,
     }))
 }
 

--- a/tests/cpp_compile/mod.rs
+++ b/tests/cpp_compile/mod.rs
@@ -135,7 +135,7 @@ impl CompilationResult {
         panic!("{msg}");
     }
 
-    fn error_lines(&self) -> Vec<String> {
+    pub fn error_lines(&self) -> Vec<String> {
         assert!(!self.0.status.success());
 
         // MSVC reports errors to stdout rather than stderr, so consider both.

--- a/tests/cpp_ui_tests.rs
+++ b/tests/cpp_ui_tests.rs
@@ -1,28 +1,285 @@
 mod cpp_compile;
 
 use indoc::indoc;
+use proc_macro2::TokenStream;
 use quote::quote;
+
+use cpp_compile::CompilationResult;
+
+#[must_use]
+fn compile_test(rust_code: TokenStream, include_h: &str) -> CompilationResult {
+    let test = cpp_compile::Test::new(rust_code);
+    test.write_file("include.h", include_h);
+    test.compile()
+}
 
 /// This is a regression test for `static_assert(::rust::is_complete...)`
 /// which we started to emit in <https://github.com/dtolnay/cxx/commit/534627667>
 #[test]
 fn test_unique_ptr_of_incomplete_foward_declared_pointee() {
-    let test = cpp_compile::Test::new(quote! {
-        #[cxx::bridge]
-        mod ffi {
-            unsafe extern "C++" {
-                include!("include.h");
-                type ForwardDeclaredType;
+    let compiled = compile_test(
+        quote! {
+            #[cxx::bridge]
+            mod ffi {
+                unsafe extern "C++" {
+                    include!("include.h");
+                    type ForwardDeclaredType;
+                }
+                impl UniquePtr<ForwardDeclaredType> {}
             }
-            impl UniquePtr<ForwardDeclaredType> {}
-        }
-    });
-    test.write_file(
-        "include.h",
+        },
         indoc! {"
             class ForwardDeclaredType;
         "},
     );
-    let err_msg = test.compile().expect_single_error();
-    assert!(err_msg.contains("definition of `::ForwardDeclaredType` is required"));
+    assert!(compiled
+        .expect_single_error()
+        .contains("definition of `::ForwardDeclaredType` is required"))
+}
+
+#[test]
+fn test_safe_shared_extern_with_wrong_field_type() {
+    // Type mismatch in one of the struct fields
+    let compiled = compile_test(
+        quote! {
+            #[cxx::bridge]
+            mod ffi {
+                #[safe_shared_extern]
+                struct A {
+                    a: u8,
+                }
+
+                extern "C++" {
+                    include!("include.h");
+                }
+            }
+        },
+        indoc! {"
+            struct A {
+                signed char a;
+            };
+        "},
+    );
+    assert!(compiled.expect_single_error().contains("wrong field type"));
+}
+
+#[test]
+fn test_safe_shared_extern_with_missing_field_cpp() {
+    // Missing field in C++
+    let compiled = compile_test(
+        quote! {
+            #[cxx::bridge]
+            mod ffi {
+                #[safe_shared_extern]
+                struct A {
+                    a: u8,
+                    b: u8,
+                }
+
+                extern "C++" {
+                    include!("include.h");
+                }
+            }
+        },
+        indoc! {"
+            struct A {
+                unsigned char b;
+            };
+        "},
+    );
+    // The error messages vary depending on the compiler
+    assert!(!compiled.error_lines().is_empty());
+}
+
+#[test]
+fn test_safe_shared_extern_with_missing_field_rust() {
+    // Missing field in Rust, resulting in different structure size
+    let compiled = compile_test(
+        quote! {
+            #[cxx::bridge]
+            mod ffi {
+                #[safe_shared_extern]
+                struct A {
+                    a: i32,
+                }
+
+                extern "C++" {
+                    include!("include.h");
+                }
+            }
+        },
+        indoc! {"
+            #include <cstdint>
+
+            struct A {
+                int32_t a;
+                int32_t b;
+            };
+        "},
+    );
+    assert!(compiled.expect_single_error().contains(
+        "unexpected struct size; note that structs with padding in the layout are not supported"
+    ));
+
+    // Missing field in Rust, which fits in the padding, so the structure size is the same.
+    // Since we cannot reliably detect this, we just refuse any struct with padding.
+    let compiled = compile_test(
+        quote! {
+            #[cxx::bridge]
+            mod ffi {
+                #[safe_shared_extern]
+                struct A {
+                    a: u8,
+                    c: i16,
+                }
+
+                extern "C++" {
+                    include!("include.h");
+                }
+            }
+        },
+        indoc! {"
+            #include <cstdint>
+
+            struct A {
+                unsigned char a;
+                unsigned char b;
+                int16_t c;
+            };
+        "},
+    );
+    assert!(compiled.expect_single_error().contains(
+        "unexpected struct size; note that structs with padding in the layout are not supported"
+    ));
+}
+
+#[test]
+fn test_safe_shared_extern_with_wrong_field_order() {
+    // Fields appear in a wrong order
+    let compiled = compile_test(
+        quote! {
+            #[cxx::bridge]
+            mod ffi {
+                #[safe_shared_extern]
+                struct A {
+                    b: u8,
+                    a: u8,
+                }
+
+                extern "C++" {
+                    include!("include.h");
+                }
+            }
+        },
+        indoc! {"
+            struct A {
+                unsigned char a;
+                unsigned char b;
+            };
+        "},
+    );
+    assert!(compiled
+        .expect_single_error()
+        .contains("wrong fields order"));
+}
+
+#[test]
+fn test_safe_shared_extern_with_wrong_field_visibility() {
+    // A field is declared private on the C++ side
+    let compiled = compile_test(
+        quote! {
+            #[cxx::bridge]
+            mod ffi {
+                #[safe_shared_extern]
+                struct A {
+                    a: u8,
+                }
+
+                extern "C++" {
+                    include!("include.h");
+                }
+            }
+        },
+        indoc! {"
+            struct A {
+            private:
+                unsigned char a;
+            };
+        "},
+    );
+    // The exact message varies from compiler to compiler
+    let err_msg = compiled.error_lines().join("\n");
+    assert!(
+        err_msg.contains("is private")
+            || err_msg.contains("is a private member")
+            || err_msg.contains("cannot access private member")
+    );
+}
+
+#[test]
+fn test_safe_shared_extern_with_errorneously_nontrivial_struct() {
+    let compiled = compile_test(
+        quote! {
+            #[cxx::bridge]
+            mod ffi {
+                #[safe_shared_extern]
+                struct A {
+                    a: u8,
+                }
+
+                extern "C++" {
+                    include!("include.h");
+
+                    // `A` must be POD because it is used as a return value.
+                    unsafe fn a() -> A;
+                }
+            }
+        },
+        indoc! {"
+            struct A {
+                unsigned char a;
+                ~A() {}
+            };
+
+            A a();
+        "},
+    );
+    assert!(compiled
+        .expect_single_error()
+        .contains("cxx does not yet support non-trivial structs as safe shared extern"));
+}
+
+/// Despite the fact that the C++ struct is non-trivial (has a destructor),
+/// since it is never used as a return value or a by-value parameter, we
+/// can support it as a `#[safe_shared_extern]`.
+///
+/// However, this is not implemented yet: we currently unconditionally reject
+/// any non-trivial structs.
+#[test]
+#[ignore = "non-trivial shared structs are currently rejected unconditionally; not implemented yet"]
+fn test_safe_shared_extern_with_nontrivial_struct() {
+    let compiled = compile_test(
+        quote! {
+            #[cxx::bridge]
+            mod ffi {
+                #[safe_shared_extern]
+                struct A {
+                    a: u8,
+                }
+
+                extern "C++" {
+                    include!("include.h");
+                }
+            }
+        },
+        indoc! {"
+            struct A {
+                unsigned char a;
+                ~A() {}
+            };
+
+            A a();
+        "},
+    );
+    compiled.assert_success();
 }

--- a/tests/cpp_ui_tests.rs
+++ b/tests/cpp_ui_tests.rs
@@ -283,3 +283,32 @@ fn test_safe_shared_extern_with_nontrivial_struct() {
     );
     compiled.assert_success();
 }
+
+#[test]
+fn test_safe_shared_extern_with_typedefed() {
+    let compiled = compile_test(
+        quote! {
+            #[cxx::bridge]
+            mod ffi {
+                #[safe_shared_extern]
+                struct A {
+                    a: u8,
+                }
+
+                extern "C++" {
+                    include!("include.h");
+
+                    unsafe fn a() -> A;
+                }
+            }
+        },
+        indoc! {"
+            typedef struct {
+                unsigned char a;
+            } A;
+
+            A a();
+        "},
+    );
+    compiled.assert_success();
+}

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -363,6 +363,13 @@ pub mod ffi {
         fn c_member_function_on_rust_type(self: &R);
     }
 
+    #[safe_shared_extern]
+    struct SafeSharedStruct {
+        a: u8,
+        b: [i8; 3],
+        c: i16,
+    }
+
     struct Dag0 {
         i: i32,
     }

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -105,6 +105,12 @@ struct Borrow {
 
 typedef char Buffer[12];
 
+struct SafeSharedStruct {
+  unsigned char a;
+  std::array<signed char, 3> b;
+  int16_t c;
+};
+
 size_t c_return_primitive();
 Shared c_return_shared();
 ::A::AShared c_return_ns_shared();


### PR DESCRIPTION
Adds the `safe_shared_extern` attribute.
    
The new attribute allows to define a shared struct that is automatically verified for compatibility with the struct defined in C++.
    
This only works for structs that have no padding in their layout. This also currently requires that the C++ struct is trivial, though this requirement may be relaxed.
    
The syntax is as follows:
```rust
mod ffi {
    #[safe_shared_extern]
    struct S {
        pub a: i32,
        pub b: i32,
    }

    extern "C++" {
        include!("include.hpp");

        // Note: no need to include `type S;` (the legacy unsafe syntax)
        unsafe fn f() -> S;
    }
}
```

Partially addresses #871.