### PR TITLE
Restore RefUnwindSafe for let_cxx_string in async

### DIFF
--- a/src/cxx_string.rs
+++ b/src/cxx_string.rs
@@ -8,6 +8,7 @@ use core::cell::UnsafeCell;
 use core::cmp::Ordering;
 use core::ffi::{CStr, c_char};
 use core::fmt::{self, Debug, Display};
+use core::panic::RefUnwindSafe;
 use core::hash::{Hash, Hasher};
 use core::marker::{PhantomData, PhantomPinned};
 use core::mem::MaybeUninit;
@@ -308,6 +309,7 @@ pub struct StackString {
 }
 
 unsafe impl Sync for StackString {}
+impl RefUnwindSafe for StackString {}
 
 impl StackString {
     pub fn new() -> Self {

--- a/tests/cxx_string.rs
+++ b/tests/cxx_string.rs
@@ -7,7 +7,7 @@
 
 use cxx::{CxxString, let_cxx_string};
 use std::fmt::Write as _;
-use std::panic;
+use std::panic::{self, RefUnwindSafe};
 
 #[test]
 fn test_async_cxx_string() {
@@ -19,8 +19,14 @@ fn test_async_cxx_string() {
     }
 
     // https://github.com/dtolnay/cxx/issues/693
-    fn assert_send(_: impl Send + Sync) {}
+    fn assert_send(_: impl Send) {}
     assert_send(f());
+
+    fn assert_sync(_: impl Sync) {}
+    assert_sync(f());
+
+    fn assert_ref_unwind_safe(_: impl RefUnwindSafe) {}
+    assert_ref_unwind_safe(f());
 }
 
 #[test]


### PR DESCRIPTION
Prior to https://github.com/dtolnay/cxx/pull/1731, async functions / async blocks containing `let_cxx_string!` used to be RefUnwindSafe.