### PR TITLE
Allow deferring the compilation of cxx.cc until the bridge gen stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,8 @@ jobs:
           CXX: ${{runner.temp}}/wasi-sdk-33.0-x86_64-linux/bin/clang++
           CXXFLAGS: --sysroot=${{runner.temp}}/wasi-sdk-33.0-x86_64-linux/share/wasi-sysroot
       - run: wasmtime --wasm=exceptions target/wasm32-wasip1/release/demo.wasm
+      # Ensure that `cxx` can compile for wasm32-wasip1 without wasi-sdk, supporting projects that only provide wasi-sdk at the bridge generation stage
+      - run: cargo build --target=wasm32-wasip1
 
   emscripten:
     name: Emscripten

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,8 +167,16 @@ jobs:
           CXX: ${{runner.temp}}/wasi-sdk-33.0-x86_64-linux/bin/clang++
           CXXFLAGS: --sysroot=${{runner.temp}}/wasi-sdk-33.0-x86_64-linux/share/wasi-sysroot
       - run: wasmtime --wasm=exceptions target/wasm32-wasip1/release/demo.wasm
-      # Ensure that `cxx` can compile for wasm32-wasip1 without wasi-sdk, supporting projects that only provide wasi-sdk at the bridge generation stage
-      - run: cargo build --target=wasm32-wasip1
+      # Verify that `cxx` can compile for wasm32-wasip1 without wasi-sdk, supporting projects that only provide wasi-sdk at the bridge generation stage
+      - run: cargo build --target=wasm32-wasip1 --features compile-builtins-at-bridge-stage
+      # Test that the final binary is compiled correctly with builtins compiled at the bridge stage
+      - run: cargo build --target=wasm32-wasip1 --manifest-path=demo/Cargo.toml --release --features cxx/compile-builtins-at-bridge-stage
+          --config='target.wasm32-wasip1.linker="${{runner.temp}}/wasi-sdk-33.0-x86_64-linux/bin/lld"'
+          --config='target.wasm32-wasip1.rustflags=["-Clink-args=-L${{runner.temp}}/wasi-sdk-33.0-x86_64-linux/share/wasi-sysroot/lib/wasm32-wasip1/eh", "-Clink-args=-lc++abi", "-Clink-args=-lunwind"]'
+        env:
+          CXX: ${{runner.temp}}/wasi-sdk-33.0-x86_64-linux/bin/clang++
+          CXXFLAGS: --sysroot=${{runner.temp}}/wasi-sdk-33.0-x86_64-linux/share/wasi-sysroot
+      - run: wasmtime --wasm=exceptions target/wasm32-wasip1/release/demo.wasm
 
   emscripten:
     name: Emscripten
@@ -317,7 +325,7 @@ jobs:
       - name: Install clang-tidy
         run: sudo apt-get update && sudo apt-get install clang-tidy-20
       - name: Run clang-tidy
-        run: clang-tidy-20 src/cxx.cc --warnings-as-errors=*
+        run: clang-tidy-20 cxx-cc/src/cxx.cc --warnings-as-errors=* -- -Iinclude
 
   eslint:
     name: ESLint

