### PR TITLE
Do not classify references as guaranteed POD

### DIFF
--- a/syntax/pod.rs
+++ b/syntax/pod.rs
@@ -27,9 +27,9 @@ impl<'a> Types<'a> {
             | TypeQuery::SharedPtr
             | TypeQuery::WeakPtr
             | TypeQuery::CxxVector
-            | TypeQuery::Void => false,
-            TypeQuery::Ref(_)
-            | TypeQuery::Str
+            | TypeQuery::Void
+            | TypeQuery::Ref(_) => false,
+            TypeQuery::Str
             | TypeQuery::Fn
             | TypeQuery::SliceRef
             | TypeQuery::Ptr(_) => true,

--- a/tests/cpp_ui_tests.rs
+++ b/tests/cpp_ui_tests.rs
@@ -26,3 +26,45 @@ fn test_unique_ptr_of_incomplete_foward_declared_pointee() {
     let err_msg = test.compile().expect_single_error();
     assert!(err_msg.contains("definition of `::ForwardDeclaredType` is required"));
 }
+
+/// This is a regression test for returning a struct with reference members across
+/// extern "C" thunks without triggering Clang's `-Wreturn-type-c-linkage`.
+/// See also: https://github.com/dtolnay/cxx/issues/1753
+///
+/// Note that the original repro required explicitly opting into extra C/C++
+/// warnings (as already done by `.github/workflows/ci.yml`):
+///
+/// ```sh
+/// $ CXX=clang++ CXXFLAGS="-Werror -Wall -Wpedantic" cargo test --test cpp_ui_tests
+/// ```
+///
+/// This is a separate test from `tests/ffi/lib.rs` and `tests/ffi/module.rs`
+/// to avoid the risk that some other input (e.g. callback functions) will
+/// suppress the warning via `out.pragma.return_type_c_linkage = true` and
+/// `#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"`.
+#[test]
+fn test_return_struct_with_ref() {
+    let test = cpp_compile::Test::new(quote! {
+        #[cxx::bridge]
+        mod ffi {
+            struct StructWithRef<'a> {
+                r: &'a usize,
+            }
+
+            unsafe extern "C++" {
+                include!("include.h");
+                fn c_return_struct_with_ref<'a>(r: &'a usize) -> StructWithRef<'a>;
+            }
+        }
+    });
+    test.write_file(
+        "include.h",
+        indoc! {"
+            #pragma once
+            #include <cstddef>
+            struct StructWithRef;
+            StructWithRef c_return_struct_with_ref(size_t const &r);
+        "},
+    );
+    test.compile().assert_success();
+}


### PR DESCRIPTION
Because `is_guaranteed_pod` evaluated to true for structs with references, `Types::needs_indirect_abi` returned false. This caused `cxx` to generate `extern "C"` functions returning these non-POD structs directly by value (e.g. `ItemRef cxxbridge1$...()`), which triggers Clang's `-Wreturn-type-c-linkage` warning/error.

By marking `Ref(_)` as non-POD in `is_guaranteed_pod`, structs containing references correctly require indirect ABI (`void cxxbridge1$...(..., ReturnType *return$)`), resolving `-Wreturn-type-c-linkage`. Top-level `&T` return types are handled earlier in `needs_indirect_abi` and remain unaffected.

Fixes https://github.com/dtolnay/cxx/issues/1753

----------------

PTAL?

/cc @apasel422