### PR TITLE
Resolve unsafe_op_in_unsafe_fn for 2024 edition

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -387,7 +387,7 @@ extern "C" fn cxx_test_suite_get_box() -> *mut R {
 
 #[unsafe(no_mangle)]
 unsafe extern "C" fn cxx_test_suite_r_is_correct(r: *const R) -> bool {
-    (*r).0 == 2020
+    unsafe { (*r).0 == 2020 }
 }
 
 #[test]


### PR DESCRIPTION
https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html

```console
warning[E0133]: dereference of raw pointer is unsafe and requires unsafe block
   --> tests/test.rs:390:5
    |
390 |     (*r).0 == 2020
    |     ^^^^ dereference of raw pointer
    |
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
note: an unsafe function restricts its caller, but its body is safe by default
   --> tests/test.rs:389:1
    |
389 | unsafe extern "C" fn cxx_test_suite_r_is_correct(r: *const R) -> bool {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: `#[warn(unsafe_op_in_unsafe_fn)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
```