### PR TITLE
Add monospace tags and qualify Rust types outside of prelude

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,43 +76,43 @@ supports a `put` operation for a discontiguous buffer upload. For example we
 might be uploading snapshots of a circular buffer which would tend to consist of
 2 chunks, or fragments of a file spread across memory for some other reason.
 
-A runnable version of this example is provided under the *demo* directory of
+A runnable version of this example is provided under the *`demo`* directory of
 this repo. To try it out, run `cargo run` from that directory.
 
 ```rust
 #[cxx::bridge]
 mod ffi {
-    // Any shared structs, whose fields will be visible to both languages.
-    struct BlobMetadata {
-        size: usize,
-        tags: Vec<String>,
-    }
+  // Any shared structs, whose fields will be visible to both languages.
+  struct BlobMetadata {
+  size: usize,
+  tags: Vec<String>,
+  }
 
-    extern "Rust" {
-        // Zero or more opaque types which both languages can pass around but
-        // only Rust can see the fields.
-        type MultiBuf;
+  extern "Rust" {
+  // Zero or more opaque types which both languages can pass around but
+  // only Rust can see the fields.
+  type MultiBuf;
 
-        // Functions implemented in Rust.
-        fn next_chunk(buf: &mut MultiBuf) -> &[u8];
-    }
+  // Functions implemented in Rust.
+  fn next_chunk(buf: &mut MultiBuf) -> &[u8];
+  }
 
-    unsafe extern "C++" {
-        // One or more headers with the matching C++ declarations. Our code
-        // generators don't read it but it gets #include'd and used in static
-        // assertions to ensure our picture of the FFI boundary is accurate.
-        include!("demo/include/blobstore.h");
+  unsafe extern "C++" {
+  // One or more headers with the matching C++ declarations. Our code
+  // generators don't read it but it gets #include'd and used in static
+  // assertions to ensure our picture of the FFI boundary is accurate.
+  include!("demo/include/blobstore.h");
 
-        // Zero or more opaque types which both languages can pass around but
-        // only C++ can see the fields.
-        type BlobstoreClient;
+  // Zero or more opaque types which both languages can pass around but
+  // only C++ can see the fields.
+  type BlobstoreClient;
 
-        // Functions implemented in C++.
-        fn new_blobstore_client() -> UniquePtr<BlobstoreClient>;
-        fn put(&self, parts: &mut MultiBuf) -> u64;
-        fn tag(&self, blobid: u64, tag: &str);
-        fn metadata(&self, blobid: u64) -> BlobMetadata;
-    }
+  // Functions implemented in C++.
+  fn new_blobstore_client() -> UniquePtr<BlobstoreClient>;
+  fn put(&self, parts: &mut MultiBuf) -> u64;
+  fn tag(&self, blobid: u64, tag: &str);
+  fn metadata(&self, blobid: u64) -> BlobMetadata;
+  }
 }
 ```
 
@@ -131,11 +131,11 @@ To look at the code generated in both languages for the example by the CXX code
 generators:
 
 ```console
-   # run Rust code generator and print to stdout
-   # (requires https://github.com/dtolnay/cargo-expand)
+  # run Rust code generator and print to stdout
+  # (requires https://github.com/dtolnay/cargo-expand)
 $ cargo expand --manifest-path demo/Cargo.toml
 
-   # run C++ code generator and print to stdout
+  # run C++ code generator and print to stdout
 $ cargo run --manifest-path bridge/cmd/Cargo.toml -- demo/src/main.rs
 ```
 
@@ -173,7 +173,7 @@ headers but for now we need the signatures written out; static assertions will
 verify that they are accurate.
 
 Your function implementations themselves, whether in C++ or Rust, *do not* need
-to be defined as `extern "C"` ABI or no\_mangle. CXX will put in the right shims
+to be defined as `extern "C"` ABI or `no_mangle`. CXX will put in the right shims
 where necessary to make it all work.
 
 <br>
@@ -195,7 +195,7 @@ than bindgen or cbindgen in a sense; you can think of it as being a replacement
 for the concept of `extern "C"` signatures as we know them, rather than a
 replacement for a bindgen. It would be reasonable to build a higher level
 bindgen-like tool on top of CXX which consumes a C++ header and/or Rust module
-(and/or IDL like Thrift) as source of truth and generates the cxx::bridge,
+(and/or IDL like Thrift) as source of truth and generates the `cxx::bridge`,
 eliminating the repetition while leveraging the static analysis safety
 guarantees of CXX.
 
