### PR TITLE
Register bazel toolchains as dev dependencies

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,11 +11,14 @@ bazel_dep(name = "platforms", version = "1.1.0")
 bazel_dep(name = "rules_cc", version = "0.2.17")
 bazel_dep(name = "rules_rust", version = "0.74.0")
 
-rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
+rust = use_extension("@rules_rust//rust:extensions.bzl", "rust", dev_dependency = True)
 rust.toolchain(versions = ["1.98.1"])
 use_repo(rust, "rust_toolchains")
 
-register_toolchains("@rust_toolchains//:all")
+register_toolchains(
+    "@rust_toolchains//:all",
+    dev_dependency = True,
+)
 
 crate_repositories = use_extension("//tools/bazel:extension.bzl", "crate_repositories")
 use_repo(crate_repositories, "crates.io", "vendor")


### PR DESCRIPTION
As recommended in https://github.com/bazelbuild/bazel-central-registry/pull/9739#pullrequestreview-4729465270 (I think).