### PR TITLE
Add string_view constructor to rust::Str

### DIFF
--- a/include/cxx.h
+++ b/include/cxx.h
@@ -124,6 +124,9 @@ public:
   Str(const std::string &);
   Str(const char *);
   Str(const char *, std::size_t);
+#if __cplusplus >= 201703L
+  Str(std::string_view s) : Str(s.data(), s.size()) {}
+#endif
 
   Str &operator=(const Str &) & noexcept = default;
 


### PR DESCRIPTION
This is much safer than manually providing pointers and size.

Note: a few lines later, we already have `operator std::string_view` defined. So it makes sense to have it in the other direction too.