### PR TITLE
Set up go version for buildifier install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,10 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version: stable
+          cache: false
       - run: go install github.com/bazelbuild/buildtools/buildifier@latest
       - run: echo $(go env GOPATH)/bin >> $GITHUB_PATH
       - run: git ls-files '*.bzl' '*.bazel' | xargs buildifier


### PR DESCRIPTION
This error appeared August 19 in CI:

```console
Run go install github.com/bazelbuild/buildtools/buildifier@latest
  go install github.com/bazelbuild/buildtools/buildifier@latest
  shell: /usr/bin/bash -e {0}
go: downloading github.com/bazelbuild/buildtools v0.0.0-20260819135130-5d08cfd22031
go: downloading github.com/google/safeopen v0.0.0-20260327150837-43626d6f4685
go: downloading github.com/golang/protobuf v1.5.0
go: downloading google.golang.org/protobuf v1.33.0
go: finding module for package golang.org/x/sys/unix
go: downloading golang.org/x/sys v0.47.0
go: toolchain upgrade needed to resolve golang.org/x/sys/unix
go: golang.org/x/sys@v0.47.0 requires go >= 1.25.0 (running go 1.24.13)
Error: Process completed with exit code 1.
```