### PR TITLE
Fix emscripten linker choice in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,12 @@ jobs:
           targets: wasm32-unknown-emscripten
           components: rust-src
       - uses: emscripten-core/setup-emsdk@v16
-      - run: cargo build --target=wasm32-unknown-emscripten --manifest-path=demo/Cargo.toml --release -Zbuild-std
+      - run: cargo build
+          --manifest-path=demo/Cargo.toml
+          --target=wasm32-unknown-emscripten
+          --release
+          -Zbuild-std
+          --config='target.wasm32-unknown-emscripten.linker="em++"'
         env:
           RUSTFLAGS: -Clink-arg=--emrun ${{env.RUSTFLAGS}}
       - name: Create demo.html for demo.js


### PR DESCRIPTION
The Emscripten job started failing in https://github.com/dtolnay/cxx/actions/runs/31065710984/job/92526492466. I can't tell whether this is some change in rustc nightly-2026-08-06, some change in the emscripten-core/setup-emsdk action, or some other change in the GitHub Actions runner environment.

```console
error: linking with `emcc` failed: exit status: 1
  |
  = note:  "emcc" "-s" "EXPORTED_FUNCTIONS=[\"_main\",\"_org$blobstore$cxxbridge1$198$MultiBuf$operator$alignof\",\"_org$blobstore$cxxbridge1$198$MultiBuf$operator$sizeof\",\"_org$blobstore$cxxbridge1$198$next_chunk\",\"_cxxbridge1$exception\",\"_cxxbridge1$rust_vec$bool$capacity\",\"_cxxbridge1$rust_vec$bool$data\",\"_cxxbridge1$rust_vec$bool$drop\",\"_cxxbridge1$rust_vec$bool$len\",\"_cxxbridge1$rust_vec$bool$new\",\"_cxxbridge1$rust_vec$bool$reserve_total\",\"_cxxbridge1$rust_vec$bool$set_len\",\"_cxxbridge1$rust_vec$bool$truncate\",\"_cxxbridge1$rust_vec$char$capacity\",\"_cxxbridge1$rust_vec$char$data\",\"_cxxbridge1$rust_vec$char$drop\",\"_cxxbridge1$rust_vec$char$len\",\"_cxxbridge1$rust_vec$char$new\",\"_cxxbridge1$rust_vec$char$reserve_total\",\"_cxxbridge1$rust_vec$char$set_len\",\"_cxxbridge1$rust_vec$char$truncate\",\"_cxxbridge1$rust_vec$f32$capacity\",\"_cxxbridge1$rust_vec$f32$data\",\"_cxxbridge1$rust_vec$f32$drop\",\"_cxxbridge1$rust_vec$f32$len\",\"_cxxbridge1$rust_vec$f32$new\",\"_cxxbridge1$rust_vec$f32$reserve_total\",\"_cxxbridge1$rust_vec$f32$set_len\",\"_cxxbridge1$rust_vec$f32$truncate\",\"_cxxbridge1$rust_vec$f64$capacity\",\"_cxxbridge1$rust_vec$f64$data\",\"_cxxbridge1$rust_vec$f64$drop\",\"_cxxbridge1$rust_vec$f64$len\",\"_cxxbridge1$rust_vec$f64$new\",\"_cxxbridge1$rust_vec$f64$reserve_total\",\"_cxxbridge1$rust_vec$f64$set_len\",\"_cxxbridge1$rust_vec$f64$truncate\",\"_cxxbridge1$rust_vec$i16$capacity\",\"_cxxbridge1$rust_vec$i16$data\",\"_cxxbridge1$rust_vec$i16$drop\",\"_cxxbridge1$rust_vec$i16$len\",\"_cxxbridge1$rust_vec$i16$new\",\"_cxxbridge1$rust_vec$i16$reserve_total\",\"_cxxbridge1$rust_vec$i16$set_len\",\"_cxxbridge1$rust_vec$i16$truncate\",\"_cxxbridge1$rust_vec$i32$capacity\",\"_cxxbridge1$rust_vec$i32$data\",\"_cxxbridge1$rust_vec$i32$drop\",\"_cxxbridge1$rust_vec$i32$len\",\"_cxxbridge1$rust_vec$i32$new\",\"_cxxbridge1$rust_vec$i32$reserve_total\",\"_cxxbridge1$rust_vec$i32$set_len\",\"_cxxbridge1$rust_vec$i32$truncate\",\"_cxxbridge1$rust_vec$i64$capacity\",\"_cxxbridge1$rust_vec$i64$data\",\"_cxxbridge1$rust_vec$i64$drop\",\"_cxxbridge1$rust_vec$i64$len\",\"_cxxbridge1$rust_vec$i64$new\",\"_cxxbridge1$rust_vec$i64$reserve_total\",\"_cxxbridge1$rust_vec$i64$set_len\",\"_cxxbridge1$rust_vec$i64$truncate\",\"_cxxbridge1$rust_vec$i8$capacity\",\"_cxxbridge1$rust_vec$i8$data\",\"_cxxbridge1$rust_vec$i8$drop\",\"_cxxbridge1$rust_vec$i8$len\",\"_cxxbridge1$rust_vec$i8$new\",\"_cxxbridge1$rust_vec$i8$reserve_total\",\"_cxxbridge1$rust_vec$i8$set_len\",\"_cxxbridge1$rust_vec$i8$truncate\",\"_cxxbridge1$rust_vec$isize$capacity\",\"_cxxbridge1$rust_vec$isize$data\",\"_cxxbridge1$rust_vec$isize$drop\",\"_cxxbridge1$rust_vec$isize$len\",\"_cxxbridge1$rust_vec$isize$new\",\"_cxxbridge1$rust_vec$isize$reserve_total\",\"_cxxbridge1$rust_vec$isize$set_len\",\"_cxxbridge1$rust_vec$isize$truncate\",\"_cxxbridge1$rust_vec$str$capacity\",\"_cxxbridge1$rust_vec$str$data\",\"_cxxbridge1$rust_vec$str$drop\",\"_cxxbridge1$rust_vec$str$len\",\"_cxxbridge1$rust_vec$str$new\",\"_cxxbridge1$rust_vec$str$reserve_total\",\"_cxxbridge1$rust_vec$str$set_len\",\"_cxxbridge1$rust_vec$str$truncate\",\"_cxxbridge1$rust_vec$string$capacity\",\"_cxxbridge1$rust_vec$string$data\",\"_cxxbridge1$rust_vec$string$drop\",\"_cxxbridge1$rust_vec$string$len\",\"_cxxbridge1$rust_vec$string$new\",\"_cxxbridge1$rust_vec$string$reserve_total\",\"_cxxbridge1$rust_vec$string$set_len\",\"_cxxbridge1$rust_vec$string$truncate\",\"_cxxbridge1$rust_vec$u16$capacity\",\"_cxxbridge1$rust_vec$u16$data\",\"_cxxbridge1$rust_vec$u16$drop\",\"_cxxbridge1$rust_vec$u16$len\",\"_cxxbridge1$rust_vec$u16$new\",\"_cxxbridge1$rust_vec$u16$reserve_total\",\"_cxxbridge1$rust_vec$u16$set_len\",\"_cxxbridge1$rust_vec$u16$truncate\",\"_cxxbridge1$rust_vec$u32$capacity\",\"_cxxbridge1$rust_vec$u32$data\",\"_cxxbridge1$rust_vec$u32$drop\",\"_cxxbridge1$rust_vec$u32$len\",\"_cxxbridge1$rust_vec$u32$new\",\"_cxxbridge1$rust_vec$u32$reserve_total\",\"_cxxbridge1$rust_vec$u32$set_len\",\"_cxxbridge1$rust_vec$u32$truncate\",\"_cxxbridge1$rust_vec$u64$capacity\",\"_cxxbridge1$rust_vec$u64$data\",\"_cxxbridge1$rust_vec$u64$drop\",\"_cxxbridge1$rust_vec$u64$len\",\"_cxxbridge1$rust_vec$u64$new\",\"_cxxbridge1$rust_vec$u64$reserve_total\",\"_cxxbridge1$rust_vec$u64$set_len\",\"_cxxbridge1$rust_vec$u64$truncate\",\"_cxxbridge1$rust_vec$u8$capacity\",\"_cxxbridge1$rust_vec$u8$data\",\"_cxxbridge1$rust_vec$u8$drop\",\"_cxxbridge1$rust_vec$u8$len\",\"_cxxbridge1$rust_vec$u8$new\",\"_cxxbridge1$rust_vec$u8$reserve_total\",\"_cxxbridge1$rust_vec$u8$set_len\",\"_cxxbridge1$rust_vec$u8$truncate\",\"_cxxbridge1$rust_vec$usize$capacity\",\"_cxxbridge1$rust_vec$usize$data\",\"_cxxbridge1$rust_vec$usize$drop\",\"_cxxbridge1$rust_vec$usize$len\",\"_cxxbridge1$rust_vec$usize$new\",\"_cxxbridge1$rust_vec$usize$reserve_total\",\"_cxxbridge1$rust_vec$usize$set_len\",\"_cxxbridge1$rust_vec$usize$truncate\",\"_cxxbridge1$slice$len\",\"_cxxbridge1$slice$new\",\"_cxxbridge1$slice$ptr\",\"_cxxbridge1$str$from\",\"_cxxbridge1$str$len\",\"_cxxbridge1$str$new\",\"_cxxbridge1$str$ptr\",\"_cxxbridge1$str$ref\",\"_cxxbridge1$string$capacity\",\"_cxxbridge1$string$clone\",\"_cxxbridge1$string$drop\",\"_cxxbridge1$string$from_utf16\",\"_cxxbridge1$string$from_utf16_lossy\",\"_cxxbridge1$string$from_utf8\",\"_cxxbridge1$string$from_utf8_lossy\",\"_cxxbridge1$string$len\",\"_cxxbridge1$string$new\",\"_cxxbridge1$string$ptr\",\"_cxxbridge1$string$reserve_additional\",\"_cxxbridge1$string$reserve_total\"]" "<2 object files omitted>" "-l" "cxxbridge-demo" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/panic_unwind/6047b267758ce24c/out/libpanic_unwind-6047b267758ce24c.rlib" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/cxx/d94c05df5c1ae56c/out/libcxx-d94c05df5c1ae56c.rlib" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/foldhash/45f55e60b6909cec/out/libfoldhash-45f55e60b6909cec.rlib" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/link-cplusplus/9aa0cbb9008a9d86/out/liblink_cplusplus-9aa0cbb9008a9d86.rlib" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/std/c620505fc70b0c19/out/libstd-c620505fc70b0c19.rlib" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/cfg-if/7ab38bf47b662795/out/libcfg_if-7ab38bf47b662795.rlib" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/rustc-demangle/46c264a548da57dd/out/librustc_demangle-46c264a548da57dd.rlib" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/std_detect/30baa70dc59577a3/out/libstd_detect-30baa70dc59577a3.rlib" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/hashbrown/a7e10e5b7dc3c0fe/out/libhashbrown-a7e10e5b7dc3c0fe.rlib" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/rustc-std-workspace-alloc/b5a5e78a44dcade8/out/librustc_std_workspace_alloc-b5a5e78a44dcade8.rlib" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/miniz_oxide/4c0c199a158e647a/out/libminiz_oxide-4c0c199a158e647a.rlib" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/adler2/909c710eadb7816a/out/libadler2-909c710eadb7816a.rlib" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/unwind/7026ac9fa3f8eec1/out/libunwind-7026ac9fa3f8eec1.rlib" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/libc/c260072375030cbb/out/liblibc-c260072375030cbb.rlib" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/rustc-std-workspace-core/c5b7562f679b0e07/out/librustc_std_workspace_core-c5b7562f679b0e07.rlib" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/alloc/925ee459216b08d4/out/liballoc-925ee459216b08d4.rlib" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/core/3c00c9952ed16fab/out/libcore-3c00c9952ed16fab.rlib" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/compiler_builtins/130a3e97cc6cc4a2/out/libcompiler_builtins-130a3e97cc6cc4a2.rlib" "-l" "stdc++" "-B<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/bin/gcc-ld" "--target=wasm32-unknown-emscripten" "-fwasm-exceptions" "-L" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/demo/e10a00f15fa7cdc2/out" "-L" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/cxx/26ad6d75f82189fb/out" "-L" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/link-cplusplus/d8a1fa74686c7474/out" "-L" "<sysroot>/lib/rustlib/wasm32-unknown-emscripten/lib/self-contained" "-o" "/home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/demo/e3b8b591f85bfd2e/out/demo.js" "-O3" "-g0" "--emrun" "-sABORTING_MALLOC=0" "-sWASM_BIGINT"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: wasm-ld: error: /home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/demo/e10a00f15fa7cdc2/out/libcxxbridge-demo.a(ff1ee5417837d52c-main.rs.o): undefined symbol: std::__2::__shared_weak_count::__release_weak()
          wasm-ld: error: /home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/demo/e10a00f15fa7cdc2/out/libcxxbridge-demo.a(ff1ee5417837d52c-main.rs.o): undefined symbol: operator delete(void*, unsigned long)
          wasm-ld: error: /home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/demo/e10a00f15fa7cdc2/out/libcxxbridge-demo.a(48d3f1b29a630f4c-blobstore.o): undefined symbol: std::__2::basic_string<char, std::__2::char_traits<char>, std::__2::allocator<char>>::append(char const*, unsigned long)
          wasm-ld: error: /home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/demo/e10a00f15fa7cdc2/out/libcxxbridge-demo.a(48d3f1b29a630f4c-blobstore.o): undefined symbol: std::__2::__hash_memory(void const*, unsigned long)
          wasm-ld: error: /home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/demo/e10a00f15fa7cdc2/out/libcxxbridge-demo.a(48d3f1b29a630f4c-blobstore.o): undefined symbol: operator delete(void*, unsigned long)
          wasm-ld: error: /home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/demo/e10a00f15fa7cdc2/out/libcxxbridge-demo.a(48d3f1b29a630f4c-blobstore.o): undefined symbol: operator delete(void*, unsigned long)
          wasm-ld: error: /home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/demo/e10a00f15fa7cdc2/out/libcxxbridge-demo.a(48d3f1b29a630f4c-blobstore.o): undefined symbol: operator delete(void*, unsigned long)
          wasm-ld: error: /home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/demo/e10a00f15fa7cdc2/out/libcxxbridge-demo.a(48d3f1b29a630f4c-blobstore.o): undefined symbol: std::__2::__hash_memory(void const*, unsigned long)
          wasm-ld: error: /home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/demo/e10a00f15fa7cdc2/out/libcxxbridge-demo.a(48d3f1b29a630f4c-blobstore.o): undefined symbol: operator new(unsigned long)
          wasm-ld: error: /home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/demo/e10a00f15fa7cdc2/out/libcxxbridge-demo.a(48d3f1b29a630f4c-blobstore.o): undefined symbol: std::__2::__next_prime(unsigned long)
          wasm-ld: error: /home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/demo/e10a00f15fa7cdc2/out/libcxxbridge-demo.a(48d3f1b29a630f4c-blobstore.o): undefined symbol: std::__2::__next_prime(unsigned long)
          wasm-ld: error: /home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/demo/e10a00f15fa7cdc2/out/libcxxbridge-demo.a(48d3f1b29a630f4c-blobstore.o): undefined symbol: operator delete(void*, unsigned long)
          wasm-ld: error: /home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/demo/e10a00f15fa7cdc2/out/libcxxbridge-demo.a(48d3f1b29a630f4c-blobstore.o): undefined symbol: operator delete(void*, unsigned long)
          wasm-ld: error: /home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/demo/e10a00f15fa7cdc2/out/libcxxbridge-demo.a(48d3f1b29a630f4c-blobstore.o): undefined symbol: std::__2::__hash_memory(void const*, unsigned long)
          wasm-ld: error: /home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/demo/e10a00f15fa7cdc2/out/libcxxbridge-demo.a(48d3f1b29a630f4c-blobstore.o): undefined symbol: operator new(unsigned long)
          wasm-ld: error: /home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/demo/e10a00f15fa7cdc2/out/libcxxbridge-demo.a(48d3f1b29a630f4c-blobstore.o): undefined symbol: std::__2::__next_prime(unsigned long)
          wasm-ld: error: /home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/demo/e10a00f15fa7cdc2/out/libcxxbridge-demo.a(48d3f1b29a630f4c-blobstore.o): undefined symbol: std::__2::__next_prime(unsigned long)
          wasm-ld: error: /home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/demo/e10a00f15fa7cdc2/out/libcxxbridge-demo.a(48d3f1b29a630f4c-blobstore.o): undefined symbol: operator new(unsigned long)
          wasm-ld: error: /home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/demo/e10a00f15fa7cdc2/out/libcxxbridge-demo.a(48d3f1b29a630f4c-blobstore.o): undefined symbol: operator delete(void*, unsigned long)
          wasm-ld: error: /home/runner/work/cxx/cxx/target/wasm32-unknown-emscripten/release/build/demo/e10a00f15fa7cdc2/out/libcxxbridge-demo.a(48d3f1b29a630f4c-blobstore.o): undefined symbol: operator delete(void*, unsigned long)
          wasm-ld: error: too many errors emitted, stopping now (use -error-limit=0 to see all errors)
          emcc: warning: link failed with undefined C++ symbols. Try linking with 'em++' or passing '-sDEFAULT_TO_CXX'
          emcc: error: '/home/runner/work/_temp/337b35fe-a850-49f2-aee8-ad0237d4e505/emsdk-main/upstream/bin/wasm-ld @/tmp/emscripten_6ekocut1.rsp.utf-8' failed (returned 1)
```