### PR TITLE
Use link_deps in Cargo bazel metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,9 +77,9 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 """
-deps = [":cxx_cc"]
 extra_aliased_targets = { cxx_cc = "cxx_cc" }
 gen_build_script = false
+link_deps = [":cxx_cc"]
 
 [patch.crates-io]
 cxx = { path = "." }


### PR DESCRIPTION
Supported since https://github.com/bazelbuild/rules_rust/pull/4109.

Closes #1740.