### PR TITLE
Replace apt emscripten with emsdk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,12 +180,15 @@ jobs:
         with:
           targets: wasm32-unknown-emscripten
           components: rust-src
-      - name: Disable initramfs update
-        run: sudo sed -i 's/^update_initramfs=yes$/update_initramfs=no/' /etc/initramfs-tools/update-initramfs.conf
-      - name: Disable man-db update
-        run: sudo rm -f /var/lib/man-db/auto-update
-      - name: Install emscripten
-        run: sudo apt-get install emscripten
+      - uses: actions/checkout@v7
+        with:
+          repository: emscripten-core/emsdk
+          ref: 6.0.2
+          path: emsdk
+      - run: echo ${{github.workspace}}/emsdk >> $GITHUB_PATH
+      - run: emsdk install latest
+      - run: emsdk activate latest
+      - run: echo ${{github.workspace}}/emsdk/upstream/emscripten >> $GITHUB_PATH
       - run: cargo build --target=wasm32-unknown-emscripten --manifest-path=demo/Cargo.toml --release -Zbuild-std
         env:
           RUSTFLAGS: -Clink-arg=--emrun ${{env.RUSTFLAGS}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,15 +180,7 @@ jobs:
         with:
           targets: wasm32-unknown-emscripten
           components: rust-src
-      - uses: actions/checkout@v7
-        with:
-          repository: emscripten-core/emsdk
-          ref: 6.0.2
-          path: emsdk
-      - run: echo ${{github.workspace}}/emsdk >> $GITHUB_PATH
-      - run: emsdk install latest
-      - run: emsdk activate latest
-      - run: echo ${{github.workspace}}/emsdk/upstream/emscripten >> $GITHUB_PATH
+      - uses: emscripten-core/setup-emsdk@v16
       - run: cargo build --target=wasm32-unknown-emscripten --manifest-path=demo/Cargo.toml --release -Zbuild-std
         env:
           RUSTFLAGS: -Clink-arg=--emrun ${{env.RUSTFLAGS}}


### PR DESCRIPTION
The Emscripten job started failing today with this error, possibly from mismatched versions of `emcc` and `wasm-opt` and other tools.

```console
error: linking with `emcc` failed: exit status: 1
  |
  = note:  "emcc" "-s" "EXPORTED_FUNCTIONS=[\"_main\",\"_org$blobstore$cxxbridge1$197$MultiBuf$operator$alignof\",\"_org$blobstore$cxxbridge1$197$MultiBuf$operator$sizeof\",\"_org$blobstore$cxxbridge1$197$next_chunk\",\"_cxxbridge1$exception\",\"_cxxbridge1$rust_vec$bool$capacity\",\"_cxxbridge1$rust_vec$bool$data\",\"_cxxbridge1$rust_vec$bool$drop\",\"_cxxbridge1$rust_vec$bool$len\",\"_cxxbridge1$rust_vec$bool$new\",\"_cxxbridge1$rust_vec$bool$reserve_total\",\"_cxxbridge1$rust_vec$bool$set_len\",\"_cxxbridge1$rust_vec$bool$truncate\",\"_cxxbridge1$rust_vec$char$capacity\",\"_cxxbridge1$rust_vec$char$data\",\"_cxxbridge1$rust_vec$char$drop\",\"_cxxbridge1$rust_vec$char$len\",\"_cxxbridge1$rust_vec$char$new\",\"_cxxbridge1$rust_vec$char$reserve_total\",\"_cxxbridge1$rust_vec$char$set_len\",\"_cxxbridge1$rust_vec$char$truncate\",\"_cxxbridge1$rust_vec$f32$capacity\",\"_cxxbridge1$rust_vec$f32$data\",\"_cxxbridge1$rust_vec$f32$drop\",\"_cxxbridge1$rust_vec$f32$len\",\"_cxxbridge1$rust_vec$f32$new\",\"_cxxbridge1$rust_vec$f32$reserve_total\",\"_cxxbridge1$rust_vec$f32$set_len\",\"_cxxbridge1$rust_vec$f32$truncate\",\"_cxxbridge1$rust_vec$f64$capacity\",\"_cxxbridge1$rust_vec$f64$data\",\"_cxxbridge1$rust_vec$f64$drop\",\"_cxxbridge1$rust_vec$f64$len\",\"_cxxbridge1$rust_vec$f64$new\",\"_cxxbridge1$rust_vec$f64$reserve_total\",\"_cxxbridge1$rust_vec$f64$set_len\",\"_cxxbridge1$rust_vec$f64$truncate\",\"_cxxbridge1$rust_vec$i16$capacity\",\"_cxxbridge1$rust_vec$i16$data\",\"_cxxbridge1$rust_vec$i16$drop\",\"_cxxbridge1$rust_vec$i16$len\",\"_cxxbridge1$rust_vec$i16$new\",\"_cxxbridge1$rust_vec$i16$reserve_total\",\"_cxxbridge1$rust_vec$i16$set_len\",\"_cxxbridge1$rust_vec$i16$truncate\",\"_cxxbridge1$rust_vec$i32$capacity\",\"_cxxbridge1$rust_vec$i32$data\",\"_cxxbridge1$rust_vec$i32$drop\",\"_cxxbridge1$rust_vec$i32$len\",\"_cxxbridge1$rust_vec$i32$new\",\"_cxxbridge1$rust_vec$i32$reserve_total\",\"_cxxbridge1$rust_vec$i32$set_len\",\"_cxxbridge1$rust_vec$i32$truncate\",\"_cxxbridge1$rust_vec$i64$capacity\",\"_cxxbridge1$rust_vec$i64$data\",\"_cxxbridge1$rust_vec$i64$drop\",\"_cxxbridge1$rust_vec$i64$len\",\"_cxxbridge1$rust_vec$i64$new\",\"_cxxbridge1$rust_vec$i64$reserve_total\",\"_cxxbridge1$rust_vec$i64$set_len\",\"_cxxbridge1$rust_vec$i64$truncate\",\"_cxxbridge1$rust_vec$i8$capacity\",\"_cxxbridge1$rust_vec$i8$data\",\"_cxxbridge1$rust_vec$i8$drop\",\"_cxxbridge1$rust_vec$i8$len\",\"_cxxbridge1$rust_vec$i8$new\",\"_cxxbridge1$rust_vec$i8$reserve_total\",\"_cxxbridge1$rust_vec$i8$set_len\",\"_cxxbridge1$rust_vec$i8$truncate\",\"_cxxbridge1$rust_vec$isize$capacity\",\"_cxxbridge1$rust_vec$isize$data\",\"_cxxbridge1$rust_vec$isize$drop\",\"_cxxbridge1$rust_vec$isize$len\",\"_cxxbridge1$rust_vec$isize$new\",\"_cxxbridge1$rust_vec$isize$reserve_total\",\"_cxxbridge1$rust_vec$isize$set_len\",\"_cxxbridge1$rust_vec$isize$truncate\",\"_cxxbridge1$rust_vec$str$capacity\",\"_cxxbridge1$rust_vec$str$data\",\"_cxxbridge1$rust_vec$str$drop\",\"_cxxbridge1$rust_vec$str$len\",\"_cxxbridge1$rust_vec$str$new\",\"_cxxbridge1$rust_vec$str$reserve_total\",\"_cxxbridge1$rust_vec$str$set_len\",\"_cxxbridge1$rust_vec$str$truncate\",\"_cxxbridge1$rust_vec$string$capacity\",\"_cxxbridge1$rust_vec$string$data\",\"_cxxbridge1$rust_vec$string$drop\",\"_cxxbridge1$rust_vec$string$len\",\"_cxxbridge1$rust_vec$string$new\",\"_cxxbridge1$rust_vec$string$reserve_total\",\"_cxxbridge1$rust_vec$string$set_len\",\"_cxxbridge1$rust_vec$string$truncate\",\"_cxxbridge1$rust_vec$u16$capacity\",\"_cxxbridge1$rust_vec$u16$data\",\"_cxxbridge1$rust_vec$u16$drop\",\"_cxxbridge1$rust_vec$u16$len\",\"_cxxbridge1$rust_vec$u16$new\",\"_cxxbridge1$rust_vec$u16$reserve_total\",\"_cxxbridge1$rust_vec$u16$set_len\",\"_cxxbridge1$rust_vec$u16$truncate\",\"_cxxbridge1$rust_vec$u32$capacity\",\"_cxxbridge1$rust_vec$u32$data\",\"_cxxbridge1$rust_vec$u32$drop\",\"_cxxbridge1$rust_vec$u32$len\",\"_cxxbridge1$rust_vec$u32$new\",\"_cxxbridge1$rust_vec$u32$reserve_total\",\"_cxxbridge1$rust_vec$u32$set_len\",\"_cxxbridge1$rust_vec$u32$truncate\",\"_cxxbridge1$rust_vec$u64$capacity\",\"_cxxbridge1$rust_vec$u64$data\",\"_cxxbridge1$rust_vec$u64$drop\",\"_cxxbridge1$rust_vec$u64$len\",\"_cxxbridge1$rust_vec$u64$new\",\"_cxxbridge1$rust_vec$u64$reserve_total\",\"_cxxbridge1$rust_vec$u64$set_len\",\"_cxxbridge1$rust_vec$u64$truncate\",\"_cxxbridge1$rust_vec$u8$capacity\",\"_cxxbridge1$rust_vec$u8$data\",\"_cxxbridge1$rust_vec$u8$drop\",\"_cxxbridge1$rust_vec$u8$len\",\"_cxxbridge1$rust_vec$u8$new\",\"_cxxbridge1$rust_vec$u8$reserve_total\",\"_cxxbridge1$rust_vec$u8$set_len\",\"_cxxbridge1$rust_vec$u8$truncate\",\"_cxxbridge1$rust_vec$usize$capacity\",\"_cxxbridge1$rust_vec$usize$data\",\"_cxxbridge1$rust_vec$usize$drop\",\"_cxxbridge1$rust_vec$usize$len\",\"_cxxbridge1$rust_vec$usize$new\",\"_cxxbridge1$rust_vec$usize$reserve_total\",\"_cxxbridge1$rust_vec$usize$set_len\",\"_cxxbridge1$rust_vec$usize$truncate\",\"_cxxbridge1$slice$len\",\"_cxxbridge1$slice$new\",\"_cxxbridge1$slice$ptr\",\"_cxxbridge1$str$from\",\"_cxxbridge1$str$len\",\"_cxxbridge1$str$new\",\"_cxxbridge1$str$ptr\",\"_cxxbridge1$str$ref\",\"_cxxbridge1$string$capacity\",\"_cxxbridge1$string$clone\",\"_cxxbridge1$string$drop\",\"_cxxbridge1$string$from_utf16\",\"_cxxbridge1$string$from_utf16_lossy\",\"_cxxbridge1$string$from_utf8\",\"_cxxbridge1$string$from_utf8_lossy\",\"_cxxbridge1$string$len\",\"_cxxbridge1$string$new\",\"_cxxbridge1$string$ptr\",\"_cxxbridge1$string$reserve_additional\",\"_cxxbridge1$string$reserve_total\"]" "<2 object files omitted>" "-l" "cxxbridge-demo" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/deps/{libpanic_unwind-8817dd21d09c18eb,libcxx-726b4d44cecfd7f2,libfoldhash-6dc0f8ffb5390294,liblink_cplusplus-76dfe8f6ec9a1ec7,libstd-914916776ec10833,libcfg_if-7ab38bf47b662795,librustc_demangle-8867368bb1b45c15,libstd_detect-a8ad64d21136755f,libhashbrown-a7e10e5b7dc3c0fe,librustc_std_workspace_alloc-b5a5e78a44dcade8,libminiz_oxide-a4097b6a9e49ad4f,libadler2-909c710eadb7816a,libunwind-b347bf5ae589c40a,liblibc-0ce234264b230ef2,librustc_std_workspace_core-c5b7562f679b0e07,liballoc-925ee459216b08d4,libcore-3c00c9952ed16fab,libcompiler_builtins-130a3e97cc6cc4a2}.rlib" "-l" "stdc++" "-B<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/bin/gcc-ld" "--target=wasm32-unknown-emscripten" "-fwasm-exceptions" "-L" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/demo-414b32f7e9673166/out" "-L" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/cxx-c089b2fc4c4dae39/out" "-L" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/link-cplusplus-cc363ba53aa1e497/out" "-L" "<sysroot>/lib/rustlib/wasm32-unknown-emscripten/lib/self-contained" "-o" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/deps/demo.js" "-O3" "-g0" "--emrun" "-sABORTING_MALLOC=0" "-sWASM_BIGINT"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: emcc: error: undefined exported symbol: "_main" [-Wundefined] [-Werror]
```