@@ -242,13 +242,13 @@ cxx-build = "1.0"
 // build.rs
 
 fn main() {
-    cxx_build::bridge("src/main.rs")  // returns a cc::Build
-        .file("src/demo.cc")
-        .std("c++11")
-        .compile("cxxbridge-demo");
+  cxx_build::bridge("src/main.rs")  // returns a cc::Build
+  .file("src/demo.cc")
+  .std("c++11")
+  .compile("cxxbridge-demo");
 
-    println!("cargo:rerun-if-changed=src/demo.cc");
-    println!("cargo:rerun-if-changed=include/demo.h");
+  println!("cargo:rerun-if-changed=src/demo.cc");
+  println!("cargo:rerun-if-changed=include/demo.h");
 }
 ```
 
@@ -259,7 +259,7 @@ fn main() {
 For use in non-Cargo builds like Bazel or Buck, CXX provides an alternate way of
 invoking the C++ code generator as a standalone command line tool. The tool is
 packaged as the `cxxbridge-cmd` crate on crates.io or can be built from the
-*bridge/cmd* directory of this repo.
+*`bridge/cmd`* directory of this repo.
 
 ```bash
 $ cargo install cxxbridge-cmd
@@ -302,8 +302,8 @@ Some of the considerations that go into ensuring safety are:
   pass your structs by value without worries. This is made possible by owning
   both sides of the boundary rather than just one.
 
-- Template instantiations: for example in order to expose a UniquePtr\<T\> type
-  in Rust backed by a real C++ unique\_ptr, we have a way of using a Rust trait
+- Template instantiations: for example in order to expose a `UniquePtr<T>` type
+  in Rust backed by a real C++ `unique_ptr`, we have a way of using a Rust trait
   to connect the behavior back to the template instantiations performed by the
   other language.
 
@@ -313,29 +313,29 @@ Some of the considerations that go into ensuring safety are:
 
 ## Builtin types
 
-In addition to all the primitive types (i32 &lt;=&gt; int32_t), the following
+In addition to all the primitive types (`i32` &harr; `int32_t`), the following
 common types may be used in the fields of shared structs and the arguments and
 returns of functions.
 
 <table>
 <tr><th>name in Rust</th><th>name in C++</th><th>restrictions</th></tr>
-<tr><td>String</td><td>rust::String</td><td></td></tr>
-<tr><td>&amp;str</td><td>rust::Str</td><td></td></tr>
-<tr><td>&amp;[T]</td><td>rust::Slice&lt;const T&gt;</td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
-<tr><td>&amp;mut [T]</td><td>rust::Slice&lt;T&gt;</td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
-<tr><td><a href="https://docs.rs/cxx/1.0/cxx/struct.CxxString.html">CxxString</a></td><td>std::string</td><td><sup><i>cannot be passed by value</i></sup></td></tr>
-<tr><td>Box&lt;T&gt;</td><td>rust::Box&lt;T&gt;</td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
-<tr><td><a href="https://docs.rs/cxx/1.0/cxx/struct.UniquePtr.html">UniquePtr&lt;T&gt;</a></td><td>std::unique_ptr&lt;T&gt;</td><td><sup><i>cannot hold opaque Rust type</i></sup></td></tr>
-<tr><td><a href="https://docs.rs/cxx/1.0/cxx/struct.SharedPtr.html">SharedPtr&lt;T&gt;</a></td><td>std::shared_ptr&lt;T&gt;</td><td><sup><i>cannot hold opaque Rust type</i></sup></td></tr>
-<tr><td>[T; N]</td><td>std::array&lt;T, N&gt;</td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
-<tr><td>Vec&lt;T&gt;</td><td>rust::Vec&lt;T&gt;</td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
-<tr><td><a href="https://docs.rs/cxx/1.0/cxx/struct.CxxVector.html">CxxVector&lt;T&gt;</a></td><td>std::vector&lt;T&gt;</td><td><sup><i>cannot be passed by value, cannot hold opaque Rust type</i></sup></td></tr>
-<tr><td>*mut T, *const T</td><td>T*, const T*</td><td><sup><i>fn with a raw pointer argument must be declared unsafe to call</i></sup></td></tr>
-<tr><td>fn(T, U) -&gt; V</td><td>rust::Fn&lt;V(T, U)&gt;</td><td><sup><i>only passing from Rust to C++ is implemented so far</i></sup></td></tr>
-<tr><td>Result&lt;T&gt;</td><td>throw/catch</td><td><sup><i>allowed as return type only</i></sup></td></tr>
+<tr><td><code>String</code></td><td><code>rust::String</code></td><td></td></tr>
+<tr><td><code>&amp;str</code></td><td><code>rust::Str</code></td><td></td></tr>
+<tr><td><code>&amp;[T]</code></td><td><code>rust::Slice&lt;const T&gt;</code></td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
+<tr><td><code>&amp;mut [T]</code></td><td><code>rust::Slice&lt;T&gt;</code></td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
+<tr><td><a href="https://docs.rs/cxx/1.0/cxx/struct.CxxString.html"><code>CxxString</code></a></td><td><code>std::string</code></td><td><sup><i>cannot be passed by value</i></sup></td></tr>
+<tr><td><code>Box&lt;T&gt;</code></td><td><code>rust::Box&lt;T&gt;</code></td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
+<tr><td><a href="https://docs.rs/cxx/1.0/cxx/struct.UniquePtr.html"><code>UniquePtr&lt;T&gt;</code></a></td><td><code>std::unique_ptr&lt;T&gt;</code></td><td><sup><i>cannot hold opaque Rust type</i></sup></td></tr>
+<tr><td><a href="https://docs.rs/cxx/1.0/cxx/struct.SharedPtr.html"><code>SharedPtr&lt;T&gt;</code></a></td><td><code>std::shared_ptr&lt;T&gt;</code></td><td><sup><i>cannot hold opaque Rust type</i></sup></td></tr>
+<tr><td><code>[T; N]</code></td><td><code>std::array&lt;T, N&gt;</code></td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
+<tr><td><code>Vec&lt;T&gt;</code></td><td><code>rust::Vec&lt;T&gt;</code></td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
+<tr><td><a href="https://docs.rs/cxx/1.0/cxx/struct.CxxVector.html"><code>CxxVector&lt;T&gt;</code></a></td><td><code>std::vector&lt;T&gt;</code></td><td><sup><i>cannot be passed by value, cannot hold opaque Rust type</i></sup></td></tr>
+<tr><td><code>*mut T</code>, <code>*const T</code></td><td><code>T*</code>, <code>const T*</code></td><td><sup><i>fn with a raw pointer argument must be declared unsafe to call</i></sup></td></tr>
+<tr><td><code>fn(T, U) -&gt; V</code></td><td><code>rust::Fn&lt;V(T, U)&gt;</code></td><td><sup><i>only passing from Rust to C++ is implemented so far</i></sup></td></tr>
+<tr><td><code>Result&lt;T&gt;</code></td><td><code>throw</code>/<code>catch</code></td><td><sup><i>allowed as return type only</i></sup></td></tr>
 </table>
 
