### PR TITLE
Add Meson-based build system

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -1,0 +1,29 @@
+name: Meson
+
+on:
+  push:
+  workflow_dispatch:
+  schedule: [cron: "40 1 * * *"]
+
+permissions:
+  contents: read
+
+jobs:
+  meson:
+    name: Meson on ${{matrix.os == 'ubuntu' && 'Linux' || matrix.os == 'macos' && 'macOS' || matrix.os == 'windows' && 'Windows' || '???'}}
+    runs-on: ${{matrix.os}}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, macos, windows]
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rust-src
+      - run: pip install meson ninja
+      - run: cargo metadata > /dev/null
+      - run: meson setup +build
+      - run: ninja -C+build
+      - run: ninja -C+build test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,12 @@ cxxbridge-cmd = { version = "=1.0.194", path = "gen/cmd" }
 [workspace]
 members = ["demo", "flags", "gen/build", "gen/cmd", "gen/lib", "macro", "tests/ffi"]
 
+[lints.rust.unexpected_cfgs]
+level = "deny"
+check-cfg = ['cfg(built_with_cargo)', 'cfg(compile_error_if_alloc)',
+             'cfg(compile_error_if_std)', 'cfg(cxx_experimental_no_alloc)',
+             'cfg(skip_ui_tests)']
+
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 rustdoc-args = [

--- a/build.rs
+++ b/build.rs
@@ -25,11 +25,6 @@ fn main() {
         println!("cargo:HEADER={}", cxx_h.to_string_lossy());
     }
 
-    println!("cargo:rustc-check-cfg=cfg(built_with_cargo)");
-    println!("cargo:rustc-check-cfg=cfg(compile_error_if_alloc)");
-    println!("cargo:rustc-check-cfg=cfg(compile_error_if_std)");
-    println!("cargo:rustc-check-cfg=cfg(cxx_experimental_no_alloc)");
-    println!("cargo:rustc-check-cfg=cfg(skip_ui_tests)");
 
     if let Some(rustc) = rustc_version() {
         if rustc.minor < 85 {

--- a/demo/meson.build
+++ b/demo/meson.build
@@ -1,0 +1,16 @@
+# This preserve_path_from is because src/blobstore.cc includes
+# "demo/src/main.rs.h".  A Meson-native project probably would use
+# current_source_dir(), or nothing at all (i.e. #include "main.rs.h").
+bridge_cc = cxxbridge_gen_cc.process('src/main.rs',
+  preserve_path_from: meson.project_source_root())
+bridge_h = cxxbridge_gen_h.process('src/main.rs',
+  preserve_path_from: meson.project_source_root())
+
+demo_cxx = static_library(
+  'cxxbridge-demo',
+  'src/blobstore.cc', bridge_cc, bridge_h, cxx_h,
+  include_directories: [incdir])
+
+pkg_demo = cargo.package('demo')
+demo = pkg_demo.executable(link_with: demo_cxx)
+test('demo', demo)

--- a/gen/cmd/meson.build
+++ b/gen/cmd/meson.build
@@ -1,0 +1,7 @@
+# FIXME: This should have "native: true", but because Meson does
+# not know that this is in build-dependencies, it also does not
+# know that its dependencies must be `native: true`.  This means
+# that cross compilation needs an emulator (e.g. QEMU or Wine)
+# to run cxxbridge-cmd.
+pkg_cmd = cargo.package('cxxbridge-cmd')
+cxxbridge_cmd = pkg_cmd.executable()

--- a/macro/meson.build
+++ b/macro/meson.build
@@ -1,0 +1,3 @@
+pkg_macro = cargo.package('cxxbridge-macro')
+macro = pkg_macro.proc_macro()
+pkg_macro.override_dependency(declare_dependency(link_with: macro))

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,47 @@
+project('cxx', ['cpp', 'rust'], version: '1.0.194',
+        meson_version: '>=1.12.0',
+        default_options: ['cpp_std=gnu++20,c++20'])
+
+# Ask user to generate Cargo.lock
+fs = import('fs')
+if not fs.exists(meson.project_source_root() / 'Cargo.lock')
+  error('Cargo.lock missing, please run "cargo metadata > /dev/null" to generate it.')
+endif
+
+# Globals
+incdir = include_directories('.')
+rustc = meson.get_compiler('rust')
+rust = import('rust')
+cargo = rust.workspace(extra_members: ['gen/cmd', 'demo'])
+pkg_cxx = cargo.package()
+
+# Environment checks
+if rustc.version().version_compare('<1.85.0')
+  warning('The cxx crate requires a rustc version 1.85.0 or newer.')
+  warning('You appear to be building with: ' + rustc.version())
+endif
+assert(meson.project_version() == pkg_cxx.version())
+
+# Build rules
+subdir('macro')
+
+core = static_library('cxxbridge', 'src/cxx.cc')
+cxx = pkg_cxx.library(link_with: core)
+pkg_cxx.override_dependency(declare_dependency(link_with: cxx))
+
+subdir('gen/cmd')
+
+cxxbridge_gen_cc = generator(
+  cxxbridge_cmd, arguments: ['@INPUT@', '--header'],
+  output: '@PLAINNAME@.h', capture: true)
+cxxbridge_gen_h = generator(
+  cxxbridge_cmd, arguments: ['@INPUT@'],
+  output: '@PLAINNAME@.cc', capture: true)
+
+cxx_h = custom_target('cxx.h',
+  output: 'cxx.h',
+  build_subdir: 'rust',
+  capture: true,
+  command: [cxxbridge_cmd, '--header'])
+
+subdir('demo')

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,0 +1,2 @@
+/*
+!/packagefiles

--- a/subprojects/packagefiles/proc-macro2-1-rs/meson/meson.build
+++ b/subprojects/packagefiles/proc-macro2-1-rs/meson/meson.build
@@ -1,0 +1,5 @@
+rustc = meson.get_compiler('rust').version()
+extra_args = [ '--cfg', 'wrap_proc_macro' ]
+if 'span-locations' in features
+  extra_args += [ '--cfg', 'span_locations' ]
+endif


### PR DESCRIPTION
Meson 1.12.0 will have enough Cargo support to build `cxx` without having to write build rules for all dependent crates, and with only a couple lines for each crate that is part of cxx.

There *are* a few remaining snags:
* Meson requires a Cargo.lock file, but `cxx` does not have one. For this reason it is necessary to run `cargo metadata > /dev/null` or something like that beforehand
* For now, nightly Rust is needed to support `--env-set`. This is planned to go away before the release.
* Cross compilation does not work yet. While version 1.12.0 supports cross compilation for procedural macro crates, it does not know that `cxxbridge-cmd` is a build-machine tool because it does not look at `build-dependencies` yet. This is high on the todo list (mesonbuild/meson#15944).
* A minimal translation of proc-macro2's build.rs is needed in order to build it with `cfg(span_locations)` (as opposed to `cfg(feature = "span_locations")` which would be handled automatically). The Meson project will probably end up distributing these bridges later on.

Of these four, only the first is somewhat by design.

The draft status is because the new CI job is untested (due to the release not existing yet) and because the above issues might be too much to merge. 

I understand if this can be a maintainability hassle, though at 70-ish lines of code it's at least better than either Buck or Bazel. 🫣

If you are interested, I will follow up after the release. If you are not interested *yet*, I will update as the above issues are tackled. If you are not interested *at all*, just close. :)

Build log:

```
ninja: Entering directory `build'
[1/29] Compiling Rust source ../subprojects/unicode-ident-1.0.24/src/lib.rs
[2/29] Compiling Rust source ../subprojects/anstyle-1.0.14/src/lib.rs
[3/29] Compiling Rust source ../subprojects/clap_lex-1.1.0/src/lib.rs
[4/29] Compiling Rust source ../subprojects/strsim-0.11.1/src/lib.rs
[5/29] Compiling Rust source ../subprojects/equivalent-1.0.2/src/lib.rs
[6/29] Compiling Rust source ../subprojects/hashbrown-0.17.1/src/lib.rs
[7/29] Compiling Rust source ../subprojects/unicode-width-0.2.2/src/lib.rs
[8/29] Compiling Rust source ../subprojects/termcolor-1.4.1/src/lib.rs
[9/29] Compiling C++ object libcxxbridge.a.p/src_cxx.cc.o
[10/29] Compiling Rust source ../subprojects/foldhash-0.2.0/src/lib.rs
[11/29] Compiling Rust source ../subprojects/link-cplusplus-1.0.12/src/lib.rs
[12/29] Compiling Rust source ../subprojects/proc-macro2-1.0.106/src/lib.rs
[13/29] Compiling Rust source ../subprojects/clap_builder-4.6.0/src/lib.rs
[14/29] Compiling Rust source ../subprojects/indexmap-2.14.0/src/lib.rs
[15/29] Compiling Rust source ../subprojects/codespan-reporting-0.13.1/src/lib.rs
[16/29] Linking static target libcxxbridge.a
[17/29] Compiling Rust source ../subprojects/quote-1.0.46/src/lib.rs
[18/29] Compiling Rust source ../subprojects/clap-4.6.1/src/lib.rs
[19/29] Compiling Rust source ../subprojects/syn-2.0.118/src/lib.rs
[20/29] Compiling Rust source ../gen/cmd/src/main.rs
[21/29] Compiling Rust source ../macro/src/lib.rs
[22/29] Generating cxx.h with a custom command (wrapped by meson to capture output)
[23/29] Generating 'demo/libcxxbridge-demo.a.p/demo/src/main.rs.h' (wrapped by meson to capture output)
[24/29] Generating 'demo/libcxxbridge-demo.a.p/demo/src/main.rs.cc' (wrapped by meson to capture output)
[25/29] Compiling Rust source ../src/lib.rs
[26/29] Compiling C++ object demo/libcxxbridge-demo.a.p/src_blobstore.cc.o
[27/29] Compiling C++ object demo/libcxxbridge-demo.a.p/meson-generated_demo_src_main.rs.cc.o
[28/29] Linking static target demo/libcxxbridge-demo.a
[29/29] Compiling Rust source ../demo/src/main.rs
```