### PR TITLE
Suppress clone_on_copy clippy lint

### DIFF
--- a/macro/src/derive.rs
+++ b/macro/src/derive.rs
@@ -138,7 +138,7 @@ fn struct_clone(strct: &Struct, span: Span) -> TokenStream {
     quote_spanned! {span=>
         #cfg_and_lint_attrs
         #[automatically_derived]
-        #[allow(clippy::expl_impl_clone_on_copy)]
+        #[allow(clippy::clone_on_copy, clippy::expl_impl_clone_on_copy)]
         impl #generics ::cxx::core::clone::Clone for #ident #generics {
             fn clone(&self) -> Self {
                 #body


### PR DESCRIPTION
New clippy lint in nightly-2026-08-08.

```console
warning: using `clone` on type `usize` which implements the `Copy` trait
  --> tests/ffi/lib.rs:38:14
   |
38 |     #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
   |              ^^^^^ help: try removing the `clone` call: `z: usize`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy
   = note: `-W clippy::clone-on-copy` implied by `-W clippy::all`
   = help: to override `-W clippy::all` add `#[allow(clippy::clone_on_copy)]`

warning: using `clone` on type `usize` which implements the `Copy` trait
  --> tests/ffi/lib.rs:81:14
   |
81 |     #[derive(Clone)]
   |              ^^^^^ help: try removing the `clone` call: `z: usize`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy
```