-The C++ API of the `rust` namespace is defined by the *include/cxx.h* file in
+The C++ API of the `rust` namespace is defined by the *`include/cxx.h`* file in
 this repo. You will need to include this header in your C++ code when working
 with those types.
 
@@ -345,12 +345,12 @@ matter of designing a nice API for each in its non-native language.
 
 <table>
 <tr><th>name in Rust</th><th>name in C++</th></tr>
-<tr><td>BTreeMap&lt;K, V&gt;</td><td><sup><i>tbd</i></sup></td></tr>
-<tr><td>HashMap&lt;K, V&gt;</td><td><sup><i>tbd</i></sup></td></tr>
-<tr><td>Arc&lt;T&gt;</td><td><sup><i>tbd</i></sup></td></tr>
-<tr><td>Option&lt;T&gt;</td><td><sup><i>tbd</i></sup></td></tr>
-<tr><td><sup><i>tbd</i></sup></td><td>std::map&lt;K, V&gt;</td></tr>
-<tr><td><sup><i>tbd</i></sup></td><td>std::unordered_map&lt;K, V&gt;</td></tr>
+<tr><td><code>std::collections::BTreeMap&lt;K, V&gt;</code></td><td><sup><i>tbd</i></sup></td></tr>
+<tr><td><code>std::collections::HashMap&lt;K, V&gt;</code></td><td><sup><i>tbd</i></sup></td></tr>
+<tr><td><code>std::sync::Arc&lt;T&gt;</code></td><td><sup><i>tbd</i></sup></td></tr>
+<tr><td><code>Option&lt;T&gt;</code></td><td><sup><i>tbd</i></sup></td></tr>
+<tr><td><sup><i>tbd</i></sup></td><td><code>std::map&lt;K, V&gt;</code></td></tr>
+<tr><td><sup><i>tbd</i></sup></td><td><code>std::unordered_map&lt;K, V&gt;</code></td></tr>
 </table>
 
 <br>

--- a/book/src/attributes.md
+++ b/book/src/attributes.md
@@ -3,9 +3,9 @@
 
 ## namespace
 
-The top-level cxx::bridge attribute macro takes an optional `namespace` argument
-to control the C++ namespace into which to emit extern Rust items and the
-namespace in which to expect to find the extern C++ items.
+The top-level `cxx::bridge` attribute macro takes an optional `namespace` argument
+to control the C++ namespace into which to emit `extern "Rust"` items and the
+namespace in which to expect to find the `extern "C++"` items.
 
 ```rust,noplayground
 #[cxx::bridge(namespace = "path::of::my::company")]
@@ -23,7 +23,7 @@ mod ffi {
 Additionally, a `#[namespace = "..."]` attribute may be used inside the bridge
 module on any extern block or individual item. An item will inherit the
 namespace specified on its surrounding extern block if any, otherwise the
-namespace specified with the top level cxx::bridge attribute if any, otherwise
+namespace specified with the top level `cxx::bridge` attribute if any, otherwise
 the global namespace.
 
 ```rust,noplayground
@@ -68,8 +68,8 @@ The `#[rust_name = "..."]` attribute replaces the name that Rust should use for
 this function, and an analogous `#[cxx_name = "..."]` attribute replaces the
 name that C++ should use.
 
-Either of the two attributes may be used on extern "Rust" as well as extern
-"C++" functions, according to which one you find clearer in context.
+Either of the two attributes may be used on `extern "Rust"` as well as `extern "C++"`
+functions, according to which one you find clearer in context.
 
 The same attribute works for renaming functions, opaque types, shared
 structs and enums, and enum variants.

--- a/book/src/binding/result.md
+++ b/book/src/binding/result.md
@@ -1,11 +1,11 @@
 {{#title Result<T> — Rust ♡ C++}}
 # Result\<T\>
 
-Result\<T\> is allowed as the return type of an extern function in either
+`Result<T>` is allowed as the return type of an extern function in either
 direction. Its behavior is to translate to/from C++ exceptions. If your codebase
 does not use C++ exceptions, or prefers to represent fallibility using something
-like outcome\<T\>, leaf::result\<T\>, StatusOr\<T\>, etc then you'll need to
-handle the translation of those to Rust Result\<T\> using your own shims for
+like `outcome<T>`, `leaf::result<T>`, `StatusOr<T>`, etc then you'll need to
+handle the translation of those to Rust `Result<T>` using your own shims for
 now. Better support for this is planned.
 
 If an exception is thrown from an `extern "C++"` function that is *not* declared
@@ -22,10 +22,10 @@ calls Rust's `std::process::abort`.
 An `extern "Rust"` function returning a Result turns into a `throw` in C++ if
 the Rust side produces an error.
 
-Note that the return type written inside of cxx::bridge must be written without
+Note that the return type written inside of `cxx::bridge` must be written without
 a second type parameter. Only the Ok type is specified for the purpose of the
 FFI. The Rust *implementation* (outside of the bridge module) may pick any error
-type as long as it has a std::fmt::Display impl.
+type as long as it has a `std::fmt::Display` impl.
 
 ```rust,noplayground
 # use std::io;
@@ -53,7 +53,7 @@ fn fallible2() -> Result<(), io::Error> {
 
 The exception that gets thrown by CXX on the C++ side is always of type
 `rust::Error` and has the following C++ public API. The `what()` member function
-gives the error message according to the Rust error's std::fmt::Display impl.
+gives the error message according to the Rust error's `std::fmt::Display` impl.
 
 ```cpp,hidelines=...
 // rust/cxx.h
@@ -80,7 +80,7 @@ public:
 An `extern "C++"` function returning a Result turns into a `catch` in C++ that
 converts the exception into an Err for Rust.
 
-Note that the return type written inside of cxx::bridge must be written without
+Note that the return type written inside of `cxx::bridge` must be written without
 a second type parameter. Only the Ok type is specified for the purpose of the
 FFI. The resulting error type created by CXX when an `extern "C++"` function
 throws will always be of type **[`cxx::Exception`]**.
@@ -110,19 +110,17 @@ fn main() {
 The specific set of caught exceptions and the conversion to error message are
 both customizable. The way you do this is by defining a template function
 `rust::behavior::trycatch` with a suitable signature inside any one of the
-headers `include!`'d by your cxx::bridge.
+headers `include!`'d by your `cxx::bridge`.
 
 The template signature is required to be:
 
 ```cpp
-namespace rust {
-namespace behavior {
+namespace rust::behavior {
 
 template <typename Try, typename Fail>
 static void trycatch(Try &&func, Fail &&fail) noexcept;
 
-} // namespace behavior
-} // namespace rust
+} // namespace rust::behavior
 ```
 
 The default `trycatch` used by CXX if you have not provided your own is the
@@ -133,8 +131,7 @@ you'd like for the Rust error to have.
 ```cpp,hidelines=...
 ...#include <exception>
 ...
-...namespace rust {
-...namespace behavior {
+...namespace rust::behavior {
 ...
 template <typename Try, typename Fail>
 static void trycatch(Try &&func, Fail &&fail) noexcept try {
@@ -143,6 +140,5 @@ static void trycatch(Try &&func, Fail &&fail) noexcept try {
   fail(e.what());
 }
 ...
-...} // namespace behavior
-...} // namespace rust
+...} // namespace rust::behavior
 ```

--- a/book/src/bindings.md
+++ b/book/src/bindings.md
@@ -1,7 +1,7 @@
 {{#title Built-in bindings — Rust ♡ C++}}
 # Built-in bindings reference
 
-In addition to all the primitive types (i32 &lt;=&gt; int32_t), the following
+In addition to all the primitive types (`i32` &harr; `int32_t`), the following
 common types may be used in the fields of shared structs and the arguments and
 returns of extern functions.
 
@@ -9,25 +9,25 @@ returns of extern functions.
 
 <table>
 <tr><th>name in Rust</th><th>name in C++</th><th>restrictions</th></tr>
-<tr><td style="padding:3px 6px">String</td><td style="padding:3px 6px"><b><a href="binding/string.md">rust::String</a></b></td><td style="padding:3px 6px"></td></tr>
-<tr><td style="padding:3px 6px">&amp;str</td><td style="padding:3px 6px"><b><a href="binding/str.md">rust::Str</a></b></td><td style="padding:3px 6px"></td></tr>
-<tr><td style="padding:3px 6px">&amp;[T]</td><td style="padding:3px 6px"><b><a href="binding/slice.md">rust::Slice&lt;const&nbsp;T&gt;</a></b></td><td style="padding:3px 6px"><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
-<tr><td style="padding:3px 6px">&amp;mut [T]</td><td style="padding:3px 6px"><b><a href="binding/slice.md">rust::Slice&lt;T&gt;</a></b></td><td style="padding:3px 6px"><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
-<tr><td style="padding:3px 6px"><b><a href="binding/cxxstring.md">CxxString</a></b></td><td style="padding:3px 6px">std::string</td><td style="padding:3px 6px"><sup><i>cannot be passed by value</i></sup></td></tr>
-<tr><td style="padding:3px 6px">Box&lt;T&gt;</td><td style="padding:3px 6px"><b><a href="binding/box.md">rust::Box&lt;T&gt;</a></b></td><td style="padding:3px 6px"><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
-<tr><td style="padding:3px 6px"><b><a href="binding/uniqueptr.md">UniquePtr&lt;T&gt;</a></b></td><td style="padding:3px 6px">std::unique_ptr&lt;T&gt;</td><td style="padding:3px 6px"><sup><i>cannot hold opaque Rust type</i></sup></td></tr>
-<tr><td style="padding:3px 6px"><b><a href="binding/sharedptr.md">SharedPtr&lt;T&gt;</a></b></td><td style="padding:3px 6px">std::shared_ptr&lt;T&gt;</td><td style="padding:3px 6px"><sup><i>cannot hold opaque Rust type</i></sup></td></tr>
-<tr><td style="padding:3px 6px">[T; N]</td><td style="padding:3px 6px">std::array&lt;T, N&gt;</td><td style="padding:3px 6px"><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
-<tr><td style="padding:3px 6px">Vec&lt;T&gt;</td><td style="padding:3px 6px"><b><a href="binding/vec.md">rust::Vec&lt;T&gt;</a></b></td><td style="padding:3px 6px"><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
-<tr><td style="padding:3px 6px"><b><a href="binding/cxxvector.md">CxxVector&lt;T&gt;</a></b></td><td style="padding:3px 6px">std::vector&lt;T&gt;</td><td style="padding:3px 6px"><sup><i>cannot be passed by value, cannot hold opaque Rust type</i></sup></td></tr>
-<tr><td style="padding:3px 6px"><b><a href="binding/rawptr.md">*mut T, *const T</a></b></td><td style="padding:3px 6px">T*, const T*</td><td style="padding:3px 6px"><sup><i>fn with a raw pointer argument must be declared unsafe to call</i></sup></td></tr>
-<tr><td style="padding:3px 6px">fn(T, U) -&gt; V</td><td style="padding:3px 6px"><b><a href="binding/fn.md">rust::Fn&lt;V(T, U)&gt;</a></b></td><td style="padding:3px 6px"><sup><i>only passing from Rust to C++ is implemented so far</i></sup></td></tr>
-<tr><td style="padding:3px 6px"><b><a href="binding/result.md">Result&lt;T&gt;</a></b></td><td style="padding:3px 6px">throw/catch</td><td style="padding:3px 6px"><sup><i>allowed as return type only</i></sup></td></tr>
+<tr><td><code>String</code></td><td><code>rust::String</code></td><td></td></tr>
+<tr><td><code>&amp;str</code></td><td><code>rust::Str</code></td><td></td></tr>
+<tr><td><code>&amp;[T]</code></td><td><code>rust::Slice&lt;const T&gt;</code></td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
+<tr><td><code>&amp;mut [T]</code></td><td><code>rust::Slice&lt;T&gt;</code></td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
+<tr><td><a href="https://docs.rs/cxx/1.0/cxx/struct.CxxString.html"><code>CxxString</code></a></td><td><code>std::string</code></td><td><sup><i>cannot be passed by value</i></sup></td></tr>
+<tr><td><code>Box&lt;T&gt;</code></td><td><code>rust::Box&lt;T&gt;</code></td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
+<tr><td><a href="https://docs.rs/cxx/1.0/cxx/struct.UniquePtr.html"><code>UniquePtr&lt;T&gt;</code></a></td><td><code>std::unique_ptr&lt;T&gt;</code></td><td><sup><i>cannot hold opaque Rust type</i></sup></td></tr>
+<tr><td><a href="https://docs.rs/cxx/1.0/cxx/struct.SharedPtr.html"><code>SharedPtr&lt;T&gt;</code></a></td><td><code>std::shared_ptr&lt;T&gt;</code></td><td><sup><i>cannot hold opaque Rust type</i></sup></td></tr>
+<tr><td><code>[T; N]</code></td><td><code>std::array&lt;T, N&gt;</code></td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
+<tr><td><code>Vec&lt;T&gt;</code></td><td><code>rust::Vec&lt;T&gt;</code></td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
+<tr><td><a href="https://docs.rs/cxx/1.0/cxx/struct.CxxVector.html"><code>CxxVector&lt;T&gt;</code></a></td><td><code>std::vector&lt;T&gt;</code></td><td><sup><i>cannot be passed by value, cannot hold opaque Rust type</i></sup></td></tr>
+<tr><td><code>*mut T</code>, <code>*const T</code></td><td><code>T*</code>, <code>const T*</code></td><td><sup><i>fn with a raw pointer argument must be declared unsafe to call</i></sup></td></tr>
+<tr><td><code>fn(T, U) -&gt; V</code></td><td><code>rust::Fn&lt;V(T, U)&gt;</code></td><td><sup><i>only passing from Rust to C++ is implemented so far</i></sup></td></tr>
+<tr><td><code>Result&lt;T&gt;</code></td><td><code>throw</code>/<code>catch</code></td><td><sup><i>allowed as return type only</i></sup></td></tr>
 </table>
 
 <br>
 
-The C++ API of the `rust` namespace is defined by the *include/cxx.h* file in
+The C++ API of the `rust` namespace is defined by the *`include/cxx.h`* file in
 the CXX GitHub repo. You will need to include this header in your C++ code when
 working with those types. **When using Cargo and the cxx-build crate, the header
 is made available to you at `#include "rust/cxx.h"`.**
@@ -47,10 +47,10 @@ matter of designing a nice API for each in its non-native language.
 
 <table>
 <tr><th>name in Rust</th><th>name in C++</th></tr>
-<tr><td>BTreeMap&lt;K, V&gt;</td><td><sup><i>tbd</i></sup></td></tr>
-<tr><td>HashMap&lt;K, V&gt;</td><td><sup><i>tbd</i></sup></td></tr>
-<tr><td>Arc&lt;T&gt;</td><td><sup><i>tbd</i></sup></td></tr>
-<tr><td>Option&lt;T&gt;</td><td><sup><i>tbd</i></sup></td></tr>
-<tr><td><sup><i>tbd</i></sup></td><td>std::map&lt;K, V&gt;</td></tr>
-<tr><td><sup><i>tbd</i></sup></td><td>std::unordered_map&lt;K, V&gt;</td></tr>
+<tr><td><code>std::collections::BTreeMap&lt;K, V&gt;</code></td><td><sup><i>tbd</i></sup></td></tr>
+<tr><td><code>std::collections::HashMap&lt;K, V&gt;</code></td><td><sup><i>tbd</i></sup></td></tr>
+<tr><td><code>std::sync::Arc&lt;T&gt;</code></td><td><sup><i>tbd</i></sup></td></tr>
+<tr><td><code>Option&lt;T&gt;</code></td><td><sup><i>tbd</i></sup></td></tr>
+<tr><td><sup><i>tbd</i></sup></td><td><code>std::map&lt;K, V&gt;</code></td></tr>
+<tr><td><sup><i>tbd</i></sup></td><td><code>std::unordered_map&lt;K, V&gt;</code></td></tr>
 </table>

--- a/book/src/context.md
+++ b/book/src/context.md
@@ -48,7 +48,7 @@ Thus using bindgen correctly requires not just juggling all your pointers
 correctly at the language boundary, but also understanding ABI details and their
 workarounds and reliably applying them. For example, the programmer will
 discover that their program sometimes segfaults if they call a function that
-returns std::unique\_ptr\<T\> through bindgen. Why? Because unique\_ptr, despite
+returns `std::unique_ptr<T>` through bindgen. Why? Because `unique_ptr`, despite
 being "just a pointer", has a different ABI than a pointer or a C struct
 containing a pointer ([bindgen#778]) and is not directly expressible in Rust.
 Bindgen emitted something that *looks* reasonable and you will have a hell of a
@@ -106,7 +106,7 @@ From this perspective, CXX is a lower level tool than the bindgens. Just as
 bindgen and cbindgen are built on top of `extern "C"`, it makes sense to think
 about higher level tools built on top of CXX. Such a tool might consume a C++
 header and/or Rust module (and/or IDL like Thrift) and emit the corresponding
-safe cxx::bridge language boundary, leveraging CXX's static analysis and
+safe `cxx::bridge` language boundary, leveraging CXX's static analysis and
 underlying implementation of that boundary. We are beginning to see this space
 explored by the [autocxx] tool, though nothing yet ready for broad use in the
 way that CXX on its own is.

--- a/book/src/tutorial.md
+++ b/book/src/tutorial.md
@@ -193,7 +193,7 @@ cxx-build = "1.0"
 
 Then add a build.rs build script adjacent to Cargo.toml to run the cxx-build
 code generator and C++ compiler. The relevant arguments are the path to the Rust
-source file containing the cxx::bridge language boundary definition, and the
+source file containing the `cxx::bridge` language boundary definition, and the
 paths to any additional C++ source files to be compiled during the Rust crate's
 build.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@
 //! tend to consist of 2 chunks, or fragments of a file spread across memory for
 //! some other reason.
 //!
-//! A runnable version of this example is provided under the *demo* directory of
+//! A runnable version of this example is provided under the *`demo`* directory of
 //! <https://github.com/dtolnay/cxx>. To try it out, run `cargo run` from that
 //! directory.
 //!
@@ -179,7 +179,7 @@
 //! assertions will verify that they are accurate.
 //!
 //! Your function implementations themselves, whether in C++ or Rust, *do not*
-//! need to be defined as `extern "C"` ABI or no\_mangle. CXX will put in the
+//! need to be defined as `extern "C"` ABI or `no_mangle`. CXX will put in the
 //! right shims where necessary to make it all work.
 //!
 //! <br>
@@ -188,7 +188,7 @@
 //!
 //! Notice that with CXX there is repetition of all the function signatures:
 //! they are typed out once where the implementation is defined (in C++ or Rust)
-//! and again inside the cxx::bridge module, though compile-time assertions
+//! and again inside the `cxx::bridge` module, though compile-time assertions
 //! guarantee these are kept in sync. This is different from [bindgen] and
 //! [cbindgen] where function signatures are typed by a human once and the tool
 //! consumes them in one language and emits them in the other language.
@@ -202,7 +202,7 @@
 //! rather than a replacement for a bindgen. It would be reasonable to build a
 //! higher level bindgen-like tool on top of CXX which consumes a C++ header
 //! and/or Rust module (and/or IDL like Thrift) as source of truth and generates
-//! the cxx::bridge, eliminating the repetition while leveraging the static
+//! the cxx::bridge`, eliminating the repetition while leveraging the static
 //! analysis safety guarantees of CXX.
 //!
 //! But note in other ways CXX is higher level than the bindgens, with rich
@@ -311,8 +311,8 @@
 //!   is made possible by owning both sides of the boundary rather than just
 //!   one.
 //!
-//! - Template instantiations: for example in order to expose a UniquePtr\<T\>
-//!   type in Rust backed by a real C++ unique\_ptr, we have a way of using a
+//! - Template instantiations: for example in order to expose a `UniquePtr<T>`
+//!   type in Rust backed by a real C++ `unique_ptr`, we have a way of using a
 //!   Rust trait to connect the behavior back to the template instantiations
 //!   performed by the other language.
 //!
@@ -322,29 +322,29 @@
 //!
 //! # Builtin types
 //!
-//! In addition to all the primitive types (i32 &lt;=&gt; int32_t), the
+//! In addition to all the primitive types (`i32` &harr; `int32_t`), the
 //! following common types may be used in the fields of shared structs and the
 //! arguments and returns of functions.
 //!
 //! <table>
 //! <tr><th>name in Rust</th><th>name in C++</th><th>restrictions</th></tr>
-//! <tr><td>String</td><td>rust::String</td><td></td></tr>
-//! <tr><td>&amp;str</td><td>rust::Str</td><td></td></tr>
-//! <tr><td>&amp;[T]</td><td>rust::Slice&lt;const T&gt;</td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
-//! <tr><td>&amp;mut [T]</td><td>rust::Slice&lt;T&gt;</td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
-//! <tr><td><a href="struct.CxxString.html">CxxString</a></td><td>std::string</td><td><sup><i>cannot be passed by value</i></sup></td></tr>
-//! <tr><td>Box&lt;T&gt;</td><td>rust::Box&lt;T&gt;</td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
-//! <tr><td><a href="struct.UniquePtr.html">UniquePtr&lt;T&gt;</a></td><td>std::unique_ptr&lt;T&gt;</td><td><sup><i>cannot hold opaque Rust type</i></sup></td></tr>
-//! <tr><td><a href="struct.SharedPtr.html">SharedPtr&lt;T&gt;</a></td><td>std::shared_ptr&lt;T&gt;</td><td><sup><i>cannot hold opaque Rust type</i></sup></td></tr>
-//! <tr><td>[T; N]</td><td>std::array&lt;T, N&gt;</td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
-//! <tr><td>Vec&lt;T&gt;</td><td>rust::Vec&lt;T&gt;</td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
-//! <tr><td><a href="struct.CxxVector.html">CxxVector&lt;T&gt;</a></td><td>std::vector&lt;T&gt;</td><td><sup><i>cannot be passed by value, cannot hold opaque Rust type</i></sup></td></tr>
-//! <tr><td>*mut T, *const T</td><td>T*, const T*</td><td><sup><i>fn with a raw pointer argument must be declared unsafe to call</i></sup></td></tr>
-//! <tr><td>fn(T, U) -&gt; V</td><td>rust::Fn&lt;V(T, U)&gt;</td><td><sup><i>only passing from Rust to C++ is implemented so far</i></sup></td></tr>
-//! <tr><td>Result&lt;T&gt;</td><td>throw/catch</td><td><sup><i>allowed as return type only</i></sup></td></tr>
+//! <tr><td><code>String</code></td><td><code>rust::String</code></td><td></td></tr>
+//! <tr><td><code>&amp;str</code></td><td><code>rust::Str</code></td><td></td></tr>
+//! <tr><td><code>&amp;[T]</code></td><td><code>rust::Slice&lt;const T&gt;</code></td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
+//! <tr><td><code>&amp;mut [T]</code></td><td><code>rust::Slice&lt;T&gt;</code></td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
+//! <tr><td><a href="https://docs.rs/cxx/1.0/cxx/struct.CxxString.html"><code>CxxString</code></a></td><td><code>std::string</code></td><td><sup><i>cannot be passed by value</i></sup></td></tr>
+//! <tr><td><code>Box&lt;T&gt;</code></td><td><code>rust::Box&lt;T&gt;</code></td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
+//! <tr><td><a href="https://docs.rs/cxx/1.0/cxx/struct.UniquePtr.html"><code>UniquePtr&lt;T&gt;</code></a></td><td><code>std::unique_ptr&lt;T&gt;</code></td><td><sup><i>cannot hold opaque Rust type</i></sup></td></tr>
+//! <tr><td><a href="https://docs.rs/cxx/1.0/cxx/struct.SharedPtr.html"><code>SharedPtr&lt;T&gt;</code></a></td><td><code>std::shared_ptr&lt;T&gt;</code></td><td><sup><i>cannot hold opaque Rust type</i></sup></td></tr>
+//! <tr><td><code>[T; N]</code></td><td><code>std::array&lt;T, N&gt;</code></td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
+//! <tr><td><code>Vec&lt;T&gt;</code></td><td><code>rust::Vec&lt;T&gt;</code></td><td><sup><i>cannot hold opaque C++ type</i></sup></td></tr>
+//! <tr><td><a href="https://docs.rs/cxx/1.0/cxx/struct.CxxVector.html"><code>CxxVector&lt;T&gt;</code></a></td><td><code>std::vector&lt;T&gt;</code></td><td><sup><i>cannot be passed by value, cannot hold opaque Rust type</i></sup></td></tr>
+//! <tr><td><code>*mut T</code>, <code>*const T</code></td><td><code>T*</code>, <code>const T*</code></td><td><sup><i>fn with a raw pointer argument must be declared unsafe to call</i></sup></td></tr>
+//! <tr><td><code>fn(T, U) -&gt; V</code></td><td><code>rust::Fn&lt;V(T, U)&gt;</code></td><td><sup><i>only passing from Rust to C++ is implemented so far</i></sup></td></tr>
+//! <tr><td><code>Result&lt;T&gt;</code></td><td><code>throw</code>/<code>catch</code></td><td><sup><i>allowed as return type only</i></sup></td></tr>
 //! </table>
 //!
-//! The C++ API of the `rust` namespace is defined by the *include/cxx.h* file
+//! The C++ API of the `rust` namespace is defined by the *`include/cxx.h`* file
 //! in <https://github.com/dtolnay/cxx>. You will need to include this header in
 //! your C++ code when working with those types.
 //!


### PR DESCRIPTION
The tables are missing monospace tags for the type names, which renders them as regular text rather than as monospaced text; this PR adds the code tags around them.

Additionally, the names outside of the Rust prelude are fully qualified, to be consistent with the C++ names which are fully qualified, however I did not qualify the names in the prelude.

Finally, I replaced nested namespace declarations (`namespace rust { namespace behavior { /* ... */ } }`) with concise namespace declarations (`namespace rust::behavior { /* ... */ }`) in documentation, which is clearer.