### PR TITLE
Strip r# prefix from raw identifiers in generated C++ names

### DIFF
--- a/syntax/names.rs
+++ b/syntax/names.rs
@@ -40,7 +40,10 @@ impl ForeignName {
         // non-alphanumeric characters (`operator++`).
         match Ident::parse_any.parse_str(text) {
             Ok(ident) => {
-                let text = ident.to_string();
+                let mut text = ident.to_string();
+                if let Some(unraw) = text.strip_prefix("r#") {
+                    text = unraw.to_owned();
+                }
                 Ok(ForeignName { text })
             }
             Err(err) => Err(Error::new(span, err)),

--- a/tests/cxx_gen.rs
+++ b/tests/cxx_gen.rs
@@ -12,6 +12,15 @@ const BRIDGE0: &str = r#"
     }
 "#;
 
+const BRIDGE_RAW_IDENTIFIER: &str = r#"
+    #[cxx::bridge]
+    mod ffi {
+        unsafe extern "C++" {
+            pub fn highlight(r#type: i32);
+        }
+    }
+"#;
+
 #[test]
 fn test_extern_c_function() {
     let opt = Opt::default();
@@ -21,6 +30,21 @@ fn test_extern_c_function() {
     // To avoid continual breakage we won't test every byte.
     // Let's look for the major features.
     assert!(output.contains(&format!("void {CXXPREFIX}$do_cpp_thing(::rust::Str foo)")));
+}
+
+#[test]
+fn test_raw_identifier_param() {
+    let opt = Opt::default();
+    let source = BRIDGE_RAW_IDENTIFIER.parse().unwrap();
+    let generated = generate_header_and_cc(source, &opt).unwrap();
+    let header = str::from_utf8(&generated.header).unwrap();
+    let implementation = str::from_utf8(&generated.implementation).unwrap();
+
+    assert!(!header.contains("r#"));
+    assert!(!implementation.contains("r#"));
+    assert!(implementation.contains(&format!(
+        "void {CXXPREFIX}$highlight(::std::int32_t type) noexcept",
+    )));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #1324.

A raw identifier used in an `extern "C++"` block purely to dodge a Rust
keyword (e.g. `pub fn highlight(r#type: i32);`) was being emitted verbatim
into the generated C++, including the `r#` prefix:

```cpp
void ffi$cxxbridge1$highlight(::std::int32_t r#type) noexcept { ... }
```

which is not valid C++.

## Root cause

`ForeignName::parse` (`syntax/names.rs`) is the single place that turns a
Rust identifier into its C++-facing name — used both for the implicit
default name and for explicit `#[cxx_name = ...]` attributes — but it
never stripped the `r#` marker before storing the name.

## Fix

Strip a leading `r#` in `ForeignName::parse`, mirroring the existing
precedent in `QualifiedName::parse_unquoted` (`syntax/qualified.rs`), which
already does this for raw identifiers in namespace segments.

This intentionally stays narrowly scoped to the issue: it doesn't attempt
to detect or rename identifiers that, after stripping `r#`, would collide
with a C++ reserved keyword (e.g. `class`, `template`) — the crate has no
C++ keyword list today, and adding one is out of scope for this fix.

## Test plan

- [x] Added `test_raw_identifier_param` in `tests/cxx_gen.rs`, asserting
      the generated header/implementation contain no `r#` and the expected
      C++ signature uses the bare identifier.
- [x] `cargo test --test cxx_gen` passes (4/4).
- [x] `cargo build` succeeds for the whole workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)