### PR TITLE
Support pointers to void: `*const ()`, `*mut ()`

### DIFF
--- a/gen/src/write.rs
+++ b/gen/src/write.rs
@@ -1498,7 +1498,7 @@ fn write_type_to_generic_writer(out: &mut impl InfallibleWrite, ty: &Type, types
             write_type_to_generic_writer(out, &a.inner, types);
             write!(out, ", {}>", a.len);
         }
-        Type::Void(_) => unreachable!(),
+        Type::Void(_) => write!(out, "void"),
     }
 }
 
@@ -1544,9 +1544,9 @@ fn write_space_after_type(out: &mut impl InfallibleWrite, ty: &Type) {
         | Type::RustVec(_)
         | Type::SliceRef(_)
         | Type::Fn(_)
-        | Type::Array(_) => write!(out, " "),
+        | Type::Array(_)
+        | Type::Void(_) => write!(out, " "),
         Type::Ref(_) | Type::Ptr(_) => {}
-        Type::Void(_) => unreachable!(),
     }
 }
 

--- a/syntax/check.rs
+++ b/syntax/check.rs
@@ -269,7 +269,7 @@ fn check_type_ref(cx: &mut Check, ty: &Ref) {
 
 fn check_type_ptr(cx: &mut Check, ty: &Ptr) {
     match ty.inner {
-        Type::Fn(_) | Type::Void(_) => {}
+        Type::Fn(_) => {}
         Type::Ref(_) => {
             cx.error(ty, "C++ does not allow pointer to reference as a type");
             return;

--- a/tests/ffi/lib.rs
+++ b/tests/ffi/lib.rs
@@ -109,6 +109,10 @@ pub mod ffi {
         s: &'a str,
     }
 
+    struct WithVoidPtr {
+        ptr: *mut (),
+    }
+
     unsafe extern "C++" {
         type C;
 
@@ -194,6 +198,7 @@ pub mod ffi {
         fn c_take_rust_vec_nested_ns_shared(v: Vec<ABShared>);
         unsafe fn c_take_const_ptr(c: *const C) -> usize;
         unsafe fn c_take_mut_ptr(c: *mut C) -> usize;
+        unsafe fn c_take_void_ptrs(a: WithVoidPtr, b: *mut (), c: *const ());
 
         fn c_try_return_void() -> Result<()>;
         fn c_try_return_primitive() -> Result<usize>;

--- a/tests/ffi/tests.cc
+++ b/tests/ffi/tests.cc
@@ -567,6 +567,12 @@ size_t c_take_mut_ptr(C *c) {
   return result;
 }
 
+void c_take_void_ptrs(WithVoidPtr a, void *b, const void *c) {
+  (void)a;
+  (void)b;
+  (void)c;
+}
+
 void c_try_return_void() {}
 
 size_t c_try_return_primitive() { return 2020; }

--- a/tests/ffi/tests.h
+++ b/tests/ffi/tests.h
@@ -192,6 +192,8 @@ void c_take_ns_enum(::A::AEnum e);
 void c_take_nested_ns_enum(::A::B::ABEnum e);
 size_t c_take_const_ptr(const C *c);
 size_t c_take_mut_ptr(C *c);
+struct WithVoidPtr;
+void c_take_void_ptrs(WithVoidPtr a, void *b, const void *c);
 
 void c_try_return_void();
 size_t c_try_return_primitive();


### PR DESCRIPTION
Add support for functions and structs involving `void *` types. On the rust side they correspond to `*mut ()` or `*const ()`.

I'm not sure if everything here fits right with the rest of cxx or if something might break.. All tests pass, though.

Resolves #1049.

Already after I implemented it, I noticed there already is another patch for this functionality (#1204), which implements it by adding an atom. As a user, I would be fine with either option.