### PR TITLE
Do not require a writable shared header directory

### DIFF
--- a/bridge/build/Cargo.toml
+++ b/bridge/build/Cargo.toml
@@ -29,6 +29,7 @@ syn = { version = "3", default-features = false, features = ["clone-impls", "ful
 cxx = { version = "1.0", path = "../.." }
 cxx-gen = { version = "0.7", path = "../lib" }
 pkg-config = "0.3.27"
+tempfile = "3.8"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/bridge/build/src/lib.rs
+++ b/bridge/build/src/lib.rs
@@ -267,7 +267,8 @@ fn validate_cfg(prj: &Project) -> Result<()> {
 
 fn make_this_crate(prj: &Project) -> Result<Crate> {
     let crate_dir = make_crate_dir(prj);
-    let include_dir = make_include_dir(prj)?;
+    let header = env::var_os("DEP_CXXBRIDGE1_HEADER");
+    let include_dir = make_include_dir(prj, header.as_deref())?;
 
     let mut this_crate = Crate {
         include_prefix: Some(prj.include_prefix.clone()),
@@ -380,16 +381,19 @@ fn make_crate_dir(prj: &Project) -> PathBuf {
     crate_dir
 }
 
-fn make_include_dir(prj: &Project) -> Result<PathBuf> {
+fn make_include_dir(prj: &Project, header: Option<&OsStr>) -> Result<PathBuf> {
     let include_dir = prj.out_dir.join("cxxbridge").join("include");
     let cxx_h = include_dir.join("rust").join("cxx.h");
     let ref shared_cxx_h = prj.shared_dir.join("rust").join("cxx.h");
-    if let Some(ref original) = env::var_os("DEP_CXXBRIDGE1_HEADER") {
+    if let Some(original) = header {
         out::absolute_symlink_file(original, cxx_h)?;
-        out::absolute_symlink_file(original, shared_cxx_h)?;
-    } else {
-        out::write(shared_cxx_h, bridge::include::HEADER.as_bytes())?;
+        let _ = out::absolute_symlink_file(original, shared_cxx_h);
+    } else if out::write(shared_cxx_h, bridge::include::HEADER.as_bytes()).is_ok() {
         out::relative_symlink_file(shared_cxx_h, cxx_h)?;
+    } else {
+        // The shared directory is only a debugging convenience and may not be
+        // writable, for example when the build script runs in a sandbox.
+        out::write(cxx_h, bridge::include::HEADER.as_bytes())?;
     }
     Ok(include_dir)
 }
@@ -475,4 +479,88 @@ fn best_effort_copy_headers(src: &Path, dst: &Path, max_depth: usize) {
 fn env_os(key: impl AsRef<OsStr>) -> Result<OsString> {
     let key = key.as_ref();
     env::var_os(key).ok_or_else(|| Error::NoEnv(key.to_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Project, bridge, make_include_dir};
+    use std::fs;
+    use std::path::Path;
+
+    fn project(root: &Path) -> Project {
+        Project {
+            include_prefix: "test".into(),
+            manifest_dir: root.to_owned(),
+            links_attribute: None,
+            out_dir: root.join("out"),
+            shared_dir: root.join("shared"),
+        }
+    }
+
+    #[test]
+    fn include_dir_without_shared_dir() {
+        check_include_dir_without_shared_dir(false);
+    }
+
+    #[test]
+    fn dependency_header_without_shared_dir() {
+        check_include_dir_without_shared_dir(true);
+    }
+
+    fn check_include_dir_without_shared_dir(dependency_header: bool) {
+        let temp = tempfile::tempdir().unwrap();
+        let prj = project(temp.path());
+        // A file blocking the directory fails even when running as root.
+        fs::write(&prj.shared_dir, b"blocked").unwrap();
+        let original = temp.path().join("original.h");
+        fs::write(&original, b"dependency header").unwrap();
+        let header = dependency_header.then_some(original.as_os_str());
+
+        let include_dir = make_include_dir(&prj, header).unwrap();
+        let expected = if dependency_header {
+            b"dependency header".as_slice()
+        } else {
+            bridge::include::HEADER.as_bytes()
+        };
+        assert_eq!(fs::read(include_dir.join("rust/cxx.h")).unwrap(), expected);
+        assert_eq!(fs::read(&prj.shared_dir).unwrap(), b"blocked");
+    }
+
+    #[test]
+    fn include_dir_with_shared_dir() {
+        for dependency_header in [false, true] {
+            let temp = tempfile::tempdir().unwrap();
+            let prj = project(temp.path());
+            let original = temp.path().join("original.h");
+            fs::write(&original, b"dependency header").unwrap();
+            let header = dependency_header.then_some(original.as_os_str());
+
+            let include_dir = make_include_dir(&prj, header).unwrap();
+            let expected = if dependency_header {
+                b"dependency header".as_slice()
+            } else {
+                bridge::include::HEADER.as_bytes()
+            };
+            assert_eq!(fs::read(include_dir.join("rust/cxx.h")).unwrap(), expected);
+            assert_eq!(
+                fs::read(prj.shared_dir.join("rust/cxx.h")).unwrap(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn include_dir_requires_out_dir() {
+        for dependency_header in [false, true] {
+            let temp = tempfile::tempdir().unwrap();
+            let prj = project(temp.path());
+            fs::write(&prj.out_dir, b"blocked").unwrap();
+            let original = temp.path().join("original.h");
+            fs::write(&original, b"dependency header").unwrap();
+            let header = dependency_header.then_some(original.as_os_str());
+
+            assert!(make_include_dir(&prj, header).is_err());
+            assert_eq!(fs::read(&prj.out_dir).unwrap(), b"blocked");
+        }
+    }
 }


### PR DESCRIPTION
Fixes #1752.

Allow `cxx-build` to finish when the optional shared header directory cannot be written, such as when a build script is restricted to writing under `OUT_DIR`.

With `DEP_CXXBRIDGE1_HEADER`, the local header link remains required and the shared link is best effort. Without it, retain the existing shared-header behavior when available, but write the embedded header directly under `OUT_DIR` if the shared write fails. A failure to create the required local header still propagates.

Four regression tests cover both header sources, a blocked shared directory, the normal shared path, and a blocked output directory. The blocked-path fixtures use a regular file in place of a directory, so they also fail deterministically when tests run as root. Both shared-directory failure cases failed before the production fix.

Validation on macOS arm64 with Rust 1.89:
- `cargo test -p cxx-build --offline`: 7 unit tests and 11 doc tests pass.
- `RUSTFLAGS='--cfg skip_ui_tests' cargo test --workspace --exclude cxx-test-suite`: passes.
- `cargo fmt --all -- --check`
- `cargo clippy -p cxx-build --all-targets --offline -- -D warnings -A unknown-lints`: passes. The exception is for pre-existing `clippy::assert_is_empty` attributes unknown to the installed toolchain.

No Windows or OS sandbox run was performed. Implemented and independently reviewed with OpenAI Codex (GPT-6 Astra, medium reasoning).