--- a/BUCK
+++ b/BUCK
@@ -52,7 +52,8 @@ rust_binary(
 
 cxx_library(
     name = "core",
-    srcs = ["src/cxx.cc"],
+    srcs = ["cxx-cc/src/cxx.cc"],
+    include_directories = ["include/"],
     exported_headers = {
         "cxx.h": "include/cxx.h",
     },
@@ -90,6 +91,7 @@ rust_library(
     ],
     doctests = False,
     edition = "2021",
+    rustc_flags = ["--cfg", "non_cargo_build"],
     env = {
         "CARGO_PKG_VERSION_PATCH": CARGO_PKG_VERSION_PATCH,
     },

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -52,8 +52,9 @@ cc_library(
 
 cc_library(
     name = "core-lib",
-    srcs = ["src/cxx.cc"],
+    srcs = ["cxx-cc/src/cxx.cc"],
     hdrs = ["include/cxx.h"],
+    includes = ["include/"],
     linkstatic = True,
 )
 
@@ -78,6 +79,7 @@ rust_library(
     srcs = glob(["gen/build/src/**/*.rs"]),
     compile_data = glob(["gen/build/src/gen/**/*.h"]),
     edition = "2021",
+    rustc_flags = ["--cfg", "non_cargo_build"],
     version = module_version(),
     deps = [
         "@crates.io//:cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,12 @@ repository = "https://github.com/dtolnay/cxx"
 rust-version = "1.85"
 
 [features]
-default = ["std", "cxxbridge-flags/default"] # c++11
-"c++14" = ["cxxbridge-flags/c++14"]
-"c++17" = ["cxxbridge-flags/c++17"]
-"c++20" = ["cxxbridge-flags/c++20"]
+default = ["std", "cxx-cc/default"] # c++11
+"c++14" = ["cxx-cc/c++14"]
+"c++17" = ["cxx-cc/c++17"]
+"c++20" = ["cxx-cc/c++20"]
+# Defers compilation of `cxx.cc` until the bridge generation stage
+compile-builtins-at-bridge-stage = ["cxx-cc/compile-at-bridge-stage"]
 alloc = []
 std = ["alloc", "foldhash/std"]
 
@@ -28,8 +30,7 @@ foldhash = { version = "0.2", default-features = false }
 link-cplusplus = "1.0.11"
 
 [build-dependencies]
-cc = "1.0.101"
-cxxbridge-flags = { version = "=1.0.194", path = "flags", default-features = false }
+cxx-cc = { version = "=1.0.194", path = "cxx-cc", default-features = false }
 
 [dev-dependencies]
 cc = "1.0.101"
@@ -51,7 +52,7 @@ cxx-build = { version = "=1.0.194", path = "gen/build" }
 cxxbridge-cmd = { version = "=1.0.194", path = "gen/cmd" }
 
 [workspace]
-members = ["demo", "flags", "gen/build", "gen/cmd", "gen/lib", "macro", "tests/ffi"]
+members = ["cxx-cc", "demo", "flags", "gen/build", "gen/cmd", "gen/lib", "macro", "tests/ffi"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/build.rs
+++ b/build.rs
@@ -1,27 +1,18 @@
-#![expect(unexpected_cfgs)]
-
 use std::env;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Command;
 
 fn main() {
     let manifest_dir_opt = env::var_os("CARGO_MANIFEST_DIR").map(PathBuf::from);
-    let manifest_dir = manifest_dir_opt.as_deref().unwrap_or(Path::new(""));
 
-    cc::Build::new()
-        .file(manifest_dir.join("src/cxx.cc"))
-        .cpp(true)
-        .cpp_link_stdlib(None) // linked via link-cplusplus crate
-        .std(cxxbridge_flags::STD)
-        .warnings_into_errors(cfg!(deny_warnings))
-        .compile("cxxbridge1");
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR shall be set by cargo"));
+    cxx_cc::build_cxxcc_if_cc_stage(&PathBuf::from(&out_dir)).expect("failed to compile cxx.cc");
 
-    println!("cargo:rerun-if-changed=src/cxx.cc");
     println!("cargo:rerun-if-changed=include/cxx.h");
     println!("cargo:rustc-cfg=built_with_cargo");
 
     if let Some(manifest_dir) = &manifest_dir_opt {
-        let cxx_h = manifest_dir.join("include").join("cxx.h");
+        let cxx_h = manifest_dir.join("include/cxx.h");
         println!("cargo:HEADER={}", cxx_h.to_string_lossy());
     }
 

--- a/cxx-cc/Cargo.toml
+++ b/cxx-cc/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "cxx-cc"
+version = "1.0.194"
+authors = ["Nikolai Nechaev <nikolay_nechaev@mail.ru>"]
+description = "An implementation detail of the `cxx` crate"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/dtolnay/cxx"
+rust-version = "1.85"
+
+[features]
+default = ["cxxbridge-flags/default"] # c++11
+"c++14" = ["cxxbridge-flags/c++14"]
+"c++17" = ["cxxbridge-flags/c++17"]
+"c++20" = ["cxxbridge-flags/c++20"]
+
+# By default, cxx.cc is compiled when `cxx` is built.
+# But if `compile-at-bridge-stage` is enabled, cxx.cc is
+# instead compiled when a bridge is being compiled.
+compile-at-bridge-stage = []
+
+[dependencies]
+cc = "1.0.101"
+cxxbridge-flags = { version = "=1.0.194", path = "../flags", default-features = false }

--- a/cxx-cc/src/cxx.cc
+++ b/cxx-cc/src/cxx.cc
@@ -1,4 +1,4 @@
-#include "../include/cxx.h"
+#include "cxx.h"
 #include <cstdio>
 #include <cstring>
 #include <iostream>

--- a/cxx-cc/src/lib.rs
+++ b/cxx-cc/src/lib.rs
@@ -1,0 +1,47 @@
+#![expect(unexpected_cfgs)]
+
+use std::io::Result;
+use std::path::Path;
+
+const CXX_H: &[u8] = include_bytes!("../../include/cxx.h");
+const CXX_CC: &[u8] = include_bytes!("cxx.cc");
+
+fn build_cxxcc(dir: &Path) -> Result<()> {
+    std::fs::write(dir.join("cxx.h"), CXX_H)?;
+    let cxx_cc_path = dir.join("cxx.cc");
+    std::fs::write(&cxx_cc_path, CXX_CC)?;
+    cc::Build::new()
+        .file(&cxx_cc_path)
+        .cpp(true)
+        .cpp_link_stdlib(None) // linked via link-cplusplus crate
+        .std(cxxbridge_flags::STD)
+        .warnings_into_errors(cfg!(deny_warnings))
+        .compile("cxxbridge1");
+    Ok(())
+}
+
+/// If the `compile-at-bridge-stage` feature is enabled, does nothing.
+/// Otherwise, builds `cxx.cc`.
+///
+/// # Errors
+/// Filesystem errors while preparing the compilation.
+pub fn build_cxxcc_if_cc_stage(dir: &Path) -> Result<()> {
+    if cfg!(feature = "compile-at-bridge-stage") {
+        Ok(())
+    } else {
+        build_cxxcc(dir)
+    }
+}
+
+/// If the `compile-at-bridge-stage` feature is enabled, builds `cxx.cc`.
+/// Otherwise, does nothing.
+///
+/// # Errors
+/// Filesystem errors while preparing the compilation.
+pub fn build_cxxcc_if_bridge_stage(dir: &Path) -> Result<()> {
+    if cfg!(feature = "compile-at-bridge-stage") {
+        build_cxxcc(dir)
+    } else {
+        Ok(())
+    }
+}

--- a/gen/build/Cargo.toml
+++ b/gen/build/Cargo.toml
@@ -25,6 +25,9 @@ quote = { version = "1.0.35", default-features = false }
 scratch = "1.0.5"
 syn = { version = "2.0.46", default-features = false, features = ["clone-impls", "full", "parsing", "printing"] }
 
+[target.'cfg(not(non_cargo_build))'.dependencies]
+cxx-cc = { version = "=1.0.194", path = "../../cxx-cc", default-features = false }
+
 [dev-dependencies]
 cxx = { version = "1.0", path = "../.." }
 cxx-gen = { version = "0.7", path = "../lib" }

--- a/gen/build/src/lib.rs
+++ b/gen/build/src/lib.rs
@@ -77,7 +77,7 @@
     clippy::uninlined_format_args,
     clippy::upper_case_acronyms
 )]
-#![allow(unknown_lints, mismatched_lifetime_syntaxes)]
+#![allow(unknown_lints, mismatched_lifetime_syntaxes, unexpected_cfgs)]
 
 mod cargo;
 mod cfg;
@@ -213,6 +213,11 @@ fn build(rust_source_files: &mut dyn Iterator<Item = impl AsRef<Path>>) -> Resul
     let ref prj = Project::init()?;
     validate_cfg(prj)?;
     let this_crate = make_this_crate(prj)?;
+
+    // Note: if built with a build system other than cargo, cxx.cc is linked in separately
+    // TODO: return, not panic
+    #[cfg(not(non_cargo_build))]
+    cxx_cc::build_cxxcc_if_bridge_stage(&prj.out_dir).expect("failed to compile cxx.cc");
 
     let mut build = Build::new();
     build.cpp(true);


### PR DESCRIPTION
Add the `compile-builtins-at-bridge-stage` feature that allows to defer compilation of `cxx.cc`: it will not be build when `cxx` is compiled but when a bridge is compiled.

Notes:

1.  `cargo test --features compile-builtins-at-bridge-stage` won't work: some tests run without generating any bridges and they expected builtins to be linked. `cargo test` works as usual.

2.  Even when two different crates generate bridges with `cxx`, and `compile-builtins-at-bridge-stage` is used, it does not cause a linking error. But it's not obvious why: I can see that in this case two separate `libcxxbridge1.a` files are generated in my target directory. This should probably be investigated further, and we might want a test for that.

Fixes #1